### PR TITLE
follow symlinks when building knowledge base

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -535,7 +535,9 @@ class RailsConfig(BaseModel):
             # Iterate all .yml files and join them
             raw_config = {}
 
-            for root, dirs, files in os.walk(config_path):
+            for root, dirs, files in os.walk(config_path, followlinks=True):
+                # followlinks means symlinks will be walked through instead of ignored
+
                 for file in files:
                     # This is the raw configuration that will be loaded from the file.
                     _raw_config = {}


### PR DESCRIPTION
The method that collects documents for the knowledge base does not walk over symlinks. Those are convenient to setup multiple examples that all use the same knowledge base hence this PR adds the followlinks parameter to the walk method to index contents for linked folders.