### PR TITLE
feat(embeddings): add search threshold to BasicEmbeddingsIndex

### DIFF
--- a/docs/user_guides/advanced/embedding-search-providers.md
+++ b/docs/user_guides/advanced/embedding-search-providers.md
@@ -16,6 +16,7 @@ core:
       use_batching: False
       max_batch_size: 10
       max_batch_hold: 0.01
+      search_threshold: None
     cache:
       enabled: False
       key_generator: md5
@@ -31,6 +32,7 @@ knowledge_base:
       use_batching: False
       max_batch_size: 10
       max_batch_hold: 0.01
+      search_threshold: None
     cache:
       enabled: False
       key_generator: md5

--- a/docs/user_guides/configuration-guide.md
+++ b/docs/user_guides/configuration-guide.md
@@ -600,6 +600,11 @@ rails:
     user_messages:
       # Whether to use only the embeddings when interpreting the user's message
       embeddings_only: True
+      # Use only the embeddings when the similarity is above the specified threshold.
+      embeddings_only_similarity_threshold: 0.5
+      # When the fallback is set to None, if the similarity is below the threshold, the user intent is computed normally using the LLM.
+      # When it is set to a string value, that string value will be used as the intent.
+      embeddings_only_fallback_intent: None
 ```
 
 **IMPORTANT**: This is recommended only when enough examples are provided.

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -374,6 +374,9 @@ class LLMGenerationActions:
                 # If the option to use only the embeddings is activated, we take the first
                 # canonical form.
                 if results and config.rails.dialog.user_messages.embeddings_only:
+                    # TODO: propagate the similarity thresholds here
+                    #   depending on whether a `embeddings_only_fallback_intent` is set or not,
+                    #   it should return the provided intent or let this continue normally.
                     return ActionResult(
                         events=[
                             new_event_dict(

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -59,7 +59,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         embedding_engine=None,
         index=None,
         cache_config: Union[EmbeddingsCacheConfig, Dict[str, Any]] = None,
-        search_threshold: Optional[float] = None,
+        search_threshold: float = float("inf"),
         use_batching: bool = False,
         max_batch_size: int = 10,
         max_batch_hold: float = 0.01,
@@ -291,8 +291,11 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
     def _filter_results(
         indices: List[int], distances: List[float], threshold: float
     ) -> List[int]:
-        return [
-            index
-            for index, distance in zip(indices, distances)
-            if distance <= threshold
-        ]
+        if threshold == float("inf"):
+            return indices
+        else:
+            return [
+                index
+                for index, distance in zip(indices, distances)
+                if distance <= threshold
+            ]

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -48,6 +48,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
     embedding_size: int
     cache_config: EmbeddingsCacheConfig
     embeddings: List[List[float]]
+    search_threshold: float
     use_batching: bool
     max_batch_size: int
     max_batch_hold: float
@@ -58,6 +59,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         embedding_engine=None,
         index=None,
         cache_config: Union[EmbeddingsCacheConfig, Dict[str, Any]] = None,
+        search_threshold: Optional[float] = None,
         use_batching: bool = False,
         max_batch_size: int = 10,
         max_batch_hold: float = 0.01,
@@ -79,6 +81,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         self.embedding_model = embedding_model
         self.embedding_engine = embedding_engine
         self._embedding_size = 0
+        self.search_threshold = search_threshold or float("inf")
         if isinstance(cache_config, Dict):
             self._cache_config = EmbeddingsCacheConfig(**cache_config)
         else:
@@ -267,9 +270,29 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         else:
             _embedding = (await self._get_embeddings([text]))[0]
 
+        if self._index is None:
+            raise ValueError(
+                "Index is not built yet. Ensure to call `build` before searching."
+            )
+
         results = self._index.get_nns_by_vector(
             _embedding,
             max_results,
+            include_distances=True,
         )
 
-        return [self._items[i] for i in results]
+        filtered_results = self._filter_results(
+            results[0], results[1], self.search_threshold
+        )
+
+        return [self._items[i] for i in filtered_results]
+
+    @staticmethod
+    def _filter_results(
+        indices: List[int], distances: List[float], threshold: float
+    ) -> List[int]:
+        return [
+            index
+            for index, distance in zip(indices, distances)
+            if distance <= threshold
+        ]

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -59,7 +59,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         embedding_engine=None,
         index=None,
         cache_config: Union[EmbeddingsCacheConfig, Dict[str, Any]] = None,
-        search_threshold: float = float("inf"),
+        search_threshold: float = None,
         use_batching: bool = False,
         max_batch_size: int = 10,
         max_batch_hold: float = 0.01,
@@ -255,7 +255,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
 
         return result
 
-    async def search(self, text: str, max_results: int = 20) -> List[IndexItem]:
+    async def search(
+        self, text: str, max_results: int = 20, threshold: Optional[float] = None
+    ) -> List[IndexItem]:
         """Search the closest `max_results` items.
 
         Args:
@@ -265,6 +267,9 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
         Returns:
             List[IndexItem]: The closest items found.
         """
+        if threshold is None:
+            threshold = self.search_threshold
+
         if self.use_batching:
             _embedding = await self._batch_get_embeddings(text)
         else:
@@ -281,9 +286,7 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             include_distances=True,
         )
 
-        filtered_results = self._filter_results(
-            results[0], results[1], self.search_threshold
-        )
+        filtered_results = self._filter_results(results[0], results[1], threshold)
 
         return [self._items[i] for i in filtered_results]
 

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 from typing import Any, Dict, List, Optional, Union
 
 from annoy import AnnoyIndex
@@ -22,6 +23,8 @@ from nemoguardrails.embeddings.cache import cache_embeddings
 from nemoguardrails.embeddings.index import EmbeddingsIndex, IndexItem
 from nemoguardrails.embeddings.providers import EmbeddingModel, init_embedding_model
 from nemoguardrails.rails.llm.config import EmbeddingsCacheConfig
+
+log = logging.getLogger(__name__)
 
 
 class BasicEmbeddingsIndex(EmbeddingsIndex):
@@ -285,6 +288,14 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             max_results,
             include_distances=True,
         )
+
+        # In verbose mode, we show detailed info about the scores
+        if threshold != float("inf"):
+            log_items = []
+            for i in range(len(results[0])):
+                score = 1 - results[1][i] / 2
+                log_items.append((score, self._items[results[0][i]].text))
+            log.info("Similarity scores :: %s", str(log_items))
 
         filtered_results = self._filter_results(results[0], results[1], threshold)
 

--- a/nemoguardrails/embeddings/basic.py
+++ b/nemoguardrails/embeddings/basic.py
@@ -297,5 +297,5 @@ class BasicEmbeddingsIndex(EmbeddingsIndex):
             return [
                 index
                 for index, distance in zip(indices, distances)
-                if distance <= threshold
+                if (1 - distance / 2) >= threshold
             ]

--- a/nemoguardrails/embeddings/index.py
+++ b/nemoguardrails/embeddings/index.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -62,6 +62,8 @@ class EmbeddingsIndex:
         This is optional, might not be needed for all implementations."""
         pass
 
-    async def search(self, text: str, max_results: int) -> List[IndexItem]:
+    async def search(
+        self, text: str, max_results: int, threshold: Optional[float]
+    ) -> List[IndexItem]:
         """Searches the index for the closest matches to the provided text."""
         raise NotImplementedError()

--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -158,7 +158,7 @@ class VerboseHandler(logging.StreamHandler):
                 else:
                     msg += f"[dim]{title}[/]"
 
-                console.print(msg, highlight=False, no_wrap=True)
+                console.print(msg, highlight=False, no_wrap=False)
 
 
 def set_verbose(

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -292,6 +292,16 @@ class UserMessagesConfig(BaseModel):
         default=False,
         description="Whether to use only embeddings for computing the user canonical form messages.",
     )
+    embeddings_only_similarity_threshold: Optional[float] = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description="The similarity threshold to use when using only embeddings for computing the user canonical form messages.",
+    )
+    embeddings_only_fallback_intent: Optional[str] = Field(
+        default=None,
+        description="Defines the fallback intent when the similarity is below the threshold. If set to None, the user intent is computed normally using the LLM. If set to a string value, that string is used as the intent.",
+    )
 
 
 class DialogRails(BaseModel):

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -398,7 +398,13 @@ class LLMRails:
                 **{
                     k: v
                     for k, v in esp_config.parameters.items()
-                    if k in ["use_batching", "max_batch_size", "matx_batch_hold"]
+                    if k
+                    in [
+                        "use_batching",
+                        "max_batch_size",
+                        "matx_batch_hold",
+                        "search_threshold",
+                    ]
                     and v is not None
                 },
             )

--- a/tests/test_embeddings_only_user_messages.py
+++ b/tests/test_embeddings_only_user_messages.py
@@ -15,32 +15,39 @@
 
 import pytest
 
-from nemoguardrails import RailsConfig
+from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.actions.llm.utils import LLMCallException
 from tests.utils import TestChat
 
-config = RailsConfig.from_content(
-    """
-    define user express greeting
-      "hi"
 
-    define bot express greeting
-      "Hello!"
+@pytest.fixture
+def config():
+    return RailsConfig.from_content(
+        """
+        define user express greeting
+          "hi"
 
-    define flow
-      user express greeting
-      bot express greeting
-    """,
-    """
-    rails:
-        dialog:
-            user_messages:
-                embeddings_only: True
-    """,
-)
+        define bot express greeting
+          "Hello!"
+
+        define flow
+          user express greeting
+          bot express greeting
+        """,
+        """
+        rails:
+            dialog:
+                user_messages:
+                    embeddings_only: True
+                    embeddings_only_similarity_threshold: 0.5
+                    embeddings_only_fallback_intent: "express greeting"
+        """,
+    )
 
 
-def test_1():
+def test_greeting(config):
+    """Test that the bot responds with 'Hello!' when the user says 'hello'."""
+
     chat = TestChat(
         config,
         llm_completions=[],
@@ -50,7 +57,9 @@ def test_1():
     chat << "Hello!"
 
 
-def test_2():
+def test_error_when_embeddings_only_is_false(config):
+    """Test that an error is raised when the 'embeddings_only' option is False."""
+
     # Check that if we deactivate the embeddings_only option we get an error
     config.rails.dialog.user_messages.embeddings_only = False
     chat = TestChat(
@@ -61,3 +70,18 @@ def test_2():
     with pytest.raises(LLMCallException):
         chat >> "hello"
         chat << "Hello!"
+
+
+def test_fallback_intent(config):
+    """Test that the bot uses the fallback intent when it doesn't recognize the user's message."""
+
+    rails = LLMRails(config)
+    res = rails.generate(messages=[{"role": "user", "content": "lets use fallback"}])
+    assert res["content"] == "Hello!"
+
+    config.rails.dialog.user_messages.embeddings_only_fallback_intent = None
+    rails = LLMRails(config)
+    with pytest.raises(LLMCallException):
+        rails.generate(messages=[{"role": "user", "content": "lets use fallback"}])
+    #
+    # Check the bot's response


### PR DESCRIPTION
This commit introduces a search threshold to the `BasicEmbeddingsIndex` class. This threshold is used to filter the search results based on their distances. The `_filter_results` method is added to perform this filtering. The `search` method is updated to use this new feature. The `search_threshold` parameter is also added to the `LLMRails` classs.

TODO:

- [ ] Check if the updated doc is ok

