### PR TITLE
Fix custom prompts configuration manual.md

### DIFF
--- a/docs/user_guides/configuration-guide.md
+++ b/docs/user_guides/configuration-guide.md
@@ -270,6 +270,7 @@ prompts:
     models:
       - openai/gpt-3.5-turbo
     max_length: 3000
+    output_parser: user_intent
     content: |-
       <<This is a placeholder for a custom prompt for generating the user intent>>
 ```


### PR DESCRIPTION
If you make custom prompt work as per #486, you should write the output parser. 

Additionally, it seems that need to list all the items available as config for prompts in this user guide file.