### PR TITLE
Fix: pass config and kwargs to passthrough_fn runnable for issue 665

### DIFF
--- a/nemoguardrails/integrations/langchain/utils.py
+++ b/nemoguardrails/integrations/langchain/utils.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from functools import partial, wraps
+
+
+def async_wrap(func):
+    @wraps(func)
+    async def run(*args, loop=None, executor=None, **kwargs):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        pfunc = partial(func, *args, **kwargs)
+        return await loop.run_in_executor(executor, pfunc)
+
+    return run

--- a/tests/test_runnable_rails.py
+++ b/tests/test_runnable_rails.py
@@ -68,6 +68,24 @@ def test_string_in_string_out_with_verbose_flag():
     assert result == "Paris."
 
 
+def test_configurable_passed_to_invoke():
+    llm = FakeLLM(
+        responses=[
+            "Paris.",
+        ]
+    )
+    config = RailsConfig.from_content(config={"models": []})
+    rails = RunnableRails(config, llm=llm)
+
+    prompt = PromptTemplate.from_template("The capital of {param1} ")
+    chain = prompt | (rails | llm)
+
+    configurable = {"configurable": {"param1": "value1", "param2": "value2"}}
+    result = chain.invoke({"param1": "France"}, config=configurable)
+
+    assert result == "Paris."
+
+
 def test_string_in_string_out_pipe_syntax():
     llm = FakeLLM(
         responses=[


### PR DESCRIPTION
fix: updated the code to pass config and kwargs to passthrough_fn

also wrapped synchronous runnable into asynchronous so that it stays consistent with all synchronous runnables

[issue link](https://github.com/NVIDIA/NeMo-Guardrails/issues/665)