### PR TITLE
Bug fix for callbacks

### DIFF
--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -241,4 +241,6 @@ logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
     parent_run_id=None,
     handlers=handlers,
     inheritable_handlers=handlers,
+    tags=[],
+    inheritable_tags=[],
 )

--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -241,6 +241,4 @@ logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
     parent_run_id=None,
     handlers=handlers,
     inheritable_handlers=handlers,
-    tags=[],
-    inheritable_tags=[],
 )


### PR DESCRIPTION
See relevant LangChain Pull Request:

https://github.com/hwchase17/langchain/pull/6858

Was getting the following error:

![image](https://github.com/NVIDIA/NeMo-Guardrails/assets/31565026/6410d349-074f-4443-8036-cb0f79163325)


Fixed by by providing `tags = []` and `inheritable_tags = []` arguments in callbacks.py, giving:

```
logging_callback_manager_for_chain = AsyncCallbackManagerForChainRun(
    run_id=uuid.uuid4(),
    parent_run_id=None,
    handlers=handlers,
    inheritable_handlers=handlers,
    tags=[],
    inheritable_tags=[],
)
```

