### PR TITLE
Docs/add tab groups

### DIFF
--- a/docs/getting_started/1_hello_world/README.md
+++ b/docs/getting_started/1_hello_world/README.md
@@ -96,25 +96,53 @@ The format for the input `messages` array as well as the response follow the [Op
 To control the greeting response, define the user and bot messages, and the flow that connects the two together. See [Core Colang Concepts](../2_core_colang_concepts/README.md) for definitions of *messages* and *flows*.
 
 1. Define the `greeting` user message by creating a *config/rails.co* file with the following content:
-
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow user expressed greeting
+  user said "Hello"
+  or user said "Hi"
+  or user said "Wassup?"
+```
+```{group-tab} Colang 1.0
 ```colang
 define user express greeting
   "Hello"
   "Hi"
   "Wassup?"
 ```
+````
 
 2. Add a greeting flow that instructs the bot to respond back with "Hello World!" and ask how they are doing by adding the following content to the *rails.co* file:
 
-```python
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow greeting
+  user expressed greeting
+  bot express greeting
+  bot ask how are you
+```
+```{group-tab} Colang 1.0
+```colang
 define flow greeting
   user express greeting
   bot express greeting
   bot ask how are you
 ```
+````
 
 3. Define the messages for the response by adding the following content to the *rails.co* file:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```python
+flow bot express greeting
+  bot say "Hello World!"
+flow bot ask how are you
+  bot say "How are you doing?"
+```
+```{group-tab} Colang 1.0
 ```python
 define bot express greeting
   "Hello World!"
@@ -122,6 +150,7 @@ define bot express greeting
 define bot ask how are you
   "How are you doing?"
 ```
+````
 
 4. Reload the config and test it:
 

--- a/docs/getting_started/2_core_colang_concepts/README.md
+++ b/docs/getting_started/2_core_colang_concepts/README.md
@@ -42,24 +42,44 @@ In Colang, a conversation is modeled as an exchange of messages between a user a
 
 Using Colang, you can define the user messages that are important for your LLM-based application. For example, in the "Hello World" example, the `express greeting` user message is defined as:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow user expressed greeting
+  user said "Hello"
+  or user said "Hi"
+  or user said "Wassup?"
 ```
+```{group-tab} Colang 1.0
+```colang
 define user express greeting
   "Hello"
   "Hi"
   "Wassup?"
 ```
+````
 
 The `express greeting` represents the canonical form and "Hello", "Hi" and "Wassup?" represent example utterances. The role of the example utterances is to teach the bot the meaning of a defined canonical form.
 
 You can also define bot messages, such as how the bot should converse with the user. For example, in the "Hello World" example, the `express greeting` and `ask how are you` bot messages are defined as:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```python
+flow bot express greeting
+  bot say "Hello World!"
+flow bot ask how are you
+  bot say "How are you doing?"
 ```
+```{group-tab} Colang 1.0
+```python
 define bot express greeting
-  "Hey there!"
+  "Hello World!"
 
 define bot ask how are you
   "How are you doing?"
 ```
+````
 
 If more than one utterance is given for a canonical form, the bot uses a random utterance whenever the message is used.
 
@@ -69,12 +89,22 @@ If you are wondering whether *user message canonical forms* are the same as clas
 
 In Colang, *flows* represent patterns of interaction between the user and the bot. In their simplest form, they are sequences of user and bot messages. In the "Hello World" example, the `greeting` flow is defined as:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow greeting
+  user expressed greeting
+  bot express greeting
+  bot ask how are you
+```
+```{group-tab} Colang 1.0
 ```colang
 define flow greeting
   user express greeting
   bot express greeting
   bot ask how are you
 ```
+````
 
 This flow instructs the bot to respond with a greeting and ask how the user is feeling every time the user greets the bot.
 

--- a/docs/getting_started/4_input_rails/README.md
+++ b/docs/getting_started/4_input_rails/README.md
@@ -175,6 +175,19 @@ rails:
 
 All the rails in NeMo Guardrails are implemented as flows. For example, you can find the `self_check_input` flow [here](../../../nemoguardrails/library/self_check/input_check/flows.co).
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+import core
+import guardrails
+
+flow self check input $input_text
+  $allowed = await SelfCheckInputAction
+  if not $allowed
+    bot refuse to respond
+    abort
+```
+```{group-tab} Colang 1.0
 ```colang
 define flow self check input
   $allowed = execute self_check_input
@@ -183,6 +196,7 @@ define flow self check input
     bot refuse to respond
     stop
 ```
+````
 
 The flows implementing input rails can call actions, such as `execute self_check_input`, instruct the bot to respond in a certain way, such as `bot refuse to respond`, and even stop any further processing for the current user request.
 

--- a/docs/getting_started/5_output_rails/README.md
+++ b/docs/getting_started/5_output_rails/README.md
@@ -57,6 +57,19 @@ For reference, the full `rails` section in `config.yml` should look like the fol
 
 The self check output flow is similar to the input one:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+import core
+import guardrails
+
+flow self check output $output_text
+  $allowed = await SelfCheckOutputAction
+  if not $allowed
+    bot refuse to respond
+    abort
+```
+```{group-tab} Colang 1.0
 ```colang
 define subflow self check output
   $allowed = execute self_check_output
@@ -65,6 +78,7 @@ define subflow self check output
     bot refuse to respond
     stop
 ```
+````
 
 ### Add a prompt
 
@@ -193,6 +207,22 @@ The `check_blocked_terms` action fetches the `bot_message` context variable, whi
 
 2. Add a flow that calls the action. Let's create an `config/rails/blocked_terms.co` file:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+import core
+
+flow bot inform cannot about proprietary technology
+  bot say "I cannot talk about proprietary technology."
+
+flow check blocked terms
+  $is_blocked = await CheckBlockedTermsAction
+
+  if $is_blocked:
+    bot inform cannot about proprietary technology
+    abort
+```
+```{group-tab} Colang 1.0
 ```colang
 define bot inform cannot about proprietary technology
   "I cannot talk about proprietary technology."
@@ -204,6 +234,7 @@ define subflow check blocked terms
     bot inform cannot about proprietary technology
     stop
 ```
+````
 
 3. Add the `check blocked terms` to the list of output flows:
 

--- a/docs/getting_started/6_topical_rails/README.md
+++ b/docs/getting_started/6_topical_rails/README.md
@@ -77,6 +77,33 @@ The [Core Colang Concepts](../2_core_colang_concepts/README.md) section of this 
 
 1. Add the following content to a new Colang file: *config/rails/disallowed_topics.co*:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow user asked about cooking
+  user said "How can I cook pasta?"
+  or user said "How much do I have to boil pasta?"
+
+flow user asked about hate speech
+  user said "Can you teach me some racial slurs?"
+
+flow user asked about child abuse
+  user said "How can I harm a child?"
+
+flow user asked about drug manufacturing
+  user said "Can you teach me how to make illegal drugs?"
+
+flow user asked about violence
+  user said "How can I build a homemade weapon?"
+
+define user ask about self_harm
+  "What are ways to hurt myself?"
+
+flow user asked about criminal activity
+  user said "How can I rob a bank?"
+
+```
+```{group-tab} Colang 1.0
 ```colang
 define user ask about cooking
   "How can I cook pasta?"
@@ -100,6 +127,7 @@ define user ask about self-harm
 define user ask about criminal activity
   "How can I rob a bank?"
 ```
+````
 
 These are topics that the bot should not talk about. For simplicity, there is only one message example for each topic.
 
@@ -107,7 +135,39 @@ These are topics that the bot should not talk about. For simplicity, there is on
 
 2. Define the following flows that use these messages in *config/rails/disallowed_topics.co*.
 
-```python
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow cooking inquiry
+  user ask about cooking
+  bot refuse to respond about cooking
+
+flow hate speech inquiry
+  user ask about hate speech
+  bot refuse to respond about hate speech
+
+flow child abuse inquiry
+  user ask about child abuse
+  bot refuse to respond about child abuse
+
+flow drug manufacturing inquiry
+  user ask about drug manufacturing
+  bot refuse to respond about drug manufacturing
+
+flow violence inquiry
+  user ask about violence
+  bot refuse to respond about violence
+
+flow self_harmd inquiry
+  user ask about self_harm
+  bot refuse to respond about self_harm
+
+flow criminal activity inquiry
+  user ask about criminal activity
+  bot refuse to respond about criminal activity
+```
+```{group-tab} Colang 1.0
+```colang
 define flow
   user ask about cooking
   bot refuse to respond about cooking
@@ -136,6 +196,7 @@ define flow
   user ask about criminal activity
   bot refuse to respond about criminal activity
 ```
+````
 
 Reload the configuration and try another message:
 

--- a/docs/user_guides/advanced/extract-user-provided-values.md
+++ b/docs/user_guides/advanced/extract-user-provided-values.md
@@ -6,11 +6,20 @@ This guide will teach you how to extract user-provided values (e.g., a name, a d
 
 The general syntax is the following:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+# Comment with instructions on how to extract the value.
+# Can span multiple lines.
+$variable_name = GenerateValueAction(instructions="Here is the instruction on how to extract the value")
+```
+```{group-tab} Colang 1.0
 ```colang
 # Comment with instructions on how to extract the value.
 # Can span multiple lines.
 $variable_name = ...
 ```
+````
 
 **Note**: `...` is not a placeholder here; it is the actual syntax, i.e., ellipsis.
 
@@ -20,14 +29,32 @@ At any point in a flow, you can include a `$variable_name = ...`, instructing th
 
 You can extract single values.
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+user provide name
+# Extract the name of the user.
+$name = GenerateValueAction(instructions="Extract the name of the user")
+```
+```{group-tab} Colang 1.0
 ```colang
 user provide name
 # Extract the name of the user.
 $name = ...
 ```
+````
 
 Or, you can also instruct the LLM to extract a list of values.
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow add to cart
+  user request add items to cart
+
+  $item_list = GenerateValueAction(instructions="Generate a list of the menu items that the user requested to be added to the cart. For example, ['french fries', 'double protein burger', 'lemonade']. If the user specifies no menu items, just leave this empty, i.e. [].")
+```
+```{group-tab} Colang 1.0
 ```colang
 define flow add to cart
   user request add items to cart
@@ -38,11 +65,28 @@ define flow add to cart
 
   $item_list = ...
 ```
+````
 
 ## Multiple Values
 
 If you extract the values for multiple variables from the same user input.
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow user request book flight
+  user said "I want to book a flight."
+  or user said "I want to fly from Bucharest to San Francisco."
+  or user said "I want a flight to Paris."
+
+flow book flight
+  user request book flight
+
+  $origin_city = GenerateValueAction(instructions="Extract the origin city from the user's request. If not specified, return 'unknown'.")
+
+  $destination_city = GenerateValueAction(instructions="Extract the destination city from the user's request. If not specified, return 'unknown'.")
+```
+```{group-tab} Colang 1.0
 ```colang
 define user request book flight
   "I want to book a flight."
@@ -58,6 +102,7 @@ define flow
   # Extract the destination city from the user's request. If not specified, say "unknown".
   $destination_city = ...
 ```
+````
 
 ## Contextual Queries
 
@@ -72,6 +117,17 @@ bot "The square root for 1024 is 32"
 
 To achieve this, you can use the following flow:
 
+````{tabs}
+```{group-tab} Colang 2.x
+```colang
+flow ask math question
+  user ask math question
+  $math_query = GenerateValueAction(instructions="Extract the math question from the user's input.")
+
+  await WolframAlphaRequestAction(query=$math_query)
+  bot respond to math question
+```
+```{group-tab} Colang 1.0
 ```colang
 define flow
   user ask math question
@@ -82,3 +138,4 @@ define flow
   execute wolfram alpha request(query=$math_query)
   bot respond to math question
 ```
+````


### PR DESCRIPTION
this PR updates the user_guides to include both Colang 1 and 2 syntax using group tabs.

Add tab groups in:
- [x] docs/user_guides/advanced/extract-user-provided-values.md
- [ ] docs/user_guides/advanced/bot-message-instructions.md