### PR TITLE
use the consistent delimiter for existing checking and splitting

### DIFF
--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -133,8 +133,10 @@ class VerboseHandler(logging.StreamHandler):
     def emit(self, record) -> None:
         msg = self.format(record)
 
-        # We check if we're using the spacial syntax with "::" which denotes a title.
-        if "::" in msg:
+        # We check if we're using the spacial syntax with " :: " which denotes a title.
+        # Note that there are leading and trailing spaces around "::", it should work well
+        # for splunk queries as well.
+        if " :: " in msg:
             title, body = msg.split(" :: ", 1)
             title = title.strip()
 


### PR DESCRIPTION
This PR is to fix a corner case. Although the triggering of bug could be rare, the bug in the code needs to be fixed. 

- in `if "::" in msg:`  (line 137),  it checks if the delimiter "::" is in message or not. 
- however, another delimiter " :: " is used to do the splitting 

The inconsistency between two delimiters can lead to an error. When "::" is in the message, _e.g._ the message contains a splunk query, nevertheless, the splitting and unpacking `title, body = msg.split(" :: ", 1)` will throw an exception. 

