### PR TITLE
Fixed TypeError in logging call

### DIFF
--- a/nemoguardrails/llm/providers.py
+++ b/nemoguardrails/llm/providers.py
@@ -69,7 +69,7 @@ def get_llm_provider(model_config: Model) -> Type[BaseLanguageModel]:
         raise RuntimeError(f"Could not find LLM provider '{model_config.engine}'")
 
     # For OpenAI, we use a different provider depending on whether it's a chat model or not
-    if model_config.model == "openai" and (
+    if model_config.engine == "openai" and (
         "gpt-3.5" in model_config.model or "gpt-4" in model_config.model
     ):
         return ChatOpenAI

--- a/nemoguardrails/llm/providers.py
+++ b/nemoguardrails/llm/providers.py
@@ -52,7 +52,7 @@ def discover_langchain_providers():
     for provider_cls in _providers.values():
         # If the "_acall" method is not defined, we add it.
         if issubclass(provider_cls, LLM) and "_acall" not in provider_cls.__dict__:
-            log.debug("Adding async support to", provider_cls.__name__)
+            log.debug(f"Adding async support to {provider_cls.__name__}")
             provider_cls._acall = _acall
 
 


### PR DESCRIPTION
Fixes the following error:

```
File ~/anaconda3/envs/pytorch_p310/lib/python3.10/site-packages/nemoguardrails/llm/providers.py:55, in discover_langchain_providers()
     52 for provider_cls in _providers.values():
     53     # If the "_acall" method is not defined, we add it.
     54     if issubclass(provider_cls, LLM) and "_acall" not in provider_cls.__dict__:
---> 55         log.debug("Adding async support to", provider_cls.__name__)
     56         provider_cls._acall = _acall

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:1465, in Logger.debug(self, msg, *args, **kwargs)
   1456 """
   1457 Log 'msg % args' with severity 'DEBUG'.
   1458 
   (...)
   1462 logger.debug("Houston, we have a %s", "thorny problem", exc_info=1)
   1463 """
   1464 if self.isEnabledFor(DEBUG):
-> 1465     self._log(DEBUG, msg, args, **kwargs)

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:1624, in Logger._log(self, level, msg, args, exc_info, extra, stack_info, stacklevel)
   1621         exc_info = sys.exc_info()
   1622 record = self.makeRecord(self.name, level, fn, lno, msg, args,
   1623                          exc_info, func, extra, sinfo)
-> 1624 self.handle(record)

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:1634, in Logger.handle(self, record)
   1627 """
   1628 Call the handlers for the specified record.
   1629 
   1630 This method is used for unpickled records received from a socket, as
   1631 well as those created locally. Logger-level filtering is applied.
   1632 """
   1633 if (not self.disabled) and self.filter(record):
-> 1634     self.callHandlers(record)

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:1696, in Logger.callHandlers(self, record)
   1694     found = found + 1
   1695     if record.levelno >= hdlr.level:
-> 1696         hdlr.handle(record)
   1697 if not c.propagate:
   1698     c = None    #break out

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:968, in Handler.handle(self, record)
    966 self.acquire()
    967 try:
--> 968     self.emit(record)
    969 finally:
    970     self.release()

Cell In[2], line 32, in JupyterHandler.emit(self, record)
     30 def emit(self, record):
     31     color = self.color_map.get(record.levelname, 'black')
---> 32     msg = self.format(record)
     33     # Convert newline characters to HTML line breaks
     34     formatted_msg = msg.replace('\n', '<br/>')

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:943, in Handler.format(self, record)
    941 else:
    942     fmt = _defaultFormatter
--> 943 return fmt.format(record)

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:678, in Formatter.format(self, record)
    665 def format(self, record):
    666     """
    667     Format the specified record as text.
    668 
   (...)
    676     it is formatted using formatException() and appended to the message.
    677     """
--> 678     record.message = record.getMessage()
    679     if self.usesTime():
    680         record.asctime = self.formatTime(record, self.datefmt)

File ~/anaconda3/envs/pytorch_p310/lib/python3.10/logging/__init__.py:368, in LogRecord.getMessage(self)
    366 msg = str(self.msg)
    367 if self.args:
--> 368     msg = msg % self.args
    369 return msg

TypeError: not all arguments converted during string formatting
```