### PR TITLE
Fix stats gathering in a parallel async setup.

### DIFF
--- a/nemoguardrails/context.py
+++ b/nemoguardrails/context.py
@@ -25,3 +25,6 @@ llm_call_info_var = contextvars.ContextVar("llm_call_info", default=None)
 
 # All the generation options applicable to the current context.
 generation_options_var = contextvars.ContextVar("generation_options", default=None)
+
+# The stats about the LLM calls.
+llm_stats_var = contextvars.ContextVar("llm_stats", default=None)

--- a/nemoguardrails/logging/explain.py
+++ b/nemoguardrails/logging/explain.py
@@ -34,6 +34,12 @@ class LLMCallSummary(BaseModel):
     completion_tokens: Optional[int] = Field(
         default=None, description="The number of output tokens."
     )
+    started_at: Optional[float] = Field(
+        default=0, description="The timestamp for when the LLM call started."
+    )
+    finished_at: Optional[float] = Field(
+        default=0, description="The timestamp for when the LLM call finished."
+    )
 
 
 class LLMCallInfo(LLMCallSummary):

--- a/nemoguardrails/logging/stats.py
+++ b/nemoguardrails/logging/stats.py
@@ -30,6 +30,7 @@ class LLMStats:
             "total_tokens": 0,
             "total_prompt_tokens": 0,
             "total_completion_tokens": 0,
+            "latencies": [],
         }
 
     def inc(self, name: str, value: Union[float, int] = 1):
@@ -38,6 +39,9 @@ class LLMStats:
             self._stats[name] = 0
 
         self._stats[name] += value
+
+        if name == "total_time":
+            self._stats["latencies"].append(value)
 
     def get_stat(self, name):
         return self._stats[name]
@@ -51,13 +55,9 @@ class LLMStats:
     def __str__(self):
         return (
             f"{self._stats['total_calls']} total calls, "
-            f"{self._stats['total_time']} total time, "
+            f"{round(self._stats['total_time'], 2)} total time, "
             f"{self._stats['total_tokens']} total tokens, "
             f"{self._stats['total_prompt_tokens']} total prompt tokens, "
-            f"{self._stats['total_completion_tokens']} total completion tokens"
+            f"{self._stats['total_completion_tokens']} total completion tokens, "
+            f"{[round(x, 2) for x in self._stats['latencies']]} as latencies"
         )
-
-
-# Global stats object
-# TODO: make this per async context, otherwise, in the server setup it will be shared.
-llm_stats = LLMStats()


### PR DESCRIPTION
The LLM stats were not recorded correctly when parallel requests were involved. This PR fixes that. 