### PR TITLE
feat(llmrails): Add serialization support for LLMRails

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -63,7 +63,7 @@ from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.streaming import StreamingHandler
-from nemoguardrails.utils import new_event_dict
+from nemoguardrails.utils import get_or_create_event_loop, new_event_dict
 
 log = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ class LLMGenerationActions:
 
         # There are still some edge cases not covered by nest_asyncio.
         # Using a separate thread always for now.
-        loop = asyncio.get_event_loop()
+        loop = get_or_create_event_loop()
         if True or check_sync_call_from_async_loop():
             t = threading.Thread(target=asyncio.run, args=(self.init(),))
             t.start()

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1069,7 +1069,11 @@ class LLMRails:
         return self.explain_info
 
     def __getstate__(self):
-        return self.config
+        return {"config": self.config}
 
-    def __setstate__(self, config):
-        self.__init__(config=config)
+    def __setstate__(self, state):
+        if state["config"].config_path:
+            config = RailsConfig.from_path(state["config"].config_path)
+        else:
+            config = state["config"]
+        self.__init__(config=config, verbose=False)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 """LLM Rails entry point."""
+
 import asyncio
 import importlib.util
 import logging
@@ -1066,3 +1067,9 @@ class LLMRails:
     def explain(self) -> ExplainInfo:
         """Helper function to return the latest ExplainInfo object."""
         return self.explain_info
+
+    def __getstate__(self):
+        return self.config
+
+    def __setstate__(self, config):
+        self.__init__(config=config)


### PR DESCRIPTION
The changes include the addition of `__getstate__` and `__setstate__` and methods to the `LLMRails` class. These methods are used for pickling and unpickling of the class instance, allowing it to be serialized and deserialized.

It might resolve #614