### PR TITLE
Added support for calling models from Vertex AI API

### DIFF
--- a/docs/evaluation/README.md
+++ b/docs/evaluation/README.md
@@ -4,7 +4,6 @@ NeMo Guardrails includes a set of tools that you can use to evaluate the differe
 
 At the same time, we provide preliminary results on the performance of the rails on a set of public datasets that are relevant to each task at hand.
 
-
 ## Dialog Rails
 
 ### Aim and Usage
@@ -13,6 +12,7 @@ Dialog rails evaluation focuses on NeMo Guardrails's core mechanism to guide con
 More details about this core functionality are explained [here](./../../docs/architecture/README.md).
 
 Thus, when using dialog rails evaluation, we are assessing the performance for:
+
 1. User canonical form (intent) generation.
 2. Next step generation - in the current approach, we only assess the performance of bot canonical forms as next step in a flow.
 3. Bot message generation.
@@ -20,7 +20,7 @@ Thus, when using dialog rails evaluation, we are assessing the performance for:
 The CLI command for evaluating the dialog rails is:
 
 ```bash
-$ nemoguardrails evaluate topical --config=<rails_app_path> --verbose
+nemoguardrails evaluate topical --config=<rails_app_path> --verbose
 ```
 
 A dialog rails evaluation has the following CLI parameters:
@@ -36,10 +36,10 @@ current evaluation, this is the step.
 - `random-seed`: Random seed used by the evaluation.
 - `output-dir`: Output directory for predictions.
 
-
 ### Evaluation Results
 
 For the initial evaluation experiments for dialog rails, we have used two datasets for conversational NLU:
+
 - [_chit-chat_](https://github.com/rahul051296/small-talk-rasa-stack) dataset
 - [_banking_](https://github.com/PolyAI-LDN/task-specific-datasets/tree/master/banking_data) dataset
 
@@ -54,6 +54,7 @@ Take into account that the performance of an LLM is heavily dependent on the pro
 Therefore, currently, we only release the results for OpenAI models, but more results will follow in the next releases. All results are preliminary, as better prompting can improve them.
 
 Important lessons to be learned from the evaluation results:
+
 - Each step in the three-step approach (user intent, next step/bot intent, bot message) used by Guardrails offers an improvement in performance.
 - It is important to have at least k=3 samples in the vector database for each user intent (canonical form) to achieve good performance.
 - Some models (e.g., gpt-3.5-turbo) produce a wider variety of canonical forms, even with the few-shot prompting used by Guardrails. In these cases, it is useful to add a similarity match instead of exact match for user intents. In this case, the similarity threshold becomes an important inference parameter.
@@ -61,7 +62,7 @@ Important lessons to be learned from the evaluation results:
 - Using a single call for topical rails shows similar results to the default method (which uses up to 3 LLM calls for generating the final bot message) in most cases for `text-davinci-003` model.
 - Initial experiments show that using compact prompts has similar or even better performance on these two datasets compared to using the longer prompts.
 
-Evaluation Date - June 21, 2023. Updated July 24, 2023 for Dolly, Vicuna and Mosaic MPT models.
+Evaluation Date - June 21, 2023. Updated July 24, 2023 for Dolly, Vicuna and Mosaic MPT models. Updated Mar 7 2024 for `gemini-1.0-pro`.
 
 | Dataset   | # intents | # test samples |
 |-----------|-----------|----------------|
@@ -69,7 +70,6 @@ Evaluation Date - June 21, 2023. Updated July 24, 2023 for Dolly, Vicuna and Mos
 | banking   | 77        | 231            |
 
 Results on _chit-chat_ dataset, metric used is accuracy.
-
 
 | Model                                  | User intent, `w.o sim` | User intent, `sim=0.6` | Bot intent, `w.o sim` | Bot intent, `sim=0.6` | Bot message, `w.o sim` | Bot message, `sim=0.6` |
 |----------------------------------------|------------------------|------------------------|-----------------------|-----------------------|------------------------|------------------------|
@@ -87,10 +87,12 @@ Results on _chit-chat_ dataset, metric used is accuracy.
 | `vicuna-7b-v1.3, k=all`                | 0.62                   | 0.75                   | 0.69                  | 0.77                  | 0.71                   | 0.79                   |
 | `mpt-7b-instruct, k=all`               | 0.73                   | 0.81                   | 0.78                  | 0.82                  | 0.80                   | 0.82                   |
 | `falcon-7b-instruct, k=all`            | 0.81                   | 0.81                   | 0.81                  | 0.82                  | 0.82                   | 0.82                   |
-
+| `gemini-1.0-pro`                       | 0.83                   | 0.86                   | 0.83                  | 0.84                  | 0.83                   | 0.85
+| `gemini-1.0-pro, single call`          | 0.83                   | 0.88                   | 0.83                  | 0.85                  | 0.83                   | 0.85
+| `text-bison`                           | 0.72                   | 0.73                   | 0.76                  | 0.76                  | 0.77                   | 0.79
+| `text-bison, single call`              | 0.64                   | 0.70                   | 0.70                  | 0.73                  | 0.74                   | 0.75
 
 Results on _banking_ dataset, metric used is accuracy.
-
 
 | Model                                  | User intent, `w.o sim` | User intent, `sim=0.6` | Bot intent, `w.o sim` | Bot intent, `sim=0.6` | Bot message, `w.o sim` | Bot message, `sim=0.6` |
 |----------------------------------------|------------------------|------------------------|-----------------------|-----------------------|------------------------|------------------------|
@@ -108,18 +110,25 @@ Results on _banking_ dataset, metric used is accuracy.
 | `vicuna-7b-v1.3, k=all`                | 0.39                   | 0.62                   | 0.54                  | 0.65                  | N/A                    | N/A                    |
 | `mpt-7b-instruct, k=all`               | 0.45                   | 0.58                   | 0.50                  | 0.60                  | N/A                    | N/A                    |
 | `falcon-7b-instruct, k=all`            | 0.70                   | 0.75                   | 0.76                  | 0.78                  | N/A                    | N/A                    |
-
+| `gemini-1.0-pro`                       | 0.85                   | 0.89                   | 0.87                  | 0.91                  | N/A                    | N/A                    |
+| `gemini-1.0-pro, single call`          | 0.89                   | 0.89                   | 0.91                  | 0.89                  | N/A                    | N/A                    |
+| `text-bison`                           | 0.85                   | 0.92                   | 0.89                  | 0.94                  | N/A                    | N/A                    |
+| `text-bison, single call`              | 0.86                   | 0.90                   | 0.90                  | 0.90                  | N/A                    | N/A                    |
 
 ## Input and Output Rails
 
 ### Fact-checking Rails
+
 In the [Guardrails library](./../../docs/user_guides/guardrails-library.md), we provide two approaches out of the box for the fact-checking rail: the Self-Check fact-checking and AlignScore. For more details, read the [library guide](./../../docs/user_guides/guardrails-library.md).
 
 #### Self-Check
+
 In this approach, the fact-checking rail is implemented as an entailment prediction problem. Given an evidence passage and the predicted answer, we prompt an LLM to predict yes/no whether the answer is grounded in the evidence or not. This is the default approach.
 
 #### AlignScore
+
 This approach is based on the AlignScore model [Zha et al. 2023](https://aclanthology.org/2023.acl-long.634.pdf). Given an evidence passage and the predicted answer, the model is finetuned to predict that they are aligned when:
+
 1. All information in the predicted answer is present in the evidence passage, and
 2. None of the information in the predicted answer contradicts the evidence passage.
 The response is a value between 0.0 and 1.0. In our testing, the best average accuracies were observed with a threshold of 0.7.
@@ -127,10 +136,11 @@ The response is a value between 0.0 and 1.0. In our testing, the best average ac
 Please see the [user guide documentation](./../../docs/user_guides/guardrails-library.md#alignscore) for detailed steps on how to configure your deployment to use AlignScore.
 
 #### Evaluation
+
 To run the fact-checking rail, you can use the following CLI command:
 
 ```bash
-$ nemoguardrails evaluate fact-checking --config=path/to/guardrails/config
+nemoguardrails evaluate fact-checking --config=path/to/guardrails/config
 ```
 
 Here is a list of arguments that you can use to configure the fact-checking rail:
@@ -147,6 +157,7 @@ Here is a list of arguments that you can use to configure the fact-checking rail
         },
     }
     ```
+
 - `num-samples`: Number of samples to run the eval on. The default is 50.
 - `create-negatives`: Whether to generate synthetic negative examples or not. The default is `True`.
 - `output-dir`: The directory to save the output to. The default is `eval_outputs/factchecking`.
@@ -156,7 +167,7 @@ More details on how to set up the data in the right format and run the evaluatio
 
 #### Evaluation Results
 
-Evaluation Date - Nov 23, 2023.
+Evaluation Date - Nov 23, 2023 (Mar 7 2024 for `gemini-1.0-pro`).
 
 We evaluate the performance of the fact-checking rail on the [MSMARCO](https://huggingface.co/datasets/ms_marco) dataset using the Self-Check and the AlignScore approaches. To build the dataset, we randomly sample 100 (question, correct answer, evidence) triples, and then, for each triple, build a non-factual or incorrect answer to yield 100 (question, incorrect answer, evidence) triples.
 
@@ -167,6 +178,7 @@ We breakdown the performance into positive entailment accuracy and negative enta
 | gpt-3.5-turbo-instruct | **92.0%**                    | 69.0%                        | 80.5%            | 188.8ms                            |
 | gpt-3.5-turbo          | 76.0%                        | 89.0%                        | 82.5%            | 435.1ms                            |
 | text-davinci-003       | 70.0%                        | **93.0%**                    | 81.5%            | 272.2ms                            |
+| gemini-1.0-pro         | **92.0%**                    | **93.0%**                    | **92.5%**        | 704.5ms                            |
 | align_score-base*      | 81.0%                        | 88.0%                        | 84.5%            | **23.0ms** ^                       |
 | align_score-large*     | 87.0%                        | 90.0%                        | **88.5%**        | 46.0ms ^                           |
 
@@ -176,20 +188,22 @@ We breakdown the performance into positive entailment accuracy and negative enta
 ### Moderation Rails
 
 The moderation involves two components: input and output moderation.
-* The input moderation attempts to block user inputs that are designed to elicit harmful responses from the bot.
-* The output moderation attempts to filter the language model output to avoid unsafe content from being displayed to the user.
+
+- The input moderation attempts to block user inputs that are designed to elicit harmful responses from the bot.
+- The output moderation attempts to filter the language model output to avoid unsafe content from being displayed to the user.
 
 #### Self-Check
+
 This rail will prompt the LLM using a custom prompt for input (jailbreak) and output moderation.
 Common reasons for rejecting the input from the user include jailbreak attempts, harmful or abusive content, or other inappropriate instructions.
 For more details, consult the [Guardrails library]([Guardrails library](./../../docs/user_guides/guardrails-library.md)) guide.
 
-
 #### Evaluation
+
 The jailbreak and output moderation can be evaluated using the following CLI command:
 
 ```bash
-$ nemoguardrails evaluate moderation --config=path/to/guardrails/config
+nemoguardrails evaluate moderation --config=path/to/guardrails/config
 ```
 
 The various arguments that can be passed to evaluate the moderation rails are
@@ -216,12 +230,12 @@ More details on how to set up the data in the right format and run the evaluatio
 
 We evaluate the moderation rails on the Anthropic [Red Team Attempts dataset](https://huggingface.co/datasets/Anthropic/hh-rlhf/tree/main/red-team-attempts) and the Anthropic [Helpful Base dataset](https://huggingface.co/datasets/Anthropic/hh-rlhf/tree/main/helpful-base). This dataset contains prompts that are labeled by humans as either helpful or harmful. We randomly sample 100 prompts from each of the splits and run the evaluation using OpenAI `text-davinci-003` and `gpt-3.5-turbo` models.
 
-Evaluation Date - June 02, 2023.
+Evaluation Date - June 02, 2023 (Mar 7 2024 for `gemini-1.0-pro`).
 
 We breakdown the performance of the models on the two rails into the following metrics:
 
-* % of the prompts that are **blocked** on the Red Team Attempts dataset
-* % of the prompts that are **allowed** on the Helpful Base dataset
+- % of the prompts that are **blocked** on the Red Team Attempts dataset
+- % of the prompts that are **allowed** on the Helpful Base dataset
 
 We want the models to block as many harmful prompts as possible and allow as many helpful prompts as possible.
 
@@ -235,8 +249,12 @@ These results are using the _Simple_ prompt defined in the LLM Self-Checking met
 | gpt-3.5-turbo          | 70                           | 100                          |
 | text-davinci-003       | 80                           | 97                           |
 | nemollm-43b            | 88                           | 84                           |
+| gemini-1.0-pro         | 63<sup>*</sup>               | 97                           |
+
+<sup>*</sup> Note that as of Mar 7, 2024 `gemini-1.0-pro` when queried via the Vertex AI API occasionally produces [this error](https://github.com/GoogleCloudPlatform/generative-ai/issues/344). The backoff behavior on encountering this error affects results. For example if we consider producing this error as a form of harmful prompt blocking, `gemini-1.0-pro` blocks 99\% of harmful prompts.
 
 ##### LlamaGuard-based Moderation Rails Performance
+
 Evaluation date: January 8, 2024.
 
 Guardrails offers out-of-the-box support for Meta's new Llama Guard model for input/output moderation.
@@ -261,13 +279,15 @@ Number of user inputs labeled harmful: 730 (7.2%)
 The low precision and high recall numbers from the self check input with the complex prompt indicates an overly defensive behavior from the self check input rail. We will run this evaluation with more variations of the self check prompt and report numbers.
 
 ### Hallucination Rails
+
 For general questions that the model uses parametric knowledge to answer, we can define a hallucination rail to detect when the model is potentially making up facts. The default implementation of the hallucination rails is based on [SelfCheckGPT](https://arxiv.org/abs/2303.08896).
 
-* Given a question, we sample multiple answers from the model, often at a high temperature (temp=1.0).
-* We then check if the answers are consistent with each other. This agreement check is implemented using an LLM call similar to the fact checking rail.
-* If the answers are inconsistent, it indicates that the model might be hallucinating.
+- Given a question, we sample multiple answers from the model, often at a high temperature (temp=1.0).
+- We then check if the answers are consistent with each other. This agreement check is implemented using an LLM call similar to the fact checking rail.
+- If the answers are inconsistent, it indicates that the model might be hallucinating.
 
 #### Self-Check
+
 This rail will use the LLM for self-checking with a custom prompt if the answers are inconsistent. The custom prompt can be similar to an NLI task.
 For more details, consult the [Guardrails library]([Guardrails library](./../../docs/user_guides/guardrails-library.md)) guide.
 
@@ -276,7 +296,7 @@ For more details, consult the [Guardrails library]([Guardrails library](./../../
 To run the hallucination rail, use the following CLI command:
 
 ```bash
-$ nemoguardrails evaluate hallucination --config=path/to/guardrails/config
+nemoguardrails evaluate hallucination --config=path/to/guardrails/config
 ```
 
 Here is a list of arguments that you can use to configure the hallucination rail:
@@ -299,16 +319,17 @@ For example, the question "What is the capital of the moon?" has a false premise
 
 We then run the hallucination rail on these questions and check if the model is able to detect the hallucination. We run the evaluation using OpenAI `text-davinci-003` and `gpt-3.5-turbo` models.
 
-Evaluation Date - June 12, 2023.
+Evaluation Date - June 12, 2023 (Mar 7 2024 for `gemini-1.0-pro`).
 
 We breakdown the performance into the following metrics:
 
-* % of questions that are intercepted by the model, i.e., % of questions where the model detects are not answerable
-* % of questions that are intercepted by model + hallucination rail, i.e., % of questions where the either the model detects are not answerable or the hallucination rail detects that the model is making up facts
+- % of questions that are intercepted by the model, i.e., % of questions where the model detects are not answerable
+- % of questions that are intercepted by model + hallucination rail, i.e., % of questions where the either the model detects are not answerable or the hallucination rail detects that the model is making up facts
 
 | Model              | % intercepted - model | % intercepted - model + hallucination rail |
 |--------------------|-----------------------|--------------------------------------------|
 | text-davinci-003   | 0                     | 70                                         |
 | gpt-3.5-turbo      | 65                    | 90                                         |
+| gemini-1.0-pro     | 60                    | 73.3                                       |
 
 We find that gpt-3.5-turbo is able to intercept 65% of the questions and identify them as not answerable on its own. Adding the hallucination rail helps intercepts 25% more questions and prevents the model from making up facts.

--- a/nemoguardrails/eval/evaluate_hallucination.py
+++ b/nemoguardrails/eval/evaluate_hallucination.py
@@ -81,7 +81,11 @@ class HallucinationRailsEvaluation:
         extra_responses = []
         with llm_params(self.llm, temperature=1.0, max_tokens=100):
             for _ in range(num_responses):
-                extra_responses.append(self.llm(prompt))
+                try:
+                    extra_response = self.llm(prompt)
+                except ValueError as e:
+                    extra_response = ""
+                extra_responses.append(extra_response)
 
         return extra_responses
 
@@ -100,7 +104,10 @@ class HallucinationRailsEvaluation:
 
         for question in tqdm.tqdm(self.dataset):
             with llm_params(self.llm, temperature=0.2, max_tokens=100):
-                bot_response = self.llm(question)
+                try:
+                    bot_response = self.llm(question)
+                except ValueError as e:
+                    bot_response = ""
 
             extra_responses = self.get_extra_responses(question, num_responses=2)
             if len(extra_responses) == 0:

--- a/nemoguardrails/eval/evaluate_moderation.py
+++ b/nemoguardrails/eval/evaluate_moderation.py
@@ -91,7 +91,10 @@ class ModerationRailsEvaluation:
             Task.SELF_CHECK_INPUT, {"user_input": prompt}
         )
         print(check_input_prompt)
-        jailbreak = self.llm(check_input_prompt)
+        try:
+            jailbreak = self.llm(check_input_prompt)
+        except ValueError:
+            jailbreak = ""
         jailbreak = jailbreak.lower().strip()
         print(jailbreak)
 

--- a/nemoguardrails/eval/evaluate_topical.py
+++ b/nemoguardrails/eval/evaluate_topical.py
@@ -288,10 +288,16 @@ class TopicalRailsEvaluation:
                     history_events
                 )
 
-                generated_user_intent = get_last_user_intent_event(new_events)["intent"]
-                prediction["generated_user_intent"] = generated_user_intent
-                wrong_intent = False
-                if generated_user_intent != intent:
+                generated_user_intent = None
+                last_user_intent_event = get_last_user_intent_event(new_events)
+                if last_user_intent_event is not None:
+                    generated_user_intent = last_user_intent_event["intent"]
+                    prediction["generated_user_intent"] = generated_user_intent
+                    wrong_intent = False
+                if (
+                    generated_user_intent is not None
+                    and generated_user_intent != intent
+                ):
                     wrong_intent = True
                     # Employ semantic similarity if needed
                     if self.similarity_threshold > 0:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -335,6 +335,7 @@ class LLMRails:
                         "nlpcloud",
                         "petals",
                         "trt_llm",
+                        "vertexai",
                     ]:
                         kwargs["model_name"] = llm_config.model
                     else:


### PR DESCRIPTION
Added support for calling models from Vertex AI API. Tested by running evaluations using Gemini 1.0 Pro and `text-bison` (PaLM 2 instruction tuned) model.
Note that [this open issue](https://github.com/GoogleCloudPlatform/generative-ai/issues/344) with Vertex AI models results in calls occasionally erroring out. Some `try-catch` blocks have been added in hallucination and moderation tests that are especially likely to trigger this. 
Additionally, runs calling Vertex AI models currently trigger a `LangChainDeprecationWarning` that would need a `langchain` upgrade to `0.2.0` to remove.  