### PR TITLE
Fact check and hallucination check bug fix

### DIFF
--- a/nemoguardrails/llm/prompts/general.yml
+++ b/nemoguardrails/llm/prompts/general.yml
@@ -91,7 +91,7 @@ prompts:
     content: |-
       You are given a task to identify if the hypothesis is grounded and entailed to the evidence.
       You will only use the contents of the evidence and not rely on external knowledge.
-      Answer with yes/no. ["evidence": "{{ evidence }}"], ["hypothesis": "{{ response }}"], ["entails":]
+      Answer with yes/no. "evidence": {{ evidence }} "hypothesis": {{ response }} "entails":
 
   - task: jailbreak_check
     content: |-
@@ -109,4 +109,4 @@ prompts:
     content: |-
       You are given a task to identify if the hypothesis is in agreement with the context below.
       You will only use the contents of the context and not rely on external knowledge.
-      Answer with yes/no. ["context": "{{ paragraph }}"], ["hypothesis": "{{ statement }}"], ["agreement":]
+      Answer with yes/no. "context": {{ paragraph }} "hypothesis": {{ statement }} "agreement":

--- a/nemoguardrails/llm/prompts/general.yml
+++ b/nemoguardrails/llm/prompts/general.yml
@@ -91,7 +91,7 @@ prompts:
     content: |-
       You are given a task to identify if the hypothesis is grounded and entailed to the evidence.
       You will only use the contents of the evidence and not rely on external knowledge.
-      Answer with yes/no. "evidence": {{ evidence }} "hypothesis": {{ response }} "entails":
+      Answer with yes/no. ["evidence": "{{ evidence }}"], ["hypothesis": "{{ response }}"], ["entails":]
 
   - task: jailbreak_check
     content: |-
@@ -109,4 +109,4 @@ prompts:
     content: |-
       You are given a task to identify if the hypothesis is in agreement with the context below.
       You will only use the contents of the context and not rely on external knowledge.
-      Answer with yes/no. "context": {{ paragraph }} "hypothesis": {{ statement }} "agreement":
+      Answer with yes/no. ["context": "{{ paragraph }}"], ["hypothesis": "{{ statement }}"], ["agreement":]


### PR DESCRIPTION
Noticed a bug where fact checker was returning false even though the bot response exactly matched the data in the knowledge base. It seemed that special characters in the bot response were causing the LLM to get confused resulting in entails in fact_checking.py contianing "no". 

In order to fix this, I used square brackets in prompts in general.yml to better separate the text from the bot response, the text from the knowledge base and the text of the rest of the prompt. 

I noticed that the check_hallucination prompt was susceptible to the same issue, so applied the same change.

