### PR TITLE
Check that output exists when attempting to parse it

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -610,7 +610,7 @@ class LLMGenerationActions:
                 # If we have a parsing error, we try to reduce size of the flow, potentially
                 # up to a single step.
                 lines = result.split("\n")
-                while True:
+                while lines:
                     try:
                         parse_colang_file("dynamic.co", content="\n".join(lines))
                         break


### PR DESCRIPTION
- We don't need to attempt to parse the output if it doesn't exist
- Additionally, changing the loop conditional in this way suggests to the reader that `lines` is being shortened in each iteration
- Finally, it might make the code safer to avoid using another `while True` loop