### PR TITLE
Fix path traversal check

### DIFF
--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -138,7 +138,7 @@ def server(
     if config:
         # We make sure there is no trailing separator, as that might break things in
         # single config mode.
-        api.app.rails_config_path = config[0].rstrip(os.path.sep)
+        api.app.rails_config_path = os.path.expanduser(config[0].rstrip(os.path.sep))
     else:
         # If we don't have a config, we try to see if there is a local config folder
         local_path = os.getcwd()
@@ -189,6 +189,6 @@ def version_callback(value: bool):
 def cli(
     _: Optional[bool] = typer.Option(
         None, "-v", "--version", callback=version_callback, is_eager=True
-    )
+    ),
 ):
     pass

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -18,6 +18,7 @@ import importlib.util
 import json
 import logging
 import os.path
+import re
 import time
 import warnings
 from typing import Any, List, Optional
@@ -252,6 +253,13 @@ def _get_rails(config_ids: List[str]) -> LLMRails:
     for config_id in config_ids:
         base_path = os.path.abspath(app.rails_config_path)
         full_path = os.path.normpath(os.path.join(base_path, config_id))
+
+        # @NOTE: (Rdinu) Reject config_ids that contain dangerous characters or sequences
+        if re.search(r"[\\/]|(\.\.)", config_id):
+            raise ValueError("Invalid config_id.")
+
+        if os.path.commonprefix([full_path, base_path]) != base_path:
+            raise ValueError("Access to the specified path is not allowed.")
 
         rails_config = RailsConfig.from_path(full_path)
 

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -253,9 +253,6 @@ def _get_rails(config_ids: List[str]) -> LLMRails:
         base_path = os.path.abspath(app.rails_config_path)
         full_path = os.path.normpath(os.path.join(base_path, config_id))
 
-        if not full_path.startswith(base_path + os.sep):
-            raise ValueError("Access to the specified path is not allowed.")
-
         rails_config = RailsConfig.from_path(full_path)
 
         if not full_llm_rails_config:


### PR DESCRIPTION
This PR includes three key fixes:

1. Prevents path traversal in the `_get_rails` function by rejecting config_ids that contain dangerous characters or sequences.
2. Removes an unnecessary path check in the `_get_rails` function, simplifies the code and reducing the chance of errors.
3. Modifies the server command in the CLI to correctly expand user paths, allowing for paths starting with '~' to be used.

fixes [4706127]