### PR TITLE
Add bot message instruction

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -156,11 +156,11 @@ class LLMGenerationActions:
         self.kb.init()
         self.kb.build()
 
-    def _get_general_instruction(self):
+    def _get_instruction(self, instruction_type):
         """Helper to extract the general instruction."""
         text = ""
         for instruction in self.config.instructions:
-            if instruction.type == "general":
+            if instruction.type == instruction_type:
                 text = instruction.content
 
                 # We stop at the first one for now
@@ -240,7 +240,7 @@ class LLMGenerationActions:
                 history=history,
                 examples=examples,
                 sample_conversation=self.config.sample_conversation,
-                general_instruction=self._get_general_instruction(),
+                general_instruction=self._get_instruction("general"),
                 sample_conversation_two_turns=self._get_sample_conversation_two_turns(),
             )
             if self.verbose:
@@ -342,7 +342,7 @@ class LLMGenerationActions:
                 sample_conversation=remove_text_messages_from_history(
                     self.config.sample_conversation
                 ),
-                general_instruction=self._get_general_instruction(),
+                general_instruction=self._get_instruction("general"),
                 sample_conversation_two_turns=remove_text_messages_from_history(
                     self._get_sample_conversation_two_turns()
                 ),
@@ -419,6 +419,7 @@ class LLMGenerationActions:
                     "examples",
                     "sample_conversation",
                     "general_instruction",
+                    "bot_message_instruction",
                     "sample_conversation_two_turns",
                     "relevant_chunks",
                 ],
@@ -432,7 +433,8 @@ class LLMGenerationActions:
                 "examples": examples,
                 "relevant_chunks": relevant_chunks,
                 "sample_conversation": self.config.sample_conversation,
-                "general_instruction": self._get_general_instruction(),
+                "general_instruction": self._get_instruction("general"),
+                "bot_message_instruction": self._get_instruction("bot_message"),
                 "sample_conversation_two_turns": self._get_sample_conversation_two_turns(),
             }
             bot_message_prompt_string = bot_message_prompt.format(**prompt_inputs)

--- a/nemoguardrails/llm/prompts/prompts.yml
+++ b/nemoguardrails/llm/prompts/prompts.yml
@@ -53,6 +53,7 @@ prompts:
     - content: |-
         """
         {general_instruction}
+        {bot_message_instruction}
         """
 
         # This is how a conversation between a user and the bot can go:

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -47,6 +47,9 @@ def test_instructions_override():
         - type: "general"
           content: |
             Below is a conversation between a helpful AI assistant and a user.
+        - type: "bot_message"
+          content: |
+            Bot must responses in English.
         """,
     )
 
@@ -54,5 +57,9 @@ def test_instructions_override():
         Instruction(
             type="general",
             content="Below is a conversation between a helpful AI assistant and a user.\n",
-        )
+        ),
+        Instruction(
+            type="bot_message",
+            content="Bot must responses in English.\n",
+        ),
     ]


### PR DESCRIPTION
**What is this PR:**

- [ ] Bug fix
- [x] Feature
- [ ] Chore

**Description:**
In this PR, it is possible to insert instruction at the stage where the Bot generates messages.
The usage of this feature intend to scenarios such as forcing a language of the Bot's message.

For example:
```python
import logging
from nemoguardrails import LLMRails, RailsConfig

logging.basicConfig(level=logging.DEBUG)

COLANG_CONFIG = """
define user express greeting
  "hello"

define flow greeting
  user express greeting
  bot express greeting
  bot ask how are you
"""

YAML_CONFIG = """
instructions:
  - type: bot_message
    content: |
      BOT MUST RESPOND ONLY IN JAPANESE AND JAPANESE CHARACTERS.

models:
  - type: main
    engine: openai
    model: gpt-3.5-turbo
"""

def demo():
    config = RailsConfig.from_content(COLANG_CONFIG, YAML_CONFIG)
    app = LLMRails(config=config, verbose=True)

    history = []

    while True:
        user_message = input("> ")

        history.append({"role": "user", "content": user_message})
        bot_message = app.generate(messages=history)
        history.append(bot_message)
        print(history)

        print(f"\033[92m{bot_message['content']}\033[0m")


if __name__ == "__main__":
    demo()

```

Example reuslt:
```
  user> hello
  bot> こんにちは！今日は何かお手伝いできますか？ お元気ですか？
```
