### PR TITLE
Enhancement: Extend hallucination llm engine. Resolve #47

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ scratch.py
 firebase.json
 build
 dist
+# Ignoring this for now
+scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#58](https://github.com/NVIDIA/NeMo-Guardrails/issues/58): Fix install on Mac OS 13.
 - [#55](https://github.com/NVIDIA/NeMo-Guardrails/issues/55): Fix bug in example causing config.py to crash on computers with no CUDA-enabled GPUs.
+- Fixed the model name initialization for LLMs that use the `model` kwarg.
 
 
 ## [0.3.0] - 2023-06-30

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ The documentation is divided into the following sections:
 4. [Evaluation Tools](#evaluation-tools)
 5. [Architecture Guide](#architecture-guide)
 6. [Security Guidelines](./security/guidelines.md)
+7. [API Reference](./api/README.md)
 
 ## Getting Started
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,22 @@
+<!-- markdownlint-disable -->
+
+# API Overview
+
+## Modules
+
+- [`nemoguardrails.rails.llm.config`](./nemoguardrails.rails.llm.config.md#module-nemoguardrailsrailsllmconfig): Module for the configuration of rails.
+- [`nemoguardrails.rails.llm.llmrails`](./nemoguardrails.rails.llm.llmrails.md#module-nemoguardrailsrailsllmllmrails): LLM Rails entry point.
+
+## Classes
+
+- [`config.Document`](./nemoguardrails.rails.llm.config.md#class-document): Configuration for documents that should be used for question answering.
+- [`config.Instruction`](./nemoguardrails.rails.llm.config.md#class-instruction): Configuration for instructions in natural language that should be passed to the LLM.
+- [`config.MessageTemplate`](./nemoguardrails.rails.llm.config.md#class-messagetemplate): Template for a message structure.
+- [`config.Model`](./nemoguardrails.rails.llm.config.md#class-model): Configuration of a model used by the rails engine.
+- [`config.RailsConfig`](./nemoguardrails.rails.llm.config.md#class-railsconfig): Configuration object for the models and the rails.
+- [`config.TaskPrompt`](./nemoguardrails.rails.llm.config.md#class-taskprompt): Configuration for prompts that will be used for a specific task.
+- [`llmrails.LLMRails`](./nemoguardrails.rails.llm.llmrails.md#class-llmrails): Rails based on a given configuration.
+
+## Functions
+
+- No functions

--- a/docs/api/nemoguardrails.rails.llm.config.md
+++ b/docs/api/nemoguardrails.rails.llm.config.md
@@ -1,0 +1,141 @@
+<!-- markdownlint-disable -->
+
+<a href="../../nemoguardrails/rails/llm/config.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+# <kbd>module</kbd> `nemoguardrails.rails.llm.config`
+Module for the configuration of rails.
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L29"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `Model`
+Configuration of a model used by the rails engine.
+
+Typically, the main model is configured e.g.: {  "type": "main",  "engine": "openai",  "model": "text-davinci-003" }
+
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L49"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `Instruction`
+Configuration for instructions in natural language that should be passed to the LLM.
+
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L56"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `Document`
+Configuration for documents that should be used for question answering.
+
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `MessageTemplate`
+Template for a message structure.
+
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L72"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `TaskPrompt`
+Configuration for prompts that will be used for a specific task.
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L93"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>classmethod</kbd> `TaskPrompt.check_fields`
+
+```python
+check_fields(values)
+```
+
+
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L159"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `RailsConfig`
+Configuration object for the models and the rails.
+
+TODO: add typed config for user_messages, bot_messages, and flows.
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L318"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `RailsConfig.from_content`
+
+```python
+from_content(
+    colang_content: Optional[str] = None,
+    yaml_content: Optional[str] = None
+)
+```
+
+Loads a configuration from the provided colang/YAML content.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L227"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `RailsConfig.from_path`
+
+```python
+from_path(
+    config_path: str,
+    test_set_percentage: Optional[float] = 0.0,
+    test_set: Optional[Dict[str, List]] = {},
+    max_samples_per_intent: Optional[int] = 0
+)
+```
+
+Loads a configuration from a given path.
+
+Supports loading a from a single file, or from a directory.
+
+Also used for testing Guardrails apps, in which case the test_set is randomly created from the intent samples in the config files. In this situation test_set_percentage should be larger than 0.
+
+If we want to limit the number of samples for an intent, set the max_samples_per_intent to a positive number. It is useful for testing apps, but also for limiting the number of samples for an intent in some scenarios. The chosen samples are selected randomly for each intent.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/config.py#L339"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>classmethod</kbd> `RailsConfig.parse_object`
+
+```python
+parse_object(obj)
+```
+
+Parses a configuration object from a given dictionary.

--- a/docs/api/nemoguardrails.rails.llm.llmrails.md
+++ b/docs/api/nemoguardrails.rails.llm.llmrails.md
@@ -1,0 +1,137 @@
+<!-- markdownlint-disable -->
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+# <kbd>module</kbd> `nemoguardrails.rails.llm.llmrails`
+LLM Rails entry point.
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L38"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+## <kbd>class</kbd> `LLMRails`
+Rails based on a given configuration.
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L41"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.__init__`
+
+```python
+__init__(
+    config: nemoguardrails.rails.llm.config.RailsConfig,
+    llm: Optional[langchain.llms.base.BaseLLM] = None,
+    verbose: bool = False
+)
+```
+
+Initializes the LLMRails instance.
+
+
+
+**Args:**
+
+ - <b>`config`</b>:  A rails configuration.
+ - <b>`llm`</b>:  An optional LLM engine to use.
+ - <b>`verbose`</b>:  Whether the logging should be verbose or not.
+
+
+
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L202"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.generate`
+
+```python
+generate(prompt: Optional[str] = None, messages: Optional[List[dict]] = None)
+```
+
+Synchronous version of generate_async.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L141"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.generate_async`
+
+```python
+generate_async(
+    prompt: Optional[str] = None,
+    messages: Optional[List[dict]] = None
+)
+```
+
+Generates a completion or a next message.
+
+The format for messages is currently the following: [  {"role": "user", "content": "Hello! How are you?"},  {"role": "assistant", "content": "I am fine, thank you!"}, ] System messages are not yet supported.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L220"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.register_action`
+
+```python
+register_action(
+    action: <built-in function callable>,
+    name: Optional[str] = None
+)
+```
+
+Register a custom action for the rails configuration.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L224"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.register_action_param`
+
+```python
+register_action_param(name: str, value: Any)
+```
+
+Registers a custom action parameter.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L228"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.register_filter`
+
+```python
+register_filter(
+    filter_fn: <built-in function callable>,
+    name: Optional[str] = None
+)
+```
+
+Register a custom filter for the rails configuration.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L232"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.register_output_parser`
+
+```python
+register_output_parser(output_parser: <built-in function callable>, name: str)
+```
+
+Register a custom output parser for the rails configuration.
+
+---
+
+<a href="../../nemoguardrails/rails/llm/llmrails.py#L236"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square" /></a>
+
+### <kbd>method</kbd> `LLMRails.register_prompt_context`
+
+```python
+register_prompt_context(name: str, value_or_fn: Any)
+```
+
+Register a value to be included in the prompt context.
+
+:name: The name of the variable or function that will be used. :value_or_fn: The value or function that will be used to generate the value.

--- a/docs/user_guide/python-api.md
+++ b/docs/user_guide/python-api.md
@@ -3,7 +3,7 @@
 The primary way for using guardrails in your project is:
 
 1. Create a [`RailsConfig`](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) object.
-2. Create an [`LLMRails`](../api/nemoguardrails.rails.llm.llmrails.md#class-llmrails) instance. The `LLMRails` class is the core class that enforces the configured guardrails.
+2. Create an [`LLMRails`](../api/nemoguardrails.rails.llm.llmrails.md#class-llmrails) instance which provides an interface to the LLM that automatically applies the configured guardrails.
 3. Generate LLM responses using the [`LLMRails.generate(...)`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) or [`LLMRails.generate_async(...)`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate_async) methods.
 
 ## Basic usage
@@ -22,7 +22,7 @@ new_message = app.generate(messages=[{
 
 ## RailsConfig
 
-The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) class contains the key bits of information for configuring guardrails:
+The [`RailsConfig`](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) class contains the key bits of information for configuring guardrails:
 
 - `models`: The list of models used by the rails configuration.
 - `user_messages`: The list of user messages that should be used for the rails.
@@ -35,9 +35,9 @@ The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) c
 
 ## Message Generation
 
-To use a guardrails configuration, you can call the [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) or [LLMRails.generate_async](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate_async) methods.
+To use a guardrails configuration, you can call the [`LLMRails.generate`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) or [`LLMRails.generate_async`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate_async) methods.
 
-The [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
+The [`LLMRails.generate`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
 
 ```yaml
 properties:

--- a/docs/user_guide/python-api.md
+++ b/docs/user_guide/python-api.md
@@ -2,9 +2,9 @@
 
 The primary way for using guardrails in your project is:
 
-1. Create a [`RailsConfig`](../api/nemoguardrails.rails.llm.config.md#kbdclasskbd-railsconfig) object.
-2. Create an [`LLMRails`](../api/nemoguardrails.rails.llm.llmrails.md#kbdclasskbd-llmrails) instance. The `LLMRails` class is the core class that enforces the configured guardrails.
-3. Generate LLM responses using the [`LLMRails.generate(...)`](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) or [`LLMRails.generate_async(...)`](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate_async) methods.
+1. Create a [`RailsConfig`](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) object.
+2. Create an [`LLMRails`](../api/nemoguardrails.rails.llm.llmrails.md#class-llmrails) instance. The `LLMRails` class is the core class that enforces the configured guardrails.
+3. Generate LLM responses using the [`LLMRails.generate(...)`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) or [`LLMRails.generate_async(...)`](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate_async) methods.
 
 ## Basic usage
 
@@ -22,7 +22,7 @@ new_message = app.generate(messages=[{
 
 ## RailsConfig
 
-The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#kbdclasskbd-railsconfig) class contains the key bits of information for configuring guardrails:
+The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#class-railsconfig) class contains the key bits of information for configuring guardrails:
 
 - `models`: The list of models used by the rails configuration.
 - `user_messages`: The list of user messages that should be used for the rails.
@@ -35,9 +35,9 @@ The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#kbdclasskbd-railscon
 
 ## Message Generation
 
-To use a guardrails configuration, you can call the [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) or [LLMRails.generate_async](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate_async) methods.
+To use a guardrails configuration, you can call the [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) or [LLMRails.generate_async](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate_async) methods.
 
-The [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
+The [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsgenerate) method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
 
 ```yaml
 properties:
@@ -101,7 +101,7 @@ For convenience, this toolkit also includes a selection of LangChain tools, wrap
 
 ### Chains as Actions
 
-You can register a Langchain chain as an action using the [LLMRails.register_action](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsregister_action) method:
+You can register a Langchain chain as an action using the [LLMRails.register_action](../api/nemoguardrails.rails.llm.llmrails.md#method-llmrailsregister_action) method:
 
 ```python
 app.register_action(some_chain, name="some_chain")

--- a/docs/user_guide/python-api.md
+++ b/docs/user_guide/python-api.md
@@ -1,11 +1,12 @@
 # Python API
 
-The primary way for using guardrails in your project is
-* By creating a `RailsConfig` object.
-* Then using it to create an `LLMRails` instance. The `LLMRails` class is the core class that enforces the configured guardrails.
-* Once a bot is created, a response can be obtained with `generate(...)` or `generate_async(...)` functions
+The primary way for using guardrails in your project is:
 
-**Basic usage:**
+1. Create a [`RailsConfig`](../api/nemoguardrails.rails.llm.config.md#kbdclasskbd-railsconfig) object.
+2. Create an [`LLMRails`](../api/nemoguardrails.rails.llm.llmrails.md#kbdclasskbd-llmrails) instance. The `LLMRails` class is the core class that enforces the configured guardrails.
+3. Generate LLM responses using the [`LLMRails.generate(...)`](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) or [`LLMRails.generate_async(...)`](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate_async) methods.
+
+## Basic usage
 
 ```python
 from nemoguardrails import LLMRails, RailsConfig
@@ -19,15 +20,10 @@ new_message = app.generate(messages=[{
 }])
 ```
 
-#### RailsConfig
+## RailsConfig
 
-Functions | Inputs | Description | Returns
- --- | --- | --- | ---
-`RailsConfig.from_path(...)`| `config_path: str` | load a guardrails configuration from the specified path | `RailsConfig` instance
-`RailsConfig.from_content(...)`|`colang_content: str` <br/> `yaml_content: str`|load a guardrails configuration  directly from the provided colang and YAML content; this approach is particularly convenient for quick testing | `RailsConfig` instance
-`RailsConfig.parse_object(...)`| `obj: dict` | load a guardrails configuration from the provided dictionary.| `RailsConfig` instance
+The [RailsConfig](../api/nemoguardrails.rails.llm.config.md#kbdclasskbd-railsconfig) class contains the key bits of information for configuring guardrails:
 
-The key bits of information included in a `RailsConfig`(via the configuration files) object are:
 - `models`: The list of models used by the rails configuration.
 - `user_messages`: The list of user messages that should be used for the rails.
 - `bot_messages`: The list of bot messages that should be used for the rails.
@@ -37,14 +33,11 @@ The key bits of information included in a `RailsConfig`(via the configuration fi
 - `sample_conversation`: The sample conversation to be used inside the prompts.
 - `actions_server_url`: The actions server to be used. If specified, the actions will be executed through the actions server.
 
-#### Message Generation
-Functions | Inputs | Description | Returns
- --- | --- | --- | ---
-`LLMRails(RailsConfig).generate_async(...)`|`prompt: str` <br/> `messages: List[dict]`| async version of `generate` | bot response (dict) ```{"role": "assistant", "content": "\n".join(responses)}```
-`LLMRails(RailsConfig).generate(...)`| `prompt: str` <br/> `messages: List[dict]`| generate the completion for the provided prompt or the next message, given a history of messages | bot response using synchronous version of `generate_async`
+## Message Generation
 
+To use a guardrails configuration, you can call the [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) or [LLMRails.generate_async](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate_async) methods.
 
-The `generate` method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
+The [LLMRails.generate](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsgenerate) method takes as input either a `prompt` or a `messages` array. When a prompt is provided, the guardrails apply as in a single-turn conversation. The structure of a message is the following:
 
 ```yaml
 properties:
@@ -71,6 +64,7 @@ An example of conversation history is the following:
 ```
 
 ## Actions
+
 Actions are a key component of the Guardrails toolkit. Actions enable the execution of python code inside guardrails.
 
 ### Default Actions
@@ -107,7 +101,7 @@ For convenience, this toolkit also includes a selection of LangChain tools, wrap
 
 ### Chains as Actions
 
-You can register a Langchain chain as an action:
+You can register a Langchain chain as an action using the [LLMRails.register_action](../api/nemoguardrails.rails.llm.llmrails.md#kbdmethodkbd-llmrailsregister_action) method:
 
 ```python
 app.register_action(some_chain, name="some_chain")
@@ -160,8 +154,8 @@ These parameters are only meant to be used in advanced use cases.
 
 The following are the parameters that can be used in the actions:
 
- Parameters | Description | Type | Example
---- | --- | --- | ---
-`events` | The history of events so far; the last one is the one triggering the action itself. | List[dict] |  ```[     {'type': 'user_said', ...},     {'type': 'start_action', 'action_name': 'generate_user_intent', ...},      {'type': 'action_finished', 'action_name': 'generate_user_intent', ...} ]```
-`context` | The context data available to the action. | dict | ```{ 'last_user_message': ...,  'last_bot_message': ..., 'retrieved_relevant_chunks': ... }```
-`llm` | Access to the LLM instance (BaseLLM from LangChain). | BaseLLM | ```OpenAI(model="text-davinci-003",...)```
+| Parameters | Description                                                                         | Type       | Example                                                                                                                                                                                          |
+|------------|-------------------------------------------------------------------------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `events`   | The history of events so far; the last one is the one triggering the action itself. | List[dict] | ```[     {'type': 'user_said', ...},     {'type': 'start_action', 'action_name': 'generate_user_intent', ...},      {'type': 'action_finished', 'action_name': 'generate_user_intent', ...} ]``` |
+| `context`  | The context data available to the action.                                           | dict       | ```{ 'last_user_message': ...,  'last_bot_message': ..., 'retrieved_relevant_chunks': ... }```                                                                                                   |
+| `llm`      | Access to the LLM instance (BaseLLM from LangChain).                                | BaseLLM    | ```OpenAI(model="text-davinci-003",...)```                                                                                                                                                       |

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -90,7 +90,7 @@ class TaskPrompt(BaseModel):
         description="The name of the output parser to use for this prompt.",
     )
 
-    @root_validator(pre=True)
+    @root_validator(pre=True, allow_reuse=True)
     def check_fields(cls, values):
         if not values.get("content") and not values.get("messages"):
             raise ValidationError("One of `content` or `messages` must be provided.")
@@ -104,8 +104,8 @@ class TaskPrompt(BaseModel):
 
 
 # Load the default config values from the file
-with open(os.path.join(os.path.dirname(__file__), "default_config.yml")) as fc:
-    default_config = yaml.safe_load(fc)
+with open(os.path.join(os.path.dirname(__file__), "default_config.yml")) as _fc:
+    _default_config = yaml.safe_load(_fc)
 
 
 def _join_config(dest_config: dict, additional_config: dict):
@@ -182,7 +182,7 @@ class RailsConfig(BaseModel):
     )
 
     instructions: Optional[List[Instruction]] = Field(
-        default=[Instruction.parse_obj(obj) for obj in default_config["instructions"]],
+        default=[Instruction.parse_obj(obj) for obj in _default_config["instructions"]],
         description="List of instructions in natural language that the LLM should use.",
     )
 
@@ -197,7 +197,7 @@ class RailsConfig(BaseModel):
     )
 
     sample_conversation: Optional[str] = Field(
-        default=default_config["sample_conversation"],
+        default=_default_config["sample_conversation"],
         description="The sample conversation that should be used inside the prompts.",
     )
 
@@ -309,7 +309,7 @@ class RailsConfig(BaseModel):
 
         # If there are no instructions, we use the default ones.
         if len(raw_config.get("instructions", [])) == 0:
-            raw_config["instructions"] = default_config["instructions"]
+            raw_config["instructions"] = _default_config["instructions"]
 
         raw_config["config_path"] = config_path
 
@@ -332,7 +332,7 @@ class RailsConfig(BaseModel):
 
         # If there are no instructions, we use the default ones.
         if len(raw_config.get("instructions", [])) == 0:
-            raw_config["instructions"] = default_config["instructions"]
+            raw_config["instructions"] = _default_config["instructions"]
 
         return RailsConfig.parse_object(raw_config)
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -41,6 +41,13 @@ class LLMRails:
     def __init__(
         self, config: RailsConfig, llm: Optional[BaseLLM] = None, verbose: bool = False
     ):
+        """Initializes the LLMRails instance.
+
+        Args:
+            config: A rails configuration.
+            llm: An optional LLM engine to use.
+            verbose: Whether the logging should be verbose or not.
+        """
         self.config = config
         self.llm = llm
         self.verbose = verbose

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -133,7 +133,8 @@ class LLMRails:
             ]:
                 kwargs["model_name"] = main_llm_config.model
             else:
-                if hasattr(provider_cls, "model"):
+                # The `__fields__` attribute is computed dynamically by pydantic.
+                if "model" in provider_cls.__fields__:
                     kwargs["model"] = main_llm_config.model
 
         self.llm = provider_cls(**kwargs)


### PR DESCRIPTION
**Background:**

The original hallucination check function only supports OpenAI LLM engine (instruction models), this PR is to extend the scope of supporting engines.

**Changes:**

1. Now it supports three types of llm from langchain: OpenAI (instruction models), ChatOpenAI (chat models), and customized class inherit from one of them.
2. Update some comments and warning messages.
3. Add a new template construction for ChatOpenAI because roles must be associated with messages.
4. Minor changes to resolve the API differences between OpenAI and ChatOpenAI.

**Note:**

Unfortunately, I didn't get a chance to verify the effect of changes as I meet some issues using OpenAI these days. It would be great if you could help make some tests.

