### PR TITLE
Provide a clear error message when no main model is set.

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -57,6 +57,18 @@ class LLMRails:
         """
         self.config = config
         self.llm = llm
+
+        # We do a validation to check if we have a main model specified in the config
+        # or an LLM instance has been provided.
+        main_model_count = len([m for m in self.config.models if m.type == "main"])
+
+        if self.llm is None and main_model_count == 0:
+            raise ValueError(
+                "No main LLM model has been provided for `LLMRails`. "
+                "Please specify one in `config.yml` or provide an instance "
+                "using the `llm` parameter."
+            )
+
         self.verbose = verbose
 
         # We allow the user to register additional embedding search providers, so we keep

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -22,6 +22,10 @@ def test_input_rail_exists_check():
     with pytest.raises(ValueError) as exc_info:
         config = RailsConfig.from_content(
             yaml_content="""
+            models:
+                - type: main
+                  engine: openai
+                  model: gpt-3.5-turbo-instruct
             rails:
                 input:
                     flows:
@@ -37,6 +41,10 @@ def test_output_rail_exists_check():
     with pytest.raises(ValueError) as exc_info:
         config = RailsConfig.from_content(
             yaml_content="""
+            models:
+                - type: main
+                  engine: openai
+                  model: gpt-3.5-turbo-instruct
             rails:
                 output:
                     flows:
@@ -52,6 +60,10 @@ def test_retrieval_rail_exists_check():
     with pytest.raises(ValueError) as exc_info:
         config = RailsConfig.from_content(
             yaml_content="""
+            models:
+                - type: main
+                  engine: openai
+                  model: gpt-3.5-turbo-instruct
             rails:
                 retrieval:
                     flows:
@@ -67,6 +79,10 @@ def test_self_check_input_prompt_exception():
     with pytest.raises(ValueError) as exc_info:
         config = RailsConfig.from_content(
             yaml_content="""
+            models:
+                - type: main
+                  engine: openai
+                  model: gpt-3.5-turbo-instruct
             rails:
                 input:
                     flows:
@@ -82,6 +98,10 @@ def test_self_check_output_prompt_exception():
     with pytest.raises(ValueError) as exc_info:
         config = RailsConfig.from_content(
             yaml_content="""
+            models:
+                - type: main
+                  engine: openai
+                  model: gpt-3.5-turbo-instruct
             rails:
                 output:
                     flows:
@@ -91,6 +111,14 @@ def test_self_check_output_prompt_exception():
         LLMRails(config=config)
 
     assert "You must provide a `self_check_output` prompt" in str(exc_info.value)
+
+
+def test_no_main_llm_exception():
+    with pytest.raises(ValueError) as exc_info:
+        config = RailsConfig.from_content(yaml_content="models: []")
+        LLMRails(config=config)
+
+    assert "No main LLM model" in str(exc_info.value)
 
 
 # def test_self_check_facts_prompt_exception():


### PR DESCRIPTION
If no main LLM model is configured, the following error might be triggered:

```
ERROR:nemoguardrails.actions.action_dispatcher:Error 'NoneType' object has no attribute 'agenerate_prompt'
```

This PR adds a clear message for this error. 

Related to #204.