### PR TITLE
Do not store pip cache during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,7 @@ RUN apt-get install -y gcc g++
 # Copy and install NeMo Guardrails
 WORKDIR /nemoguardrails
 COPY . /nemoguardrails
-RUN pip install -e .[all]
-
-# Remove the PIP cache
-RUN rm -rf /root/.cache/pip
+RUN pip install --no-cache-dir -e .[all]
 
 # Make port 8000 available to the world outside this container
 EXPOSE 8000

--- a/nemoguardrails/library/factchecking/align_score/Dockerfile
+++ b/nemoguardrails/library/factchecking/align_score/Dockerfile
@@ -1,8 +1,8 @@
 # Use python:3.10 as the base image
-FROM python:3.10 as base
+FROM python:3.10
 
 # Install git
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git
 
 # Set working directory
 WORKDIR /app

--- a/nemoguardrails/library/factchecking/align_score/Dockerfile
+++ b/nemoguardrails/library/factchecking/align_score/Dockerfile
@@ -1,8 +1,8 @@
 # Use python:3.10 as the base image
-FROM python:3.10
+FROM python:3.10 as base
 
 # Install git
-RUN apt-get update && apt-get install -y git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app
@@ -10,7 +10,7 @@ WORKDIR /app
 # Clone and install the alignscore package
 RUN git clone https://github.com/yuh-zha/AlignScore.git
 WORKDIR /app/AlignScore
-RUN pip install .
+RUN pip install --no-cache-dir .
 
 # Download the Spacy en_core_web_sm model
 RUN python -m spacy download en_core_web_sm
@@ -24,11 +24,14 @@ RUN curl -OL https://huggingface.co/yzha/AlignScore/resolve/main/AlignScore-base
 # Switch
 WORKDIR /app
 
-# Copy the source code
-COPY . /app
+# Copy requirements.txt
+COPY requirements.txt .
 
 # Install the minimal set of requirements for AlignScore Server
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the source code
+COPY . .
 
 # Download the punkt model to speed up start time
 RUN python -c "import nltk; nltk.download('punkt')"

--- a/nemoguardrails/library/jailbreak_detection/Dockerfile
+++ b/nemoguardrails/library/jailbreak_detection/Dockerfile
@@ -2,19 +2,18 @@
 FROM python:3.10-slim
 
 # Install git
-RUN apt-get update && apt-get install -y git && apt-get install gcc -y && apt-get install g++ -y && apt-get install python3-dev -y && apt-get clean
-
-# Upgrade pip
- RUN pip install --upgrade pip
-
-# Copy the source code
-COPY . /app
+RUN apt-get update && apt-get install -y git gcc g++ python3-dev && apt-get clean
 
 # Set working directory
 WORKDIR /app
 
-# Install the minimal set of requirements for jailbreak detection Server
-RUN pip install -r requirements.txt
+# Copy only requirements.txt
+COPY requirements.txt .
+
+# Upgrade pip and install the minimal set of requirements for jailbreak detection Server
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
 
 # Set the device on which the model should load e.g., "cpu", "cuda:0", etc.
 ENV JAILBREAK_CHECK_DEVICE=cpu

--- a/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
+++ b/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
@@ -5,25 +5,24 @@ FROM nvidia/cuda:12.3.1-base-ubuntu20.04
 RUN apt-get update && apt-get install -y git && apt-get install gcc -y && apt-get install g++ -y && apt-get clean
 
 # Install python
-RUN apt-get install python3 python3-pip python3-dev -y
-
-# Upgrade pip
-RUN pip install --upgrade pip
-
-# Copy the source code
-COPY . /app
+RUN apt-get install python3 python3-pip python3-dev -y && apt-get clean
 
 # Set working directory
 WORKDIR /app
 
-# Install the minimal set of requirements for jailbreak detection Server
-RUN pip install -r requirements.txt
+# Copy only requirements.txt
+COPY requirements.txt .
+
+# Upgrade pip and install the minimal set of requirements for jailbreak detection Server
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
 
 # Set the device on which the model should load e.g., "cpu", "cuda:0", etc.
 ENV JAILBREAK_CHECK_DEVICE=cuda:0
 
 # Predownload the GPT2 model.
-RUN python -c "from transformers import GPT2LMHeadModel, GPT2TokenizerFast; GPT2LMHeadModel.from_pretrained('gpt2-large'); GPT2TokenizerFast.from_pretrained('gpt2-large');"
+RUN python3 -c "from transformers import GPT2LMHeadModel, GPT2TokenizerFast; GPT2LMHeadModel.from_pretrained('gpt2-large'); GPT2TokenizerFast.from_pretrained('gpt2-large');"
 
 # Expose a port for the server
 EXPOSE 1337

--- a/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
+++ b/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
@@ -2,27 +2,30 @@
 FROM nvidia/cuda:12.3.1-base-ubuntu20.04
 
 # Install git
-RUN apt-get update && apt-get install -y git && apt-get install gcc -y && apt-get install g++ -y && apt-get clean
+RUN apt-get update && apt-get install -y git gcc g++ && apt-get clean
 
 # Install python
-RUN apt-get install python3 python3-pip python3-dev -y && apt-get clean
+RUN apt-get install python3 python3-pip python3-dev -y
+
+# Upgrade pip
+RUN pip install --no-cache-dir --upgrade pip
 
 # Set working directory
 WORKDIR /app
 
-# Copy only requirements.txt
+# Copy the source code
 COPY requirements.txt .
 
-# Upgrade pip and install the minimal set of requirements for jailbreak detection Server
-RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
+# Install the minimal set of requirements for jailbreak detection Server
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Predownload the GPT2 model.
+RUN python3 -c "from transformers import GPT2LMHeadModel, GPT2TokenizerFast; GPT2LMHeadModel.from_pretrained('gpt2-large'); GPT2TokenizerFast.from_pretrained('gpt2-large');"
 
 COPY . .
 
 # Set the device on which the model should load e.g., "cpu", "cuda:0", etc.
 ENV JAILBREAK_CHECK_DEVICE=cuda:0
-
-# Predownload the GPT2 model.
-RUN python3 -c "from transformers import GPT2LMHeadModel, GPT2TokenizerFast; GPT2LMHeadModel.from_pretrained('gpt2-large'); GPT2TokenizerFast.from_pretrained('gpt2-large');"
 
 # Expose a port for the server
 EXPOSE 1337


### PR DESCRIPTION
Hi, thanks for developing the guardrails.
Removing the pip cache in a layer subsequent to the pip install does not reduce image size because the cache stays in the final image. It is more effective and cleaner not using any caching at all.

Adding the option `--no-cache-dir` during pip command reduces the final artifact size for each of the Dockerfiles in the repo, like listed below.

1. `Dockerfile`: from 1.68GB to 1.58GB;
2. `nemoguardrails/library/jailbreak_detection/Dockerfile`: from 12.3GB to 9.37GB;
3. `nemoguardrails/library/jailbreak_detection/Dockerfile-GPU`: from 12.3GB to 9.41GB;
4. `nemoguardrails/library/factchecking/align_score/Dockerfile`: from 9.6GB to 7.6GB;


For the last three dockerfiles, I reordered the COPY and RUN directives in order to avoid having to download the dependencies every time a single line of code changes.
There could be definitely be more optimizations, such as multi-layer builds.