### PR TITLE
Fix gpt-3.5-turbo-instruct prompt.

### DIFF
--- a/nemoguardrails/llm/prompts/openai-gpt35-instruct.yml
+++ b/nemoguardrails/llm/prompts/openai-gpt35-instruct.yml
@@ -1,2 +1,0 @@
-# Prompts for OpenAI gpt-3.5-turbo-instruct.
-prompts: []

--- a/nemoguardrails/llm/prompts/openai.yml
+++ b/nemoguardrails/llm/prompts/openai.yml
@@ -1,0 +1,118 @@
+# Collection of all the prompts
+prompts:
+    # GENERAL PROMPTS
+
+    - task: general
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          {{ general_instructions }}
+
+          {{ history | user_assistant_sequence }}
+          Assistant:
+
+    # Prompt for detecting the user message canonical form.
+    - task: generate_user_intent
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # This is how the user talks:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          # Choose intent from this list: {{ potential_user_intents }}
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+
+    # Prompt for generating the next steps.
+    - task: generate_next_steps
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation | remove_text_messages }}
+
+          # This is how the bot thinks:
+          {{ examples | remove_text_messages}}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) | remove_text_messages}}
+          {{ history | colang | remove_text_messages}}
+
+    # Prompt for generating the bot message from a canonical form.
+    - task: generate_bot_message
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          {% if relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ relevant_chunks }}
+          ```
+          {% endif %}
+
+          # This is how the bot talks:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+
+    # Prompt for generating the user intent, next steps and bot message in a single call.
+    - task: generate_intent_steps_message
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # For each user message, generate the next steps and finish with the bot message.
+          # These are some examples how the bot thinks:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+
+    # Prompt for generating the value of a context variable.
+    - task: generate_value
+      models:
+        - openai/gpt-3.5-turbo-instruct
+      content: |-
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # This is how the bot thinks:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+          # {{ instructions }}
+          ${{ var_name }} =

--- a/tests/test_llm_task_manager.py
+++ b/tests/test_llm_task_manager.py
@@ -153,7 +153,7 @@ def test_prompt_length_exceeded_empty_events():
             prompts:
             - task: generate_user_intent
               models:
-              - gpt-3.5-turbo-instruct
+              - openai/gpt-3.5-turbo-instruct
               max_length: 2000
               content: |-
                 {{ general_instructions }}
@@ -195,7 +195,7 @@ def test_prompt_length_exceeded_compressed_history():
             prompts:
             - task: generate_user_intent
               models:
-              - gpt-3.5-turbo-instruct
+              - openai/gpt-3.5-turbo-instruct
               max_length: 3000
               content: |-
                 {{ general_instructions }}
@@ -257,7 +257,7 @@ def test_stop_configuration_parameter():
             prompts:
             - task: generate_user_intent
               models:
-              - gpt-3.5-turbo-instruct
+              - openai/gpt-3.5-turbo-instruct
               stop:
               - <<end>>
               - <<stop>>


### PR DESCRIPTION
The change in default prompts coupled with the partial name matching for task templates (added as part of Llama-3 prompts improvements) resulted in `gpt-3.5-turbo-instruct` using the prompts for `gpt-3.5-turbo` (which are chat templates, and not working great). This PR adds back the original prompts explicitly for `gpt-3.5-turbo-instruct`. 