### PR TITLE
Fix verbose behavior in Rails within Python script (GH-178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed logging issue where `verbose=true` flag did not trigger expected log output.
 
 ## [0.6.1] - 2023-12-20
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -34,6 +34,7 @@ from nemoguardrails.language.parser import parse_colang_file
 from nemoguardrails.llm.providers import get_llm_provider, get_llm_provider_names
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.logging.stats import llm_stats
+from nemoguardrails.logging.verbose import set_verbose
 from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
 from nemoguardrails.rails.llm.utils import get_history_cache_key
@@ -58,6 +59,9 @@ class LLMRails:
         self.config = config
         self.llm = llm
         self.verbose = verbose
+
+        if self.verbose:
+            set_verbose(True)
 
         # We allow the user to register additional embedding search providers, so we keep
         # an index of them.


### PR DESCRIPTION
- Address verbose output issue when running Rails command from a Python script.
- When user runs rails with `verbose=true` the `set_verbose()` function is now called.
- Response to GitHub discussion #178.