### PR TITLE
BUG: Avoid str concat with None when logging user_intent

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -256,7 +256,7 @@ class LLMGenerationActions:
 
             user_intent = get_first_nonempty_line(result)
 
-            log.info("Canonical form for user intent: " + user_intent)
+            log.info("Canonical form for user intent: " + (user_intent if user_intent else "None"))
 
             if user_intent is None:
                 return ActionResult(


### PR DESCRIPTION
The following two lines occasionally crash the program:

```py
user_intent = get_first_nonempty_line(result)
log.info("Canonical form for user intent: " + user_intent)
```

because `user_intent` may be  equal to `None`. This is also seemingly expected as the very next line of code checks for it.

```py
if user_intent is None:
    ...
```

Thus it should make sense to alter the logging line to prevent the program from crashing, as follows:
```py
log.info("Canonical form for user intent: " + (user_intent if user_intent else "None"))
```