### PR TITLE
added ability to set embedding models and use openai

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -44,6 +44,7 @@ from nemoguardrails.kb.index import IndexItem
 from nemoguardrails.kb.kb import KnowledgeBase
 from nemoguardrails.language.parser import parse_colang_file
 from nemoguardrails.llm.params import llm_params
+from nemoguardrails.llm.providers import get_embedding_provider_names
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -71,7 +72,8 @@ class LLMGenerationActions:
         for model in self.config.models:
             if model.type == "embedding":
                 self.embedding_model = model.model
-                assert model.engine == "SentenceTransformer"
+                assert model.engine in get_embedding_provider_names()
+                self.embedding_engine = model.engine
                 break
 
         # If we have user messages, we build an index with them
@@ -108,7 +110,9 @@ class LLMGenerationActions:
         if len(items) == 0:
             return
 
-        self.user_message_index = BasicEmbeddingsIndex(self.embedding_model)
+        self.user_message_index = BasicEmbeddingsIndex(
+            embedding_model=self.embedding_model, embedding_engine=self.embedding_engine
+        )
         self.user_message_index.add_items(items)
 
         # NOTE: this should be very fast, otherwise needs to be moved to separate thread.
@@ -129,7 +133,9 @@ class LLMGenerationActions:
         if len(items) == 0:
             return
 
-        self.bot_message_index = BasicEmbeddingsIndex(self.embedding_model)
+        self.bot_message_index = BasicEmbeddingsIndex(
+            embedding_model=self.embedding_model, embedding_engine=self.embedding_engine
+        )
         self.bot_message_index.add_items(items)
 
         # NOTE: this should be very fast, otherwise needs to be moved to separate thread.
@@ -163,7 +169,9 @@ class LLMGenerationActions:
         if len(items) == 0:
             return
 
-        self.flows_index = BasicEmbeddingsIndex(self.embedding_model)
+        self.flows_index = BasicEmbeddingsIndex(
+            embedding_model=self.embedding_model, embedding_engine=self.embedding_engine
+        )
         self.flows_index.add_items(items)
 
         # NOTE: this should be very fast, otherwise needs to be moved to separate thread.

--- a/nemoguardrails/kb/basic.py
+++ b/nemoguardrails/kb/basic.py
@@ -15,10 +15,12 @@
 
 from typing import List
 
+import openai
 from annoy import AnnoyIndex
 from sentence_transformers import SentenceTransformer
+from torch import cuda
 
-from nemoguardrails.kb.index import EmbeddingsIndex, IndexItem
+from nemoguardrails.kb.index import EmbeddingModel, EmbeddingsIndex, IndexItem
 
 
 class BasicEmbeddingsIndex(EmbeddingsIndex):
@@ -28,11 +30,12 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
     It uses Annoy to perform the search.
     """
 
-    def __init__(self, embedding_model=None, index=None):
+    def __init__(self, embedding_model=None, embedding_engine=None, index=None):
         self._model = None
         self._items = []
         self._embeddings = []
         self.embedding_model = embedding_model
+        self.embedding_engine = embedding_engine
 
         # When the index is provided, it means it's from the cache.
         self._index = index
@@ -43,7 +46,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
     def _init_model(self):
         """Initialize the model used for computing the embeddings."""
-        self._model = SentenceTransformer(self.embedding_model)
+        self._model = init_embedding_model(
+            embedding_model=self.embedding_model, embedding_engine=self.embedding_engine
+        )
 
     def _get_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Compute embeddings for a list of texts."""
@@ -51,7 +56,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             self._init_model()
 
         embeddings = self._model.encode(texts)
-        return [embedding.tolist() for embedding in embeddings]
+        return embeddings
 
     def add_item(self, item: IndexItem):
         """Add a single item to the index."""
@@ -85,3 +90,42 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         )
 
         return [self._items[i] for i in results]
+
+
+class SentenceTransformerEmbeddingModel(EmbeddingModel):
+    """Embedding model using sentence-transformers."""
+
+    def __init__(self, embedding_model: str):
+        device = "cuda" if cuda.is_available() else "cpu"
+        self.model = SentenceTransformer(embedding_model, device=device)
+        # Get the embedding dimension of the model
+        self.embedding_size = self.model.get_sentence_embedding_dimension()
+
+    def encode(self, documents: List[str]) -> List[List[float]]:
+        return self.model.encode(documents)
+
+
+class OpenAIEmbeddingModel(EmbeddingModel):
+    """Embedding model using OpenAI API."""
+
+    def __init__(self, embedding_model: str):
+        self.model = embedding_model
+        self.embedding_size = len(self.encode(["test"])[0])
+
+    def encode(self, documents: List[str]) -> List[List[float]]:
+        """Encode a list of documents into embeddings."""
+
+        # Make embedding request to OpenAI API
+        res = openai.Embedding.create(input=documents, engine=self.model)
+        embeddings = [record["embedding"] for record in res["data"]]
+        return embeddings
+
+
+def init_embedding_model(embedding_model: str, embedding_engine: str) -> EmbeddingModel:
+    """Initialize the embedding model."""
+    if embedding_engine == "SentenceTransformers":
+        return SentenceTransformerEmbeddingModel(embedding_model)
+    elif embedding_engine == "openai":
+        return OpenAIEmbeddingModel(embedding_model)
+    else:
+        raise ValueError(f"Invalid embedding engine: {embedding_engine}")

--- a/nemoguardrails/kb/index.py
+++ b/nemoguardrails/kb/index.py
@@ -43,3 +43,11 @@ class EmbeddingsIndex:
     def search(self, text: str, max_results: int) -> List[IndexItem]:
         """Searches the index for the closes matches to the provided text."""
         raise NotImplementedError()
+
+
+class EmbeddingModel:
+    """The embedding model is responsible for creating the embeddings."""
+
+    def encode(self, documents: List[str]) -> List[List[float]]:
+        """Encode the provided documents into embeddings."""
+        raise NotImplementedError()

--- a/nemoguardrails/llm/providers.py
+++ b/nemoguardrails/llm/providers.py
@@ -80,3 +80,8 @@ def get_llm_provider(model_config: Model) -> Type[BaseLanguageModel]:
 def get_llm_provider_names() -> List[str]:
     """Returns the list of supported LLM providers."""
     return list(sorted(list(_providers.keys())))
+
+
+def get_embedding_provider_names() -> List[str]:
+    """Returns the list of supported embedding providers."""
+    return ["openai", "SentenceTransformers"]


### PR DESCRIPTION
**Moved to #101 for signed commits**

Addressing #99. Added ability to choose embedding model via the config.yaml. Also added OpenAI API as option (alongside Sentence Transformers). We can do:

```yaml
models:
  - type: main
    engine: openai
    model: text-davinci-003
  - type: embedding
    engine: openai
    model: text-embedding-ada-002
```

and

```yaml
models:
  - type: main
    engine: openai
    model: text-davinci-003
  - type: embedding
    engine: SentenceTransformers
    model: all-MiniLM-L6-v2
```

I understand there is also some work ongoing in this space, but in a private repo, naturally, I can't see this, so I apologize if any of this conflicts with or overlaps. Let me know if any of this can be of use!

Thanks