### PR TITLE
Add the `relevant_chunks` to the gpt-3.5 general prompt template.

### DIFF
--- a/nemoguardrails/llm/prompts/openai.yml
+++ b/nemoguardrails/llm/prompts/openai.yml
@@ -8,6 +8,13 @@ prompts:
       content: |-
           {{ general_instructions }}
 
+          {% if relevant_chunks != None and relevant_chunks != '' %}
+            This is some relevant context:
+            ```markdown
+            {{ relevant_chunks }}
+            ```
+          {% endif %}
+
           {{ history | user_assistant_sequence }}
           Assistant:
 


### PR DESCRIPTION
The `relevant_chunks` were missing from the general prompt for `gpt-3.5-turbo-instruct` model. 