### PR TITLE
typer upgrade to 0.9 with support to 0.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pydantic==1.10.9
 aiohttp==3.8.5
 langchain==0.0.352
 requests==2.31.0
-typer==0.7.0
+typer>=0.7.0,<=0.9.0
 PyYAML~=6.0
 setuptools~=65.5.1
 annoy==1.17.3

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "aiohttp==3.8.5",
         "langchain==0.0.352",
         "requests>=2.31.0",
-        "typer==0.7.0",
+        "typer>=0.7.0,<=0.9.0",
         "PyYAML~=6.0",
         "setuptools~=65.5.1",
         "annoy==1.17.3",


### PR DESCRIPTION
Upgraded type related to [this issue](![image](https://github.com/NVIDIA/NeMo-Guardrails/assets/41304927/4ef52f9b-c7de-4e0b-b0bb-0a6c193e7ff0))

2 lines of code changed, passed all tests as shown in screenshot:
<img width="842" alt="nemoguardrails-typer-upgrade" src="https://github.com/NVIDIA/NeMo-Guardrails/assets/41304927/64a9ddda-24d0-41e1-a984-f15f15f03d41">

requesting pull direct to 'develop' branch do to simplicity of task. If preferred to pull request to another branch, I'll get that done soon.