### PR TITLE
Remove redundant `hasattr` check in `nemoguardrails/llm/params.py`

### DIFF
--- a/nemoguardrails/llm/params.py
+++ b/nemoguardrails/llm/params.py
@@ -41,9 +41,7 @@ class LLMParams:
             if hasattr(self.llm, param):
                 self.original_params[param] = getattr(self.llm, param)
                 setattr(self.llm, param, value)
-            elif hasattr(self.llm, "model_kwargs") and param in getattr(
-                self.llm, "model_kwargs", {}
-            ):
+            elif param in getattr(self.llm, "model_kwargs", {}):
                 self.original_params[param] = self.llm.model_kwargs[param]
                 self.llm.model_kwargs[param] = value
             else:


### PR DESCRIPTION
In Python, the getattr function is used to dynamically retrieve the value of an attribute or to call a method of an object.

Here's the basic syntax of the getattr function:

`object`: The object from which you want to retrieve the attribute.
`attribute_name`: A string representing the name of the attribute you want to access.
`default`: An optional value that will be returned if the attribute does not exist

Since we already have
```
elif param in getattr(self.llm, "model_kwargs", {}):
```
If "model_kwargs" is not an attribute of `self.llm`, the boolean statement will reduce to:
```
elif param in {}
```
which will evaluate to false. Therefore, we don't need to check for `hasattr(self.llm, "model_kwargs")` separately.

Thus, I have removed the `hasattr(...)` check that precedes the `param in getattr(...)` check.