### PR TITLE
Fix/output parser deprecation warning

### DIFF
--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -66,11 +66,6 @@ async def self_check_facts(
     if llm_task_manager.has_output_parser(task):
         result = llm_task_manager.parse_task_output(task, output=response)
     else:
-        log.warn(
-            f"Deprecation Warning: Output parser is not registered for the task. "
-            f"The correct way is to register the 'output_parser' in the prompts.yml for {task.value}. "
-            "This behavior will be deprecated in future versions.",
-        )
         result = llm_task_manager.output_parsers["is_content_safe"](response)
 
     is_not_safe, _ = result

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -78,11 +78,6 @@ async def self_check_input(
             result = llm_task_manager.parse_task_output(task, output=response)
 
         else:
-            log.warn(
-                f"Deprecation Warning: Output parser is not registered for the task. "
-                f"The correct way is to register the 'output_parser' in the prompts.yml for {task.value}. "
-                "This behavior will be deprecated in future versions.",
-            )
             result = llm_task_manager.output_parsers["is_content_safe"](response)
 
         is_safe, _ = result

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -82,11 +82,6 @@ async def self_check_output(
         if llm_task_manager.has_output_parser(task):
             result = llm_task_manager.parse_task_output(task, output=response)
         else:
-            log.warn(
-                f"Deprecation Warning: Output parser is not registered for the task. "
-                f"The correct way is to register the 'output_parser' in the prompts.yml for {task.value}. "
-                "This behavior will be deprecated in future versions.",
-            )
             result = llm_task_manager.output_parsers["is_content_safe"](response)
 
         is_safe, _ = result

--- a/tests/test_rails_config.py
+++ b/tests/test_rails_config.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+
+from nemoguardrails import RailsConfig
+
+
+def test_check_output_parser_exists(caplog):
+    caplog.set_level(logging.INFO)
+    values = {
+        "prompts": [
+            {"task": "self_check_input", "output_parser": None},
+            {"task": "self_check_facts", "output_parser": "parser1"},
+            {"task": "self_check_output", "output_parser": "parser2"},
+        ]
+    }
+
+    result = RailsConfig.check_output_parser_exists(values)
+
+    assert result == values
+    assert (
+        "Deprecation Warning: Output parser is not registered for the task."
+        in caplog.text
+    )
+    assert "self_check_input" in caplog.text


### PR DESCRIPTION
- Add a new root validator to the `RailsConfig` class to check if an output
parser is registered for each task. If not, a deprecation warning is
logged. This change is in preparation for a future version where
registering the 'output_parser' in the prompts.yml for each task will
be mandatory.

- Remove the deprecation warnings related to output parser registration
from the self_check_facts, self_check_input, and self_check_output
actions. The warnings are now handled in the RailsConfig class.

Pending:
- [x] Add tests
- [x] double check the `tasks_requiring_output_parser` with @drazvan 