### PR TITLE
Use "config" as the default config_id for completions endpoint

### DIFF
--- a/docs/user_guides/server-guide.md
+++ b/docs/user_guides/server-guide.md
@@ -53,6 +53,7 @@ GET /v1/rails/configs
 ```
 
 Sample response:
+
 ```json
 [
   {"id":"abc"},
@@ -64,9 +65,11 @@ Sample response:
 #### /v1/chat/completions
 
 To get the completion for a chat session, use the `/v1/chat/completions` endpoint:
+
 ```
 POST /v1/chat/completions
 ```
+
 ```json
 {
     "config_id": "benefits_co",
@@ -91,6 +94,7 @@ The completion endpoint also supports combining multiple configurations in a sin
 ```
 POST /v1/chat/completions
 ```
+
 ```json
 {
     "config_ids": ["config_1", "config_2"],
@@ -101,7 +105,7 @@ POST /v1/chat/completions
 }
 ```
 
-The configurations will be combined in the order they are specified in the `config_ids` list. If there are any conflicts between the configurations, the last configuration in the list will take precedence. The rails will be combined in the order they are specified in the `config_ids` list. The model type and engine across the configurations must be the same.
+The configurations will be combined in the order they are specified in the `config_ids` list. If there are any conflicts between the configurations, the last configuration in the list will take precedence. The rails will be combined in the order they are specified in the `config_ids` list. The model type and engine across the configurations must be the same. If neither `config_id` nor `config_ids` is supplied, the default value of `config` will be used.
 
 ### Threads
 
@@ -120,6 +124,7 @@ Next, when making a call to the `/v1/chat/completions` endpoint, you must also i
 ```
 POST /v1/chat/completions
 ```
+
 ```json
 {
     "config_id": "config_1",
@@ -134,7 +139,6 @@ POST /v1/chat/completions
 > NOTE: for security reasons, the `thread_id` must have a minimum length of 16 characters.
 
 As an example, check out this [configuration](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/examples/configs/threads/README.md).
-
 
 #### Limitations
 
@@ -173,6 +177,7 @@ GET /v1/actions/list
 ```
 
 Sample response:
+
 ```json
 ["apify","bing_search","google_search","google_serper","openweather_query","searx_search","serp_api_query","wikipedia_query","wolframalpha_query","zapier_nla_query"]
 ```
@@ -180,9 +185,11 @@ Sample response:
 #### `/v1/actions/run`
 
 To execute an action with a set of parameters, use the `/v1/actions/run` endpoint:
+
 ```
 POST /v1/actions/run
 ```
+
 ```json
 {
     "action_name": "wolfram_alpha_request",

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -133,14 +133,6 @@ class RequestBody(BaseModel):
         description="A state object that should be used to continue the interaction.",
     )
 
-    @validator("config_ids", always=True)
-    def check_if_set(cls, v, values, **kwargs):
-        if v is not None and values.get("config_id") is not None:
-            raise ValueError("Only one of config_id or config_ids should be specified")
-        if v is None and values.get("config_id") is None:
-            raise ValueError("Either config_id or config_ids must be specified")
-        return v
-
 
 class ResponseBody(BaseModel):
     messages: List[dict] = Field(
@@ -256,7 +248,10 @@ async def chat_completion(body: RequestBody, request: Request):
     TODO: add support for explicit state object.
     """
     if not body.config_ids:
-        body.config_ids = [body.config_id]
+        if body.config_id:
+            body.config_ids = [body.config_id]
+        else:
+            body.config_ids = ["config"]
     log.info("Got request for config %s", body.config_id)
     for logger in registered_loggers:
         asyncio.get_event_loop().create_task(


### PR DESCRIPTION
This PR is in response to issue #451 