### PR TITLE
[bugfix] staticmethod and classmethod action decorators fix

### DIFF
--- a/nemoguardrails/actions/actions.py
+++ b/nemoguardrails/actions/actions.py
@@ -39,7 +39,17 @@ def action(
         Args:
             fn_or_cls: The function or class being decorated.
         """
-        fn_or_cls.action_meta = {
+
+        # Detect the decorator being applied to staticmethod or classmethod.
+        # Will annotate the the inner function in that case as otherwise
+        # metaclass will be giving us the unannotated enclosed function on
+        # attribute lookup.
+        if hasattr(fn_or_cls, "__func__"):
+            fn_or_cls_target = fn_or_cls.__func__
+        else:
+            fn_or_cls_target = fn_or_cls
+
+        fn_or_cls_target.action_meta = {
             "name": name or fn_or_cls.__name__,
             "is_system_action": is_system_action,
             "execute_async": execute_async,


### PR DESCRIPTION
`action` decorator does not preserve the decorator argument options if applied to staticmethods or classmethods. For example:

```python
import os

from nemoguardrails import LLMRails
from nemoguardrails import RailsConfig
from nemoguardrails.actions.actions import action

os.environ["OPENAI_API_KEY"]="sk-..."

config = RailsConfig.from_path(".")
rails = LLMRails(config)

@action(name="func")
def test_func():
    return "hello"

class Test:
    @action(name="method")
    def test_method(self):
        return "method"

    @action(name="staticmethod")
    @staticmethod
    def test_staticmethod():
        return "static"

    @action(name="classmethod")
    @classmethod
    def test_classmethod(cls):
        return "class"

rails.register_action(test_func)
rails.register_action(Test().test_method)
rails.register_action(Test.test_staticmethod)
rails.register_action(Test.test_classmethod)

assert "func" in rails.runtime.registered_actions
assert "method" in rails.runtime.registered_actions
assert "staticmethod" in rails.runtime.registered_actions
assert "classmethod" in rails.runtime.registered_actions
```

The last two assertions will fail. This PR makes them pass.