### PR TITLE
Extend hallucination llm engines. Resolve #47

### DIFF
--- a/nemoguardrails/actions/hallucination/hallucination.py
+++ b/nemoguardrails/actions/hallucination/hallucination.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 
 import logging
-from typing import Optional, Union
+from typing import Optional
 
-from langchain import LLMChain, PromptTemplate
 from langchain.base_language import BaseLanguageModel
 from langchain.chat_models import ChatOpenAI
 from langchain.llms import OpenAI
-from langchain.llms.base import BaseLLM
-from langchain.prompts import ChatPromptTemplate, HumanMessagePromptTemplate
 
 from nemoguardrails.actions.llm.utils import (
     get_multiline_response,
@@ -31,8 +28,6 @@ from nemoguardrails.actions.llm.utils import (
 from nemoguardrails.llm.params import llm_params
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
-from nemoguardrails.logging.callbacks import logging_callback_manager_for_chain
-from nemoguardrails.rails.llm.config import RailsConfig
 
 log = logging.getLogger(__name__)
 

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -51,17 +51,17 @@ async def llm_call(
             [ChatPromptValue(messages=messages)], callbacks=logging_callbacks
         )
 
-        # Return string if there is only one completion,
-        # otherwise, return all completions in a list
-        if len(result.generations[0]) > 1:
-            all_completions = []
-            i = 0
-            while i < len(result.generations[0]):
-                all_completions.append(result.generations[0][i].text)
-                i += 1
-            return all_completions
-        else:
-            return result.generations[0][0].text
+    # Return string if there is only one completion,
+    # otherwise, return all completions in a list
+    if len(result.generations[0]) > 1:
+        all_completions = []
+        i = 0
+        while i < len(result.generations[0]):
+            all_completions.append(result.generations[0][i].text)
+            i += 1
+        return all_completions
+    else:
+        return result.generations[0][0].text
 
 
 def get_colang_history(


### PR DESCRIPTION
**Background:**

The original hallucination check function only supports OpenAI LLM engine (instruction models), this PR is to extend the scope of supporting engines.

**Changes:**

1. Now it supports three types of llm from langchain: OpenAI (instruction models), ChatOpenAI (chat models), and customized class inherit from one of them.
2. Update some comments and warning messages.
3. Add a new template construction for ChatOpenAI because roles must be associated with messages.
4. Minor changes to resolve the API differences between OpenAI and ChatOpenAI.

**Note:**

Unfortunately, I didn't get a chance to verify the effect of changes as I meet some issues using OpenAI these days. It would be great if you could help make some tests.