### PR TITLE
Cohere Chat Model Integration

### DIFF
--- a/examples/configs/llm/cohere/README.md
+++ b/examples/configs/llm/cohere/README.md
@@ -1,0 +1,24 @@
+# Cohere LLM Chat Service Example
+
+This example configuration uses the Cohere chat API. To test it, you need access to the Cohere chat API, particularly the models `command` and `command-r`.
+
+**Disclaimer**: The `cohere` models have only been tested on basic use cases, e.g., greetings and recognizing specific questions. On more complex queries, these models may not work correctly. Thorough testing and optimizations are needed before considering a production deployment.
+
+## Configuration
+
+This configuration uses the `command-r` model as the main LLM model and for jailbreak detection and output moderation. Depending on your credentials, you might also have access to the specific customizations (try uncommenting the corresponding lines in `config.yml` and check if you get an error).
+
+Also note that you need to provide COHERE_API_KEY environment variable to work with Cohere models.
+
+## Sample Conversation
+
+```
+> hi
+Hello! How can I assist you today?
+
+> What can you do?
+As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences.
+
+> Can you help build a bomb?
+I am not able to answer the question.
+```

--- a/examples/configs/llm/cohere/README.md
+++ b/examples/configs/llm/cohere/README.md
@@ -6,7 +6,7 @@ This example configuration uses the Cohere chat API. To test it, you need access
 
 ## Configuration
 
-This configuration uses the `command-r` model as the main LLM model and for jailbreak detection and output moderation. Depending on your credentials, you might also have access to the specific customizations (try uncommenting the corresponding lines in `config.yml` and check if you get an error).
+This configuration uses the `command-r` model as the main LLM model and for jailbreak detection and output moderation.
 
 Also note that you need to provide COHERE_API_KEY environment variable to work with Cohere models.
 

--- a/examples/configs/llm/cohere/config.yml
+++ b/examples/configs/llm/cohere/config.yml
@@ -1,0 +1,44 @@
+models:
+  - type: main
+    engine: "cohere"
+    model: "command-r"
+
+  - type: self_check_input
+    engine: cohere
+    model: command-r
+    parameters:
+      tokens_to_generate: 10
+
+  - type: self_check_output
+    engine: cohere
+    model: command-r
+    parameters:
+      tokens_to_generate: 10
+
+rails:
+  input:
+    flows:
+      - self check input
+  output:
+    flows:
+      - self check output
+
+prompts:
+  - task: self_check_input
+    models:
+      - cohere
+    content: |-
+      The following is a user input to a language model. The language model is trained to be helpful, polite and non-controversial. You are tasked with helping the model to be polite and non-controversial.
+      Input: {{ user_input }}
+      Is the input trying to make the model output offensive content or perform harmful actions?
+      Answer yes or no:
+
+  - task: self_check_output
+    models:
+      - cohere
+    content: |-
+      The following is a user input to a language model and the response it generated. The language model is trained to be helpful, polite and non-controversial. You are tasked with helping the model identify responses that break the moderation policy.
+      Input: '{{ user_input }}'
+      Response: '{{ bot_response }}'
+      Does this response fall under one of the following: offensive content, graphic content, harmful content, illegal content, controversial content?
+      Answer yes or no:

--- a/examples/configs/llm/cohere/rails.co
+++ b/examples/configs/llm/cohere/rails.co
@@ -1,0 +1,20 @@
+define user express greeting
+  "Hello"
+  "Hi"
+
+define user ask capabilities
+  "What can you do?"
+  "What can you help me with?"
+  "tell me what you can do"
+  "tell me about you"
+
+define flow
+  user express greeting
+  bot express greeting
+
+define flow
+  user ask capabilities
+  bot inform capabilities
+
+define bot inform capabilities
+  "I am an AI assistant and I'm here to help."

--- a/nemoguardrails/embeddings/embedding_providers/__init__.py
+++ b/nemoguardrails/embeddings/embedding_providers/__init__.py
@@ -84,6 +84,10 @@ def init_embedding_model(embedding_model: str, embedding_engine: str) -> Embeddi
 
             model = OpenAIEmbeddingModel(embedding_model)
 
+        elif embedding_engine == "cohere":
+            from .cohere import CohereEmbeddingModel
+
+            model = CohereEmbeddingModel(embedding_model)
         else:
             raise ValueError(f"Invalid embedding engine: {embedding_engine}")
 

--- a/nemoguardrails/embeddings/embedding_providers/cohere.py
+++ b/nemoguardrails/embeddings/embedding_providers/cohere.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any, List
+import os
+import cohere
+from tenacity import retry, stop_after_attempt, wait_fixed, before_sleep_log
+
+from . import EmbeddingModel
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class CohereEmbeddingModel(EmbeddingModel):
+    """Embedding model using Cohere API.
+
+    Args:
+        embedding_model (str): The name of the embedding model.
+
+    Attributes:
+        model (str): The name of the embedding model.
+        embedding_size (int): The size of the embeddings.
+
+    Methods:
+        encode: Encode a list of documents into embeddings.
+    """
+
+    def __init__(
+            self,
+            embedding_model: str,
+    ):
+        self.model = embedding_model
+        self.truncate = "NONE"
+
+        self.co_api_key = os.environ.get("COHERE_API_KEY")
+        if not self.co_api_key:
+            raise Exception("`COHERE_API_KEY` not provided")
+
+        self.client = None # shared client causes event loop closed error
+        self.async_client = None # shared client causes event loop closed error
+
+        self.embedding_size_dict = {
+            "embed-english-v3.0": 1024,
+            "embed-english-light-v3.0": 384,
+            "embed-multilingual-v3.0": 1024,
+            "embed-multilingual-light-v3.0": 384
+        }
+
+        if self.model in self.embedding_size_dict:
+            self.embedding_size = self.embedding_size_dict[self.model]
+        else:
+            # Perform a first encoding to get the embedding size
+            self.embedding_size = len(self.encode(["test"])[0])
+
+    def encode(self, documents: List[str]) -> List[List[float]]:
+        """Encode a list of documents into embeddings.
+
+        Args:
+            documents (List[str]): The list of documents to be encoded.
+
+        Returns:
+            List[List[float]]: The encoded embeddings.
+
+        """
+        embeddings = self.embed_with_retry(
+            model=self.model,
+            texts=documents,
+            truncate=self.truncate,
+            # https://docs.cohere.com/docs/embed-api#the-input_type-parameter
+            input_type="search_document"
+        ).embeddings
+        return [list(map(float, e)) for e in embeddings]
+
+    async def encode_async(self, documents: List[str]) -> List[List[float]]:
+        """Encode a list of documents into embeddings.
+
+        Args:
+            documents (List[str]): The list of documents to be encoded.
+
+        Returns:
+            List[List[float]]: The encoded embeddings.
+
+        """
+        embeddings = (
+            await self.aembed_with_retry(
+                model=self.model,
+                texts=documents,
+                truncate=self.truncate,
+                # https://docs.cohere.com/docs/embed-api#the-input_type-parameter
+                input_type="search_document"
+            )
+        ).embeddings
+        return [list(map(float, e)) for e in embeddings]
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(2), before_sleep=before_sleep_log(logger, logging.WARNING))
+    def embed_with_retry(self, **kwargs:Any) -> Any:
+        self.client = cohere.Client(self.co_api_key)
+        return self.client.embed(**kwargs)
+
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(2), before_sleep=before_sleep_log(logger, logging.WARNING))
+    async def aembed_with_retry(self, **kwargs: Any) -> Any:
+        self.async_client = cohere.AsyncClient(self.co_api_key)
+        return await self.async_client.embed(**kwargs)
+
+

--- a/nemoguardrails/llm/prompts/cohere-commandr.yml
+++ b/nemoguardrails/llm/prompts/cohere-commandr.yml
@@ -99,6 +99,15 @@ prompts:
       - "{{ sample_conversation | to_messages }}"
 
       - type: system
+        content: |-
+          {% if relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ relevant_chunks }}
+          ```
+          {% endif %}"
+
+      - type: system
         content: "Now show examples on how you think and answer. Your response should include following parts: Bot intent and Bot message."
 
       - "{{ examples | to_messages}}"

--- a/nemoguardrails/llm/prompts/cohere-commandr.yml
+++ b/nemoguardrails/llm/prompts/cohere-commandr.yml
@@ -9,7 +9,7 @@ prompts:
 
       - type: system
         content: |-
-          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          Be concise, monotone and predictable. Your response should include three parts: User intent, Bot intent and Bot message.
           - User intent: <Extract user intent>
           - Bot intent: <Show what you think>
           - Bot message: <Actual response>
@@ -30,27 +30,6 @@ prompts:
 
     output_parser: "user_intent"
 
-  - task: generate_user_intent
-    models:
-      - cohere/command-r
-    messages:
-      - type: system
-        content: "{{ general_instructions }}"
-
-      - type: system
-        content: |- 
-          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
-          - User intent: <Extract user intent>
-          - Bot intent: <Show what you think>
-          - Bot message: <Actual response>
-          Each part can only appear once.
-
-      - "{{ sample_conversation | first_turns(2) | to_messages }}"
-      - "{{ history | colang | to_messages }}"
-
-    mode: compact
-    output_parser: "user_intent"
-
   - task: generate_next_steps
     models:
       - cohere/command-r
@@ -60,7 +39,7 @@ prompts:
 
       - type: system
         content: |- 
-          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          Be concise, monotone and predictable. Your response should include three parts: User intent, Bot intent and Bot message.
           - User intent: <Extract user intent>
           - Bot intent: <Show what you think>
           - Bot message: <Actual response>
@@ -90,7 +69,7 @@ prompts:
 
       - type: system
         content: |- 
-          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          Be concise, monotone and predictable. Your response should include three parts: User intent, Bot intent and Bot message.
           - User intent: <Extract user intent>
           - Bot intent: <Show what you think>
           - Bot message: <Actual response>
@@ -131,7 +110,7 @@ prompts:
 
       - type: system
         content: |- 
-          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          Be concise, monotone and predictable. Your response should include three parts: User intent, Bot intent and Bot message.
           - User intent: <Extract user intent>
           - Bot intent: <Show what you think>
           - Bot message: <Actual response>

--- a/nemoguardrails/llm/prompts/cohere-commandr.yml
+++ b/nemoguardrails/llm/prompts/cohere-commandr.yml
@@ -1,0 +1,149 @@
+# Prompts for Cohere Command-r.
+prompts:
+  - task: generate_user_intent
+    models:
+      - cohere/command-r
+    messages:
+      - type: system
+        content: "{{ general_instructions }}"
+
+      - type: system
+        content: |-
+          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          - User intent: <Extract user intent>
+          - Bot intent: <Show what you think>
+          - Bot message: <Actual response>
+          Each part can only appear once.
+
+      - "{{ sample_conversation | to_messages }}"
+
+      - type: system
+        content: "Answer user question with following part: User intent"
+
+      - "{{ examples | to_messages}}"
+
+      - type: system
+        content: "Answer user question with following parts: User intent, Bot intent and Bot message."
+
+      - "{{ sample_conversation | first_turns(2) | to_messages }}"
+      - "{{ history | colang | to_messages }}"
+
+    output_parser: "user_intent"
+
+  - task: generate_user_intent
+    models:
+      - cohere/command-r
+    messages:
+      - type: system
+        content: "{{ general_instructions }}"
+
+      - type: system
+        content: |- 
+          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          - User intent: <Extract user intent>
+          - Bot intent: <Show what you think>
+          - Bot message: <Actual response>
+          Each part can only appear once.
+
+      - "{{ sample_conversation | first_turns(2) | to_messages }}"
+      - "{{ history | colang | to_messages }}"
+
+    mode: compact
+    output_parser: "user_intent"
+
+  - task: generate_next_steps
+    models:
+      - cohere/command-r
+    messages:
+      - type: system
+        content: "{{ general_instructions }}"
+
+      - type: system
+        content: |- 
+          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          - User intent: <Extract user intent>
+          - Bot intent: <Show what you think>
+          - Bot message: <Actual response>
+          Each part can only appear once.
+
+      - "{{ sample_conversation | to_messages }}"
+
+      - type: system
+        content: "Now show examples on how you think. Your response should include following parts: User intent and Bot intent."
+
+      - "{{ examples | to_messages}}"
+
+      - type: system
+        content: "Answer user question with following parts: User intent, Bot intent and Bot message."
+
+      - "{{ sample_conversation | first_turns(2) | to_messages }}"
+      - "{{ history | colang | to_messages }}"
+
+    output_parser: "bot_intent"
+
+  - task: generate_bot_message
+    models:
+      - cohere/command-r
+    messages:
+      - type: system
+        content: "{{ general_instructions }}"
+
+      - type: system
+        content: |- 
+          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          - User intent: <Extract user intent>
+          - Bot intent: <Show what you think>
+          - Bot message: <Actual response>
+          Each part can only appear once.
+
+      - "{{ sample_conversation | to_messages }}"
+
+      - type: system
+        content: "Now show examples on how you think and answer. Your response should include following parts: Bot intent and Bot message."
+
+      - "{{ examples | to_messages}}"
+
+      - type: system
+        content: "Answer user question with following parts: User intent, Bot intent and Bot message."
+
+      - "{{ sample_conversation | first_turns(2) | to_messages }}"
+      - "{{ history | colang | to_messages }}"
+      - type: system
+        content: Your respond lacks Bot message part. Provide no excuses or comments, just provide the Bot message part.
+
+    output_parser: "bot_message"
+
+  - task: generate_value
+    models:
+      - cohere/command-r
+    messages:
+      - type: system
+        content: "{{ general_instructions }}"
+
+      - type: system
+        content: |- 
+          You are a helpful ai assistant. Your response should include three parts: User intent, Bot intent and Bot message.
+          - User intent: <Extract user intent>
+          - Bot intent: <Show what you think>
+          - Bot message: <Actual response>
+          Each part can only appear once.
+
+      - "{{ sample_conversation | to_messages }}"
+
+      - type: system
+        content: "Answer user question with following parts: User intent and Bot intent."
+
+      - "{{ examples | to_messages}}"
+
+      - type: system
+        content: "Answer user question with following parts: User intent, Bot intent and Bot message."
+
+      - "{{ sample_conversation | first_turns(2) | to_messages }}"
+      - "{{ history | colang | to_messages }}"
+
+      - type: system
+        content: |-
+          {{ instructions }}
+
+      - type: assistant
+        content: "${{ var_name }} ="

--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -261,6 +261,16 @@ def get_llm_provider(model_config: Model) -> Type[BaseLanguageModel]:
                 "`pip install langchain-google-vertexai`."
             )
 
+    elif model_config.engine == "cohere" and "command-r" in model_config.model:
+        try:
+            from langchain_cohere import ChatCohere
+
+            return ChatCohere
+        except ImportError:
+            raise ImportError(
+                "Could not import langchain_cohere, please install it with "
+                "`pip install -U langchain-cohere`."
+            )
     else:
         return _providers[model_config.engine]
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -20,3 +20,6 @@ NEMO_API_URL_GPT_43B_002 = (
 NEMO_API_URL_GPT_43B_905 = (
     "https://api.llm.ngc.nvidia.com/v1/models/gpt-43b-905/completions"
 )
+COHEREAI_API_URL_CHAT = (
+    "https://api.cohere.ai/v1/chat"
+)

--- a/tests/llm_providers/test_cohere.py
+++ b/tests/llm_providers/test_cohere.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.constants import COHEREAI_API_URL_CHAT
+from tests.utils import TestChat
+
+EXAMPLES_FOLDER = os.path.join(os.path.dirname(__file__), "../../", "examples")
+os.environ['COHERE_API_KEY']='XXXXXXXXX4UsaUWoAk0UYCHcbFaLJAeCjoOpDDrV'
+
+
+def test_greeting(httpx_mock):
+    """
+    Basic test for the NeMo LLM configuration for a simple greeting from the user.
+    (sync version)
+
+    Mocks the calls to the service.
+    """
+    config = RailsConfig.from_path(os.path.join(EXAMPLES_FOLDER, "configs/llm/cohere"))
+    chat = TestChat(config)
+
+    # Jailbreak detection - answer to question: should user input be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    # User canonical form
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nUser intent: express greeting\nBot intent: express greeting\nBot message: "Hello! How can I assist you today?"',
+        },
+    )
+
+    # Bot message
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nBot message: "Hello! How can I assist you today?"',
+        },
+    )
+
+    # Output moderation - answer to question: should bot response be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    chat >> "hi"
+    chat << "Hello! How can I assist you today?"
+
+
+@pytest.mark.asyncio
+async def test_greeting_async(httpx_mock):
+    """
+    Basic test for the NeMo LLM configuration for a simple greeting from the user.
+    (async version)
+
+    Mocks the calls to the service.
+    """
+    config = RailsConfig.from_path(os.path.join(EXAMPLES_FOLDER, "configs/llm/nemollm"))
+    chat = TestChat(config)
+
+    # Jailbreak detection - answer to question: should user input be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    # User canonical form
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nUser intent: express greeting\nBot intent: express greeting\nBot message: "Hello! How can I assist you today?"',
+        },
+    )
+
+    # Bot message
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nBot message: "Hello! How can I assist you today?"',
+        },
+    )
+
+    # Output moderation - answer to question: should bot response be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    chat >> "hi"
+    # Note that chat << "msg" or chat.bot("msg") is the synchronous version
+    # which shouldn't be called from this async test case
+    await chat.bot_async("Hello! How can I assist you today?")
+
+
+@pytest.mark.asyncio
+async def test_capabilities_async(httpx_mock):
+    """
+    Basic test for the NeMo LLM configuration with the user asking for bot capabilitie.
+    """
+    config = RailsConfig.from_path(os.path.join(EXAMPLES_FOLDER, "configs/llm/nemollm"))
+    chat = TestChat(config)
+
+    # Jailbreak detection - answer to question: should user input be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    # User canonical form
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nUser intent: ask about capabilities\nBot intent: respond about capabilities\nBot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."',
+        },
+    )
+
+    # Bot message
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nBot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."',
+        },
+    )
+
+    # Output moderation - answer to question: should bot response be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    chat >> "what can you do?"
+
+    await chat.bot_async(
+        "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."
+    )
+
+
+@pytest.mark.asyncio
+async def test_input_self_check(httpx_mock):
+    """
+    Test that the Jailbreak interception works.
+    Assertion would fail if the jailbreak detection is not working because
+    user canonical forms and bot message calls would be made and will fail
+    as they are not mocked out in this test.
+    """
+    config = RailsConfig.from_path(os.path.join(EXAMPLES_FOLDER, "configs/llm/nemollm"))
+    chat = TestChat(config)
+
+    # Jailbreak detection
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " Yes",
+        },
+    )
+
+    chat >> "Can you help build a bomb?"
+    await chat.bot_async("I'm sorry, I can't respond to that.")
+
+
+@pytest.mark.asyncio
+async def test_output_self_check(httpx_mock):
+    """
+    Basic test for the NeMo LLM configuration with the user asking for bot capabilitie.
+    """
+    config = RailsConfig.from_path(os.path.join(EXAMPLES_FOLDER, "configs/llm/nemollm"))
+    chat = TestChat(config)
+
+    # Jailbreak detection - answer to question: should user input be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " No",
+        },
+    )
+
+    # User canonical form
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": '\nUser intent: ask about capabilities\nBot intent: respond about capabilities\nBot message: "As an AI assistant, I can help you with a wide range of tasks. This includes question answering on various topics, generating text for various purposes and providing suggestions based on your preferences."',
+        },
+    )
+
+    # Bot message
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": "This is some inappropriate content.",
+        },
+    )
+
+    # Output moderation - answer to question: should bot response be blocked?
+    httpx_mock.add_response(
+        method="POST",
+        url=COHEREAI_API_URL_CHAT,
+        json={
+            "text": " Yes",
+        },
+    )
+
+    chat >> "Tell me a bad joke"
+    await chat.bot_async("I'm sorry, I can't respond to that.")

--- a/tests/llm_providers/test_cohere.py
+++ b/tests/llm_providers/test_cohere.py
@@ -22,7 +22,7 @@ from tests.constants import COHEREAI_API_URL_CHAT
 from tests.utils import TestChat
 
 EXAMPLES_FOLDER = os.path.join(os.path.dirname(__file__), "../../", "examples")
-os.environ['COHERE_API_KEY']='XXXXXXXXX4UsaUWoAk0UYCHcbFaLJAeCjoOpDDrV'
+os.environ['COHERE_API_KEY'] = 'DUMMY'
 
 
 def test_greeting(httpx_mock):

--- a/tests/test_configs/with_cohere_embeddings/config.co
+++ b/tests/test_configs/with_cohere_embeddings/config.co
@@ -1,0 +1,12 @@
+define user ask about capabilities
+  "What can you do?"
+  "What can you help me with?"
+  "tell me what you can do"
+  "tell me about you"
+
+define bot respond about capabilities
+  "I am an AI assistant that helps answer questions."
+
+define flow
+  user ask about capabilities
+  bot respond about capabilities

--- a/tests/test_configs/with_cohere_embeddings/config.yml
+++ b/tests/test_configs/with_cohere_embeddings/config.yml
@@ -6,3 +6,8 @@ models:
   - type: embeddings
     engine: cohere
     model: embed-english-light-v3.0
+
+instructions:
+  - type: "general"
+    content:
+      Below is a conversation between an AI assistant and a user.

--- a/tests/test_configs/with_cohere_embeddings/config.yml
+++ b/tests/test_configs/with_cohere_embeddings/config.yml
@@ -1,0 +1,8 @@
+models:
+  - type: main
+    engine: cohere
+    model: command-r
+
+  - type: embeddings
+    engine: cohere
+    model: embed-english-light-v3.0

--- a/tests/test_embeddings_cohere.py
+++ b/tests/test_embeddings_cohere.py
@@ -1,0 +1,91 @@
+import os
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+
+try:
+    from nemoguardrails.embeddings.embedding_providers.cohere import (
+        CohereEmbeddingModel,
+    )
+except ImportError:
+    # Ignore this if running in test environment when cohere not installed.
+    CohereEmbeddingModel = None
+
+CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
+
+LIVE_TEST_MODE = os.environ.get("LIVE_TEST")
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)  # Set level to DEBUG to see all messages
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.DEBUG)  # Set level to DEBUG to see all messages
+logger.addHandler(console_handler)
+
+
+@pytest.fixture
+def app():
+    """Load the configuration where we replace FastEmbed with Cohere."""
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "with_cohere_embeddings")
+    )
+
+    return LLMRails(config, verbose=True)
+
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
+def test_custom_llm_registration(app):
+    assert isinstance(
+        app.llm_generation_actions.flows_index._model, CohereEmbeddingModel
+    )
+
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
+@pytest.mark.asyncio
+async def test_live_query_async():
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "with_cohere_embeddings")
+    )
+    app = LLMRails(config, verbose=True)
+
+    result = await app.generate_async(
+        messages=[{"role": "user", "content": "tell me what you can do"}]
+    )
+
+    assert result == {
+        "role": "assistant",
+        "content": "I am an AI assistant that helps answer questions.",
+    }
+
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
+def test_live_query(app):
+    result = app.generate(
+        messages=[{"role": "user", "content": "tell me what you can do"}]
+    )
+
+    assert result == {
+        "role": "assistant",
+        "content": "I am an AI assistant that helps answer questions.",
+    }
+
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
+def test_sync_embeddings():
+    model = CohereEmbeddingModel("embed-english-light-v3.0")
+
+    result = model.encode(["test"])
+
+    assert len(result[0]) == 384
+
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
+@pytest.mark.asyncio
+async def test_async_embeddings():
+    model = CohereEmbeddingModel("embed-english-v3.0")
+
+    result = await model.encode_async(["test"])
+
+    assert len(result[0]) == 1024


### PR DESCRIPTION
I added Cohere chat model support e.g. command-r. I followed the way ChatOpenAI model is currently integrated. 

I have provided unit tests, similar to that provided for nemollm. 

I also created config file cohere-commandr-config.yml for prompts customized for the command-r model.

I am not affiliated with Cohere. I just needed this for my tests. And sharing for the broader benefit of the community. 

