### PR TITLE
Colang parser improvements

### DIFF
--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -117,10 +117,15 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             if colang_flow:
                 assert isinstance(flow, Flow)
                 # Check if we need to exclude this flow.
-                # TODO: Implement this better, e.g. as a flow declarator
+                # TODO: deprecate the use of the "# meta: " comment in favor of
+                #   @meta(llm_exclude=True)
                 if "# meta: exclude from llm" in colang_flow or (
                     "exclude_from_llm" not in flow.file_info
                     or flow.file_info["exclude_from_llm"]
+                    or (
+                        "meta" in flow.decorators
+                        and flow.decorators["meta"].parameters.get("llm_exclude")
+                    )
                 ):
                     continue
 

--- a/nemoguardrails/colang/runtime.py
+++ b/nemoguardrails/colang/runtime.py
@@ -32,7 +32,10 @@ class Runtime:
         self.verbose = verbose
 
         # Register the actions with the dispatcher.
-        self.action_dispatcher = ActionDispatcher(config_path=config.config_path)
+        self.action_dispatcher = ActionDispatcher(
+            config_path=config.config_path,
+            import_paths=list(config.imported_paths.values()),
+        )
 
         # The list of additional parameters that can be passed to the actions.
         self.registered_action_params: dict = {}

--- a/nemoguardrails/colang/v2_x/lang/colang_ast.py
+++ b/nemoguardrails/colang/v2_x/lang/colang_ast.py
@@ -47,6 +47,18 @@ class FlowParamDef:
 
 @dataclass_json
 @dataclass
+class DecoratorDef:
+    """The definition for a flow decorator.
+
+    Explicit typing is not yet supported.
+    """
+
+    name: str
+    parameters: dict = field(default_factory=dict)
+
+
+@dataclass_json
+@dataclass
 class FlowReturnMemberDef:
     """The definition for a flow return member.
 
@@ -126,6 +138,7 @@ class Flow(Element):
     """Element that represents a flow."""
 
     name: str = ""
+    decorators: List[DecoratorDef] = field(default_factory=list)
     parameters: List[FlowParamDef] = field(default_factory=list)
     return_members: List[FlowReturnMemberDef] = field(default_factory=list)
     elements: List[Element] = field(default_factory=list)

--- a/nemoguardrails/colang/v2_x/lang/colang_ast.py
+++ b/nemoguardrails/colang/v2_x/lang/colang_ast.py
@@ -47,18 +47,6 @@ class FlowParamDef:
 
 @dataclass_json
 @dataclass
-class DecoratorDef:
-    """The definition for a flow decorator.
-
-    Explicit typing is not yet supported.
-    """
-
-    name: str
-    parameters: dict = field(default_factory=dict)
-
-
-@dataclass_json
-@dataclass
 class FlowReturnMemberDef:
     """The definition for a flow return member.
 
@@ -116,6 +104,36 @@ def _make_hashable(obj: Any) -> Any:
 
 @dataclass_json
 @dataclass
+class Decorator(Element):
+    """The definition for a flow decorator.
+
+    Explicit typing is not yet supported.
+    """
+
+    name: str = ""
+    parameters: dict = field(default_factory=dict)
+    _type: str = "decorator"
+
+
+@dataclass_json
+@dataclass
+class Import(Element):
+    """The definition for an import statement.
+
+    We support both "path mode" and "package" mode.
+
+        import core
+        import rag.advanced
+        import "some-spec/some-sub-package"
+    """
+
+    path: Optional[str] = None
+    package: Optional[str] = None
+    _type: str = "import"
+
+
+@dataclass_json
+@dataclass
 class Value(Element):
     """Element that contains a value."""
 
@@ -138,7 +156,7 @@ class Flow(Element):
     """Element that represents a flow."""
 
     name: str = ""
-    decorators: List[DecoratorDef] = field(default_factory=list)
+    decorators: List[Decorator] = field(default_factory=list)
     parameters: List[FlowParamDef] = field(default_factory=list)
     return_members: List[FlowReturnMemberDef] = field(default_factory=list)
     elements: List[Element] = field(default_factory=list)

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -41,6 +41,8 @@ priority_stmt: "priority" expr _NEWLINE
 label_stmt: NAME":" _NEWLINE
 global_stmt: "global" var_name _NEWLINE
 
+// --------------------------------
+
 // A "spec" is a unifying concept for flows, actions, events
 spec_operator: "match" -> match_spec
              | "await" -> await_spec
@@ -95,18 +97,20 @@ simple_arguments: simple_argvalue+
 // Compound statements
 ?compound_stmt: if_stmt | while_stmt | when_stmt
 while_stmt: "while" test suite
-if_stmt: "if" test suite elifs ["else" suite]
+if_stmt: _IF test suite elifs ["else" suite]
 elifs: elif_*
 elif_: _ELSE_IF test suite
 when_stmt: "when" spec_expr suite orwhens ["else" suite]
 orwhens: orwhen_*
 orwhen_: _OR_WHEN spec_expr suite
 
+// --------------------------------
+
 // Test expression (used both for conditions and assignment)
 test: or_test
 ?or_test: and_test (_OR and_test)*
 ?and_test: not_test_ (_AND not_test_)*
-?not_test_: "not" not_test_ -> not_test
+?not_test_: _NOT not_test_ -> not_test
          | comparison
 ?comparison: expr (comp_op expr)*
 star_expr: "*" expr
@@ -124,12 +128,12 @@ expr: or_expr
 !_add_op: "+"|"-"
 !_shift_op: "<<"|">>"
 !_mul_op: "*"|"@"|"/"|"%"|"//"
-!comp_op: "<"|">"|"=="|">="|"<="|"<>"|"!="|"in"|"not" "in"|"is"|"is" "not"
+!comp_op: "<"|">"|"=="|">="|"<="|"<>"|"!="|_IN|_NOT _IN|_IS|_IS _NOT
 
 ?power: atom_expr ("**" factor)?
-?atom_expr: func_name "(" [arguments] ")"    -> funccall
+?atom_expr: name "(" [arguments] ")"    -> funccall
           | atom_expr "[" subscriptlist "]"  -> getitem
-          | atom_expr "." name               -> getattr
+          | atom_expr "." attr_name          -> getattr
           | "[" _exprlist? "]"  -> list
           | "{" _dict_exprlist? "}" -> dict
           | "{" _exprlist "}" -> set
@@ -166,9 +170,10 @@ sliceop: ":" [test]
 spec_name: name+
          | "(" name+ ")"
 
-func_name: FUNC_NAME
+// --------------------------------
 
 name: NAME
+attr_name: NAME
 var_name: VAR_NAME
 comment: COMMENT
 
@@ -179,25 +184,33 @@ number: DEC_NUMBER | FLOAT_NUMBER
 string: STRING
 doc_string: LONG_STRING
 
+// --------------------------------
+
 // LEXER rules below
 
-_ELSE_IF.1: /(elif|else\s+if)/
-
-_OR_WHEN.1: /(orwhen)/
-
-COMMENT: /#[^\n]*/
-
-_AND.1: /(and[ \t]|(\r?\n[\t ]*)+and[ \t])/
-_OR.1: /(or[ \t]|(\r?\n[\t ]*)+or[ \t])/
+// High priority keywords
 
 // TODO: Create a positive lookbehind for whitespace characters: e.g. with /(?<=\s)
 _FLOW.1: /(?<!\.)flow(?!(\s*\(|[a-zA-Z0-9_]))/
 
+_IF.1: /if/
+_ELSE_IF.1: /(elif|else\s+if)/
+_OR_WHEN.1: /(orwhen)/
+_AND.1: /(and[ \t]|(\r?\n[\t ]*)+and[ \t])/
+_OR.1: /(or[ \t]|(\r?\n[\t ]*)+or[ \t])/
+_IS.1: /is/
+_IN.1: /in/
+_NOT.1: /not/
+
+// Names
+
 NAME: /[^\W\d]\w*/
 VAR_NAME: /\$[^\W\d]\w*/
-FUNC_NAME: /(?<![a-zA-Z]\s)(flow|action)(?=\()/
 
+COMMENT: /#[^\n]*/
 _NEWLINE: (/\r?\n[\t ]*/)+
+
+// Primitive values
 
 STRING: /r?("(?!"").*?(?<!\\)(\\\\)*?"|'(?!'').*?(?<!\\)(\\\\)*?')/i
 LONG_STRING: /(""".*?(?<!\\)(\\\\)*?"""|'''.*?(?<!\\)(\\\\)*?''')/is

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -51,7 +51,7 @@ spec_operator: "match" -> match_spec
              | "activate" -> activate_spec
              | "send" -> send_spec
 
-spec_op: spec_operator spec_expr |
+spec_op: spec_operator spec_expr
        | non_var_spec_expr
 
 ?spec_op_stmt: spec_op _NEWLINE

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -22,7 +22,7 @@ return_member_def: var_name ("=" test)?
 
 
 // Simple statements
-?simple_stmt: set_stmt | return_stmt | abort_stmt | break_stmt | continue_stmt | pass_stmt | log_stmt | print_stmt | priority_stmt | label_stmt | global_stmt | expr_stmt
+?simple_stmt: set_stmt | return_stmt | abort_stmt | break_stmt | continue_stmt | pass_stmt | log_stmt | print_stmt | priority_stmt | label_stmt | global_stmt | expr_stmt | import_stmt
 set_stmt: var_name set_op set_right_side _NEWLINE
 ?set_right_side: test | spec_op
 
@@ -43,6 +43,7 @@ print_stmt: "print" expr _NEWLINE
 priority_stmt: "priority" expr _NEWLINE
 label_stmt: NAME":" _NEWLINE
 global_stmt: "global" var_name _NEWLINE
+import_stmt: "import" (package_name | string) _NEWLINE
 expr_stmt: "(" test ")"
 
 // --------------------------------
@@ -182,6 +183,7 @@ attr_name: NAME
 decorator_name: NAME
 method_name: NAME
 var_name: VAR_NAME
+package_name: NAME ("." NAME)*
 comment: COMMENT
 
 // Primitive types

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -8,7 +8,10 @@ suite: _NEWLINE _INDENT (stmt+) _DEDENT
 
 // Flow definition and calling
 ?def_stmt: flow_def
-flow_def: _FLOW spec_name [flow_params_def] ["->" return_members_def] suite
+decorators: (decorator _NEWLINE)*
+decorator: "@" decorator_name ["(" decorator_parameters ")"]
+decorator_parameters: _argvalues*
+flow_def: decorators _FLOW spec_name [flow_params_def] ["->" return_members_def] suite
 ?flow_params_def: flow_params_def_classic | flow_params_def_simple
 flow_params_def_classic: "(" (flow_param_def ("," flow_param_def)*) ")"
 flow_params_def_simple: (flow_param_def)+
@@ -174,6 +177,7 @@ spec_name: name+
 
 name: NAME
 attr_name: NAME
+decorator_name: NAME
 var_name: VAR_NAME
 comment: COMMENT
 

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -22,7 +22,7 @@ return_member_def: var_name ("=" test)?
 
 
 // Simple statements
-?simple_stmt: set_stmt | return_stmt | abort_stmt | break_stmt | continue_stmt | pass_stmt | log_stmt | print_stmt | priority_stmt | label_stmt | global_stmt
+?simple_stmt: set_stmt | return_stmt | abort_stmt | break_stmt | continue_stmt | pass_stmt | log_stmt | print_stmt | priority_stmt | label_stmt | global_stmt | expr_stmt
 set_stmt: var_name set_op set_right_side _NEWLINE
 ?set_right_side: test | spec_op
 
@@ -43,6 +43,7 @@ print_stmt: "print" expr _NEWLINE
 priority_stmt: "priority" expr _NEWLINE
 label_stmt: NAME":" _NEWLINE
 global_stmt: "global" var_name _NEWLINE
+expr_stmt: "(" test ")"
 
 // --------------------------------
 
@@ -137,6 +138,7 @@ expr: or_expr
 ?atom_expr: name "(" [arguments] ")"    -> funccall
           | atom_expr "[" subscriptlist "]"  -> getitem
           | atom_expr "." attr_name          -> getattr
+          | atom_expr "." method_name "(" [arguments] ")" -> method
           | "[" _exprlist? "]"  -> list
           | "{" _dict_exprlist? "}" -> dict
           | "{" _exprlist "}" -> set
@@ -178,6 +180,7 @@ spec_name: name+
 name: NAME
 attr_name: NAME
 decorator_name: NAME
+method_name: NAME
 var_name: VAR_NAME
 comment: COMMENT
 

--- a/nemoguardrails/colang/v2_x/lang/transformer.py
+++ b/nemoguardrails/colang/v2_x/lang/transformer.py
@@ -365,6 +365,13 @@ class ColangTransformer(Transformer):
         else:
             raise Exception(f"Invalid element '{children[2]['_type']}'")
 
+    def _expr_stmt(self, children: list, meta: Meta) -> Assignment:
+        return Assignment(
+            key="_",
+            expression=children[0]["elements"][0],
+            _source=self.__source(meta),
+        )
+
     def _while_stmt(self, children: list, meta: Meta) -> While:
         assert len(children) == 2
         return While(

--- a/nemoguardrails/colang/v2_x/lang/transformer.py
+++ b/nemoguardrails/colang/v2_x/lang/transformer.py
@@ -25,12 +25,13 @@ from nemoguardrails.colang.v2_x.lang.colang_ast import (
     Assignment,
     Break,
     Continue,
-    DecoratorDef,
+    Decorator,
     Flow,
     FlowParamDef,
     FlowReturnMemberDef,
     Global,
     If,
+    Import,
     Label,
     Log,
     Print,
@@ -143,7 +144,7 @@ class ColangTransformer(Transformer):
                         decorator_parameters[k] = literal_eval(decorator_parameters[k])
 
             decorator_defs.append(
-                DecoratorDef(name=decorator_name, parameters=decorator_parameters)
+                Decorator(name=decorator_name, parameters=decorator_parameters)
             )
 
         param_defs = []
@@ -369,6 +370,21 @@ class ColangTransformer(Transformer):
         return Assignment(
             key="_",
             expression=children[0]["elements"][0],
+            _source=self.__source(meta),
+        )
+
+    def _import_stmt(self, children: list, meta: Meta) -> Import:
+        path = None
+        package = None
+
+        if children[0]["_type"] == "package_name":
+            package = ".".join(el["elements"][0] for el in children[0]["elements"])
+        else:
+            path = children[0]["elements"][0]["elements"][0]
+
+        return Import(
+            path=path,
+            package=package,
             _source=self.__source(meta),
         )
 

--- a/nemoguardrails/colang/v2_x/library/core.co
+++ b/nemoguardrails/colang/v2_x/library/core.co
@@ -1,0 +1,21 @@
+flow user said $text -> $transcript
+  # meta: user action
+  match UtteranceUserAction.Finished(final_transcript=$text) as $event
+  $transcript = $event.arguments.final_transcript
+
+flow user said something -> $transcript
+  match UtteranceUserAction.Finished() as $event
+  send UserActionLog(flow_id="user said", parameter=$event.arguments.final_transcript, intent_flow_id="user said something")
+  $transcript = $event.arguments.final_transcript
+
+flow unhandled user intent -> $intent
+  match UnhandledEvent(event="FinishFlow", flow_id=r"^user ", loop_ids={$loop_id}) as $event
+  $intent = $event.arguments.flow_id
+
+flow _bot_say $text
+  """It's an internal helper for higher semantic level flows"""
+  await UtteranceBotAction(script=$text) as $action
+
+flow bot say $text
+  # meta: bot action
+  await _bot_say $text

--- a/nemoguardrails/colang/v2_x/library/utils.co
+++ b/nemoguardrails/colang/v2_x/library/utils.co
@@ -1,0 +1,8 @@
+flow wait indefinitely
+  """Little helper flow to wait indefinitely."""
+  match NeverComingEvent()
+
+flow wait $time_s $timer_id="wait_timer_{{uid()}}"
+  """Wait the specified number of seconds before continuing."""
+  # meta: loop_id=NEW
+  await TimerBotAction(timer_name=$timer_id, duration=$time_s)

--- a/nemoguardrails/colang/v2_x/runtime/flows.py
+++ b/nemoguardrails/colang/v2_x/runtime/flows.py
@@ -28,6 +28,7 @@ from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple, Union
 from dataclasses_json import dataclass_json
 
 from nemoguardrails.colang.v2_x.lang.colang_ast import (
+    Decorator,
     ElementType,
     FlowParamDef,
     FlowReturnMemberDef,
@@ -306,6 +307,11 @@ class FlowConfig:
 
     # The flow parameters
     parameters: List[FlowParamDef]
+
+    # The decorators for the flow.
+    # Maps the name of the applied decorators to the arguments.
+    # If positional arguments are provided, then the "$0", "$1", ... are used as the keys.
+    decorators: Dict[str, Decorator] = field(default_factory=dict)
 
     # The flow return member variables
     return_members: List[FlowReturnMemberDef] = field(default_factory=list)

--- a/nemoguardrails/colang/v2_x/runtime/runtime.py
+++ b/nemoguardrails/colang/v2_x/runtime/runtime.py
@@ -132,6 +132,7 @@ class RuntimeV2_x(Runtime):
             self.flow_configs[flow_id] = FlowConfig(
                 id=flow_id,
                 elements=flow.elements,
+                decorators={decorator.name: decorator for decorator in flow.decorators},
                 parameters=flow.parameters,
                 return_members=flow.return_members,
                 source_code=flow.source_code,

--- a/nemoguardrails/colang/v2_x/runtime/statemachine.py
+++ b/nemoguardrails/colang/v2_x/runtime/statemachine.py
@@ -106,10 +106,23 @@ def initialize_flow(state: State, flow_config: FlowConfig) -> None:
     flow_config.elements = expand_elements(flow_config.elements, state.flow_configs)
 
     # Extract flow loop id if available
+    # TODO: deprecate this convention in the favor of the `@loop("some_id")` decorator.
     if flow_config.source_code:
         match = re.search(r"#\W*meta:\W*loop_id\W*=\W*(\w*)", flow_config.source_code)
         if match:
             flow_config.loop_id = match.group(1)
+
+    # Extract loop id from decorator if available
+    if "loop" in flow_config.decorators:
+        decorator = flow_config.decorators["loop"]
+        if "id" in decorator.parameters:
+            flow_config.loop_id = decorator.parameters["id"]
+        elif "$0" in decorator.parameters:
+            flow_config.loop_id = decorator.parameters["$0"]
+        else:
+            raise ValueError(
+                f"No loop id specified for @loop decorator for flow `{flow_config.id}`"
+            )
 
     # Extract all the label elements
     for idx, element in enumerate(flow_config.elements):

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -669,6 +669,10 @@ class RailsConfig(BaseModel):
         description="A list of additional paths from which configuration elements (colang flows, .yml files, actions)"
         " should be loaded.",
     )
+    imported_paths: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description="The mapping between the imported paths and the actual full path to which they were resolved.",
+    )
 
     # Some tasks need to be as deterministic as possible. The lowest possible temperature
     # will be used for those tasks. Models like dolly don't allow for a temperature of 0.0,

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -32,6 +32,20 @@ with open(os.path.join(os.path.dirname(__file__), "default_config.yml")) as _fc:
     _default_config = yaml.safe_load(_fc)
 
 
+# Extract the COLANGPATH directories.
+colang_path_dirs = [
+    _path.strip()
+    for _path in os.environ.get("COLANGPATH", "").split(os.path.sep)
+    if _path.strip() != ""
+]
+
+# We also make sure that the standard library is in the COLANGPATH.
+standard_library_path = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "colang", "v2_x", "library")
+)
+colang_path_dirs.append(standard_library_path)
+
+
 class Model(BaseModel):
     """Configuration of a model used by the rails engine.
 
@@ -466,34 +480,39 @@ def _load_path(
     if not os.path.exists(config_path):
         raise ValueError(f"Could not find config path: {config_path}")
 
-    for root, _, files in os.walk(config_path, followlinks=True):
-        # Followlinks to traverse symlinks instead of ignoring them.
+    if os.path.isdir(config_path):
+        for root, _, files in os.walk(config_path, followlinks=True):
+            # Followlinks to traverse symlinks instead of ignoring them.
 
-        for file in files:
-            # This is the raw configuration that will be loaded from the file.
-            _raw_config = {}
+            for file in files:
+                # This is the raw configuration that will be loaded from the file.
+                _raw_config = {}
 
-            # Extract the full path for the file and compute relative path
-            full_path = os.path.join(root, file)
-            rel_path = os.path.relpath(full_path, config_path)
+                # Extract the full path for the file and compute relative path
+                full_path = os.path.join(root, file)
+                rel_path = os.path.relpath(full_path, config_path)
 
-            # If it's a file in the `kb` folder we need to append it to the docs
-            if rel_path.startswith("kb"):
-                _raw_config = {"docs": []}
-                if rel_path.endswith(".md"):
-                    with open(full_path, encoding="utf-8") as f:
-                        _raw_config["docs"].append(
-                            {"format": "md", "content": f.read()}
-                        )
+                # If it's a file in the `kb` folder we need to append it to the docs
+                if rel_path.startswith("kb"):
+                    _raw_config = {"docs": []}
+                    if rel_path.endswith(".md"):
+                        with open(full_path, encoding="utf-8") as f:
+                            _raw_config["docs"].append(
+                                {"format": "md", "content": f.read()}
+                            )
 
-            elif file.endswith(".yml") or file.endswith(".yaml"):
-                with open(full_path, "r", encoding="utf-8") as f:
-                    _raw_config = yaml.safe_load(f.read())
+                elif file.endswith(".yml") or file.endswith(".yaml"):
+                    with open(full_path, "r", encoding="utf-8") as f:
+                        _raw_config = yaml.safe_load(f.read())
 
-            elif file.endswith(".co"):
-                colang_files.append((file, full_path))
+                elif file.endswith(".co"):
+                    colang_files.append((file, full_path))
 
-            _join_config(raw_config, _raw_config)
+                _join_config(raw_config, _raw_config)
+
+    # If it's just a .co file, we append it as is to the config.
+    elif config_path.endswith(".co"):
+        colang_files.append((config_path, config_path))
 
     return raw_config, colang_files
 
@@ -506,22 +525,84 @@ def _load_imported_paths(raw_config: dict, colang_files: List[Tuple[str, str]]):
         colang_files: The current set of colang files which will be extended as new
             configurations are loaded.
     """
-    imported_paths = []
-    while len(imported_paths) != len(raw_config["import_paths"]):
+    # We also keep a temporary array of all the paths that have been imported
+    if "imported_paths" not in raw_config:
+        raw_config["imported_paths"] = {}
+
+    while len(raw_config["imported_paths"]) != len(raw_config["import_paths"]):
         for import_path in raw_config["import_paths"]:
-            if import_path in imported_paths:
+            if import_path in raw_config["imported_paths"]:
                 continue
 
             log.info(f"Loading imported path: {import_path}")
 
-            _raw_config, _colang_files = _load_path(import_path)
+            # If the path does not exist, we try to resolve it using COLANGPATH
+            actual_path = None
+            if not os.path.exists(import_path):
+                for root in colang_path_dirs:
+                    if os.path.exists(os.path.join(root, import_path)):
+                        actual_path = os.path.join(root, import_path)
+                        break
+
+                    # We also check if we can load it as a file.
+                    if not import_path.endswith(".co") and os.path.exists(
+                        os.path.join(root, import_path + ".co")
+                    ):
+                        actual_path = os.path.join(root, import_path + ".co")
+                        break
+            else:
+                actual_path = import_path
+
+            if actual_path is None:
+                raise ValueError(f"Import path `{import_path}` could not be resolved.")
+
+            _raw_config, _colang_files = _load_path(actual_path)
 
             # Join them.
             _join_config(raw_config, _raw_config)
             colang_files.extend(_colang_files)
 
             # And mark the path as imported.
-            imported_paths.append(import_path)
+            raw_config["imported_paths"][import_path] = actual_path
+
+
+def _parse_colang_files_recursively(
+    raw_config: dict,
+    colang_files: List[Tuple[str, str]],
+    parsed_colang_files: List[dict],
+):
+    """Helper function to parse all the Colang files.
+
+    If there are imports, they will be imported recursively
+    """
+    colang_version = raw_config.get("colang_version", "1.0")
+
+    # We start parsing the colang files one by one, and if we have
+    # new import paths, we continue to update
+    while len(parsed_colang_files) != len(colang_files):
+        current_file, current_path = colang_files[len(parsed_colang_files)]
+
+        with open(current_path, "r", encoding="utf-8") as f:
+            _parsed_config = parse_colang_file(
+                current_file, content=f.read(), version=colang_version
+            )
+
+            # We join only the "import_paths" field in the config for now
+            _join_config(
+                raw_config,
+                {"import_paths": _parsed_config.get("import_paths", [])},
+            )
+
+            parsed_colang_files.append(_parsed_config)
+
+        # If there are any new imports, we load them
+        if raw_config.get("import_paths"):
+            _load_imported_paths(raw_config, colang_files)
+
+    # To allow overriding of elements from imported paths, we need to merge the
+    # parsed data in reverse order.
+    for file_parsed_data in reversed(parsed_colang_files):
+        _join_config(raw_config, file_parsed_data)
 
 
 class RailsConfig(BaseModel):
@@ -709,16 +790,9 @@ class RailsConfig(BaseModel):
                 _load_imported_paths(raw_config, colang_files)
 
             # Parse the colang files after we know the colang version
-            colang_version = raw_config.get("colang_version", "1.0")
-
-            # To allow overriding of elements from imported paths, we need to process
-            # these in reverse order.
-            for file, full_path in reversed(colang_files):
-                with open(full_path, "r", encoding="utf-8") as f:
-                    _raw_config = parse_colang_file(
-                        file, content=f.read(), version=colang_version
-                    )
-                    _join_config(raw_config, _raw_config)
+            _parse_colang_files_recursively(
+                raw_config, colang_files, parsed_colang_files=[]
+            )
 
         else:
             raise ValueError(f"Invalid config path {config_path}.")
@@ -746,33 +820,38 @@ class RailsConfig(BaseModel):
         if yaml_content:
             _join_config(raw_config, yaml.safe_load(yaml_content))
 
-        # If we have import paths, we also need to load them.
-        colang_files = []
-        if raw_config.get("import_paths"):
-            _load_imported_paths(raw_config, colang_files)
-
         # Parse the colang files after we know the colang version
         colang_version = raw_config.get("colang_version", "1.0")
 
-        # To allow overriding of elements from imported paths, we need to process
-        # these in reverse order.
-        for file, full_path in reversed(colang_files):
-            with open(full_path, "r", encoding="utf-8") as f:
-                _raw_config = parse_colang_file(
-                    file, content=f.read(), version=colang_version
-                )
-                _join_config(raw_config, _raw_config)
+        # We start parsing the colang files one by one, and if we have
+        # new import paths, we continue to update
+        colang_files = []
+        parsed_colang_files = []
 
-        # Finally, parse the content colang.
+        # First, we parse the starting content.
         if colang_content:
+            colang_files.append(("main.co", "main.co"))
+
+            _parsed_config = parse_colang_file(
+                "main.co",
+                content=colang_content,
+                version=colang_version,
+            )
+
+            # We join only the "import_paths" field in the config for now
             _join_config(
                 raw_config,
-                parse_colang_file(
-                    "main.co",
-                    content=colang_content,
-                    version=colang_version,
-                ),
+                {"import_paths": _parsed_config.get("import_paths", [])},
             )
+
+            parsed_colang_files.append(_parsed_config)
+
+        # Load any new colang files potentially coming from imports
+        if raw_config.get("import_paths"):
+            _load_imported_paths(raw_config, colang_files)
+
+        # Next, we parse any additional files recursively
+        _parse_colang_files_recursively(raw_config, colang_files, parsed_colang_files)
 
         # If there are no instructions, we use the default ones.
         if len(raw_config.get("instructions", [])) == 0:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -35,7 +35,7 @@ with open(os.path.join(os.path.dirname(__file__), "default_config.yml")) as _fc:
 # Extract the COLANGPATH directories.
 colang_path_dirs = [
     _path.strip()
-    for _path in os.environ.get("COLANGPATH", "").split(os.path.sep)
+    for _path in os.environ.get("COLANGPATH", "").split(os.pathsep)
     if _path.strip() != ""
 ]
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -165,7 +165,9 @@ class LLMRails:
 
         # We check if the configuration or any of the imported ones have config.py modules.
         config_modules = []
-        for _path in self.config.import_paths + [self.config.config_path]:
+        for _path in list(self.config.imported_paths.values()) + [
+            self.config.config_path
+        ]:
             if _path:
                 filepath = os.path.join(_path, "config.py")
                 if os.path.exists(filepath):

--- a/tests/colang/parser/v2_x/inputs/test11.co
+++ b/tests/colang/parser/v2_x/inputs/test11.co
@@ -1,0 +1,11 @@
+flow bot is happy if the user is happy while nothing happens in not
+  match $bla.Finished()
+  bot say (str(len($a)))
+  return
+
+flow main
+  while $ref is None
+    match UtteranceUserAction().Finished(final_transcript="End") as $ref
+    start UtteranceBotAction(script="Test")
+
+  start UtteranceBotAction(script="Done")

--- a/tests/colang/parser/v2_x/inputs/test12.co
+++ b/tests/colang/parser/v2_x/inputs/test12.co
@@ -1,0 +1,3 @@
+flow main
+  if len($a) > 10
+    bot say "hi"

--- a/tests/colang/parser/v2_x/inputs/test13.co
+++ b/tests/colang/parser/v2_x/inputs/test13.co
@@ -1,0 +1,12 @@
+@override
+@loop("dfdf")
+flow some flow
+  return
+
+@loop(id="dfdf")
+flow some flow
+  return
+
+@loop_bla(id="dfdf", name="bla", number=2)
+flow some flow
+  return

--- a/tests/colang/parser/v2_x/inputs/test13.co
+++ b/tests/colang/parser/v2_x/inputs/test13.co
@@ -1,3 +1,7 @@
+import umim
+import guardrails.input
+import "some/path/to/package"
+
 @override
 @loop("dfdf")
 flow some flow

--- a/tests/colang/parser/v2_x/test_ast.py
+++ b/tests/colang/parser/v2_x/test_ast.py
@@ -49,6 +49,7 @@ def test_basic():
     assert d == {
         "_source": None,
         "_type": "flow",
+        "decorators": [],
         "elements": [
             {
                 "_source": None,

--- a/tests/colang/parser/v2_x/test_basic.py
+++ b/tests/colang/parser/v2_x/test_basic.py
@@ -44,6 +44,7 @@ def test_1():
         {
             "_source": None,
             "_type": "flow",
+            "decorators": [],
             "elements": [
                 {
                     "_source": None,
@@ -122,6 +123,7 @@ def test_2():
         {
             "_source": None,
             "_type": "flow",
+            "decorators": [],
             "elements": [
                 {
                     "_source": None,
@@ -223,6 +225,7 @@ def test_3():
         {
             "_source": None,
             "_type": "flow",
+            "decorators": [],
             "elements": [
                 {
                     "_source": None,
@@ -348,6 +351,7 @@ def test_4():
     assert flows == [
         {
             "_type": "flow",
+            "decorators": [],
             "_source": None,
             "name": "test",
             "parameters": [],
@@ -888,6 +892,7 @@ def test_flow_return_values():
     assert flow == [
         {
             "_type": "flow",
+            "decorators": [],
             "_source": None,
             "name": "a",
             "parameters": [{"name": "param", "default_value_expr": None}],
@@ -917,6 +922,7 @@ def test_flow_return_values():
         },
         {
             "_type": "flow",
+            "decorators": [],
             "_source": None,
             "name": "b",
             "parameters": [],
@@ -946,6 +952,7 @@ def test_flow_return_values():
         },
         {
             "_type": "flow",
+            "decorators": [],
             "_source": None,
             "name": "c",
             "parameters": [],
@@ -978,6 +985,7 @@ def test_flow_return_values():
         },
         {
             "_type": "flow",
+            "decorators": [],
             "_source": None,
             "name": "c",
             "parameters": [],

--- a/tests/colang/parser/v2_x/test_syntax_parsing.py
+++ b/tests/colang/parser/v2_x/test_syntax_parsing.py
@@ -35,6 +35,8 @@ tests_root = os.path.join(os.path.dirname(__file__), "../../..")
         "colang/parser/v2_x/inputs/test8.co",
         "colang/parser/v2_x/inputs/test9.co",
         "colang/parser/v2_x/inputs/test10.co",
+        "colang/parser/v2_x/inputs/test11.co",
+        "colang/parser/v2_x/inputs/test12.co",
         "test_configs/example_flows_v_2_x/faq_questions.co",
         "test_configs/example_flows_v_2_x/core_flows.co",
         "test_configs/example_flows_v_2_x/confirmation_question.co",

--- a/tests/colang/parser/v2_x/test_syntax_parsing.py
+++ b/tests/colang/parser/v2_x/test_syntax_parsing.py
@@ -37,6 +37,7 @@ tests_root = os.path.join(os.path.dirname(__file__), "../../..")
         "colang/parser/v2_x/inputs/test10.co",
         "colang/parser/v2_x/inputs/test11.co",
         "colang/parser/v2_x/inputs/test12.co",
+        "colang/parser/v2_x/inputs/test13.co",
         "test_configs/example_flows_v_2_x/faq_questions.co",
         "test_configs/example_flows_v_2_x/core_flows.co",
         "test_configs/example_flows_v_2_x/confirmation_question.co",

--- a/tests/test_configs/with_custom_action_v2_x/config.co
+++ b/tests/test_configs/with_custom_action_v2_x/config.co
@@ -2,5 +2,5 @@ flow main
   global $value
   $value = 3
   match UtteranceUserAction.Finished(final_transcript="start")
-  $sum = CustomTestAction(param=5)
+  $sum = await CustomTestAction(param=5)
   start UtteranceBotAction(script="{{$sum}}")

--- a/tests/test_configs/with_imports_1/config.yml
+++ b/tests/test_configs/with_imports_1/config.yml
@@ -1,0 +1,2 @@
+models: []
+colang_version: "2.x"

--- a/tests/test_configs/with_imports_1/main.co
+++ b/tests/test_configs/with_imports_1/main.co
@@ -1,0 +1,5 @@
+import core
+
+flow main
+  user said "hi"
+  bot say "Hello there!"

--- a/tests/v2_x/test_decorator_parsing.py
+++ b/tests/v2_x/test_decorator_parsing.py
@@ -29,6 +29,7 @@ def test_1():
         flow some flow
           return
 
+        @meta(llm_exclude=True)
         @loop(id="bla")
         flow some other flow
           return
@@ -50,3 +51,4 @@ def test_1():
 
     assert flows["some flow"].loop_id == "bla"
     assert flows["some other flow"].loop_id == "bla"
+    assert flows["some other flow"].decorators["meta"].parameters["llm_exclude"]

--- a/tests/v2_x/test_decorator_parsing.py
+++ b/tests/v2_x/test_decorator_parsing.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), "../test_configs")
+
+
+def test_1():
+    config = RailsConfig.from_content(
+        colang_content="""
+
+        @loop("bla")
+        flow some flow
+          return
+
+        @loop(id="bla")
+        flow some other flow
+          return
+          user said "hi"
+
+        flow main
+          return
+
+    """,
+        config={"colang_version": "2.x"},
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    flows = chat.app.runtime.flow_configs
+
+    assert flows["some flow"].loop_id == "bla"
+    assert flows["some other flow"].loop_id == "bla"

--- a/tests/v2_x/test_expr_statement.py
+++ b/tests/v2_x/test_expr_statement.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+
+def test_1():
+    config = RailsConfig.from_content(
+        colang_content="""
+        flow user said $text
+          match UtteranceUserActionFinished(final_transcript=$text)
+
+        flow bot say $text
+          await UtteranceBotAction(script=$text)
+
+        flow user express greeting
+          user said "hi"
+
+        flow bot express greeting
+          bot say "Hello world!"
+
+        flow main
+          $a = [1,2,3]
+          ($a.append(4))
+          user express greeting
+
+          bot say $text = str(len($a))
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    chat >> "hi"
+    chat << "4"

--- a/tests/v2_x/test_flow_params.py
+++ b/tests/v2_x/test_flow_params.py
@@ -118,3 +118,39 @@ def test_2_2(config_2):
 
     chat >> "I need help"
     chat << "I'm not sure what to do next."
+
+
+def test_3():
+    config = RailsConfig.from_content(
+        colang_content="""
+        flow user said $text
+          match UtteranceUserActionFinished(final_transcript=$text)
+
+        flow bot say $text
+          await UtteranceBotAction(script=$text)
+
+        flow user express greeting
+          user said "hi"
+
+        flow bot express greeting
+          bot say "Hello world!"
+
+        flow main
+          $a = [1,2,3]
+          user express greeting
+
+          bot say $text = str(len($a))
+          bot say (str(len($a)))
+        """,
+        yaml_content="""
+        colang_version: "2.x"
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    chat >> "hi"
+    chat << "3\n3"

--- a/tests/v2_x/test_imports.py
+++ b/tests/v2_x/test_imports.py
@@ -16,6 +16,7 @@
 import os
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.rails.llm.config import colang_path_dirs
 from tests.utils import TestChat
 
 CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), "../test_configs")
@@ -52,3 +53,28 @@ def test_2():
 
     chat >> "hi"
     chat << "Hello there, it's working!"
+
+
+def test_3():
+    # This config just imports another one, to check that actions are correctly
+    # loaded.
+    colang_path_dirs.append(
+        os.path.join(os.path.dirname(__file__), "..", "test_configs")
+    )
+
+    config = RailsConfig.from_content(
+        colang_content="""
+            import with_custom_action_v2_x
+        """,
+        config={"colang_version": "2.x"},
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    chat >> "start"
+    chat << "8"
+
+    colang_path_dirs.pop()

--- a/tests/v2_x/test_imports.py
+++ b/tests/v2_x/test_imports.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), "../test_configs")
+
+
+def test_1():
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "with_imports_1"))
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    chat >> "hi"
+    chat << "Hello there!"
+
+
+def test_2():
+    config = RailsConfig.from_content(
+        colang_content="""
+        import core
+
+        flow main
+          user said "hi"
+          bot say "Hello there, it's working!"
+    """,
+        config={"colang_version": "2.x"},
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[],
+    )
+
+    chat >> "hi"
+    chat << "Hello there, it's working!"

--- a/tests/v2_x/test_run_actions.py
+++ b/tests/v2_x/test_run_actions.py
@@ -103,7 +103,7 @@ def test_3():
 
         flow main
           match UtteranceUserActionFinished(final_transcript="hi")
-          $information = FetchDictionaryAction()
+          $information = await FetchDictionaryAction()
           $response_to_user = '''Summarize the result from the AddItemAction call to the user: {{$information}}'''
           bot say $response_to_user
         """,


### PR DESCRIPTION
- allow operators and keywords to be part of flow names
- allow any function to be used in expressions
- add support for decorators
- add support for `import` statement
- add support for expression statements, e.g., `($a.append('b'))`