### PR TITLE
Fact check and hallucination check bug fix

### DIFF
--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -241,4 +241,6 @@ logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
     parent_run_id=None,
     handlers=handlers,
     inheritable_handlers=handlers,
+    tags=[],
+    inheritable_tags=[],
 )

--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -241,6 +241,4 @@ logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
     parent_run_id=None,
     handlers=handlers,
     inheritable_handlers=handlers,
-    tags=[],
-    inheritable_tags=[],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pydantic~=1.10.6
 aiohttp==3.8.4
-langchain==0.0.167
+langchain==0.0.201
 requests==2.31.0
 typer==0.7.0
 PyYAML~=6.0

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         "pydantic~=1.10.6",
         "aiohttp==3.8.4",
-        "langchain==0.0.167",
+        "langchain==0.0.201",
         "requests>=2.31.0",
         "typer==0.7.0",
         "PyYAML~=6.0",


### PR DESCRIPTION
Noticed a bug where fact checker was returning false even though the bot response exactly matched the data in the knowledge base. It seemed that special characters in the bot response were causing the LLM to get confused resulting in entails in fact_checking.py contianing no. In order to fix this, I used square brackets in prompts in general.yml to better separate the text from the bot response, the text from the knowledge base and the text of the rest of the prompt. I noticed that the check_hallucination prompt was susceptible to the same issue, so applied the same change.