### PR TITLE
Fix/colang match statement

### DIFF
--- a/nemoguardrails/colang/v2_x/lang/expansion.py
+++ b/nemoguardrails/colang/v2_x/lang/expansion.py
@@ -312,36 +312,39 @@ def _expand_match_element(
         # Single match element
         if element.spec.spec_type == SpecType.FLOW and element.spec.members is None:
             # It's a flow
-            element_ref = element.spec.ref
-            if element_ref is None:
-                element_ref = _create_ref_ast_dict_helper(
-                    f"_flow_event_ref_{new_var_uid()}"
-                )
-            assert isinstance(element_ref, dict)
-
-            arguments = {"flow_id": f"'{element.spec.name}'"}
-            for arg in element.spec.arguments:
-                arguments.update({arg: element.spec.arguments[arg]})
-
-            new_elements.append(
-                SpecOp(
-                    op="match",
-                    spec=Spec(
-                        name=InternalEvents.FLOW_FINISHED,
-                        arguments=arguments,
-                        ref=element_ref,
-                        spec_type=SpecType.EVENT,
-                    ),
-                    return_var_name=element.return_var_name,
-                )
+            raise ColangSyntaxError(
+                f"Keyword `match` cannot be used with flows (flow `{element.spec.name}`)"
             )
-            if element.return_var_name is not None:
-                new_elements.append(
-                    Assignment(
-                        key=element.return_var_name,
-                        expression=f"${element_ref['elements'][0]['elements'][0]}.arguments.return_value",
-                    )
-                )
+            # element_ref = element.spec.ref
+            # if element_ref is None:
+            #     element_ref = _create_ref_ast_dict_helper(
+            #         f"_flow_event_ref_{new_var_uid()}"
+            #     )
+            # assert isinstance(element_ref, dict)
+
+            # arguments = {"flow_id": f"'{element.spec.name}'"}
+            # for arg in element.spec.arguments:
+            #     arguments.update({arg: element.spec.arguments[arg]})k
+
+            # new_elements.append(
+            #     SpecOp(
+            #         op="match",
+            #         spec=Spec(
+            #             name=InternalEvents.FLOW_FINISHED,
+            #             arguments=arguments,
+            #             ref=element_ref,
+            #             spec_type=SpecType.EVENT,
+            #         ),
+            #         return_var_name=element.return_var_name,
+            #     )
+            # )
+            # if element.return_var_name is not None:
+            #     new_elements.append(
+            #         Assignment(
+            #             key=element.return_var_name,
+            #             expression=f"${element_ref['elements'][0]['elements'][0]}.arguments.return_value",
+            #         )
+            #     )
         elif (
             element.spec.spec_type == SpecType.EVENT or element.spec.members is not None
         ):

--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -85,6 +85,7 @@ capture_ref: "as" var_name
 // A spec includes name, arguments and potentially members access.
 // Example members: .Finished(), .action
 spec: spec_name [classic_arguments | simple_arguments] (spec_member)* [capture_ref]
+    | "(" spec_name [classic_arguments | simple_arguments] ")" (spec_member)* [capture_ref]
     | var_name (spec_member)* [capture_ref]
 spec_member: "." name [classic_arguments]
 

--- a/nemoguardrails/colang/v2_x/runtime/statemachine.py
+++ b/nemoguardrails/colang/v2_x/runtime/statemachine.py
@@ -2256,7 +2256,8 @@ def get_event_from_element(
             flow_config = state.flow_configs[element_spec.name]
             temp_flow_state = create_flow_instance(flow_config, "", "", {})
             flow_event_name = element_spec.members[0]["name"]
-            flow_event_arguments = element_spec.members[0]["arguments"]
+            flow_event_arguments = element_spec.arguments
+            flow_event_arguments.update(element_spec.members[0]["arguments"])
             flow_event_arguments = _evaluate_arguments(
                 flow_event_arguments, _get_eval_context(state, flow_state)
             )

--- a/tests/v2_x/test_flow_mechanics.py
+++ b/tests/v2_x/test_flow_mechanics.py
@@ -482,11 +482,11 @@ def test_flow_started_matching():
       await UtteranceBotAction(script=$script)
 
     flow a
-      match user said $transcript="Hi"
+      match (user said $transcript="Hi").Finished()
       bot say 'Check1'
 
     flow b
-      match user said $transcript="Hello"
+      match (user said $transcript="Hello").Finished()
       bot say 'Check2'
 
     flow main
@@ -779,7 +779,7 @@ def test_finish_flow_event():
       await UtteranceBotAction(script="Hi")
 
     flow b
-      match a
+      match a.Finished()
       await UtteranceBotAction(script="Yes")
 
     flow main
@@ -2204,4 +2204,4 @@ def test_single_flow_activation_3():
 
 
 if __name__ == "__main__":
-    test_single_flow_activation_3()
+    test_flow_started_matching()


### PR DESCRIPTION
Disable support for match statements on flows and add support for match statements on flow event with parameters , e.g. `(match flow a $param="val").Finished()`