### PR TITLE
Fixed bug in input check

### DIFF
--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -64,7 +64,7 @@ async def self_check_input(
         check = check.lower().strip()
         log.info(f"Input self-checking result is: `{check}`.")
 
-        if "yes" in check:
+        if "no" in check:
             return ActionResult(
                 return_value=False,
                 events=[


### PR DESCRIPTION
I've identified a logical error in the guardrails input check function. Currently, the function returns **True** when the intended check fails (**False**) and **False** when the check passes (**True**). This inversion of logic could lead to unintended behavior in the program.

Technical Details:

    **File(s) Modified**: /nemoguardrails/library/self_check/input_check/actions.py
    **Function Name**:  self_check_input

Description of the Change:

I have modified the if statement ( **if "yes" in check:**) in the function to ( **if "no" in check:**). It now returns the actual result of the check. This change ensures that the function behaves as expected, returning true when the check passes and false when it fails.

Benefits of the Change:

    Ensures correct behavior of the guardrails input check
    Prevents potential bugs in functionalities that rely on this check
    Improves code readability and maintainability

Additional Notes:

    I have tested the changes to confirm that the function now behaves as expected.
    This change does not affect any other parts of the code.