### PR TITLE
Feature/extend debug cli

### DIFF
--- a/CHANGELOG-Colang.md
+++ b/CHANGELOG-Colang.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [#703](https://github.com/NVIDIA/NeMo-Guardrails/pull/703) Add bot configuration as variable `$system.config`.
 * [#709](https://github.com/NVIDIA/NeMo-Guardrails/pull/709) Add basic support for most OpenAI and LLame 3 models.
 * [#712](https://github.com/NVIDIA/NeMo-Guardrails/pull/712) Add interaction loop priority levels for flows.
+* [#717](https://github.com/NVIDIA/NeMo-Guardrails/pull/717) Add CLI chat debugging commands.
 
 ### Changed
 

--- a/CHANGELOG-Colang.md
+++ b/CHANGELOG-Colang.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [#673](https://github.com/NVIDIA/NeMo-Guardrails/pull/673) Add support for new Colang 2 keyword `deactivate`.
 * [#703](https://github.com/NVIDIA/NeMo-Guardrails/pull/703) Add bot configuration as variable `$system.config`.
 * [#709](https://github.com/NVIDIA/NeMo-Guardrails/pull/709) Add basic support for most OpenAI and LLame 3 models.
+* [#712](https://github.com/NVIDIA/NeMo-Guardrails/pull/712) Add interaction loop priority levels for flows.
 
 ### Changed
 

--- a/docs/colang_2/language_reference/development-and-debugging.rst
+++ b/docs/colang_2/language_reference/development-and-debugging.rst
@@ -13,8 +13,8 @@ Currently, the Colang story designing and building environment is fairly limited
 Integrated Development Environment (IDE)
 -----------------------------------------
 
-- We suggest using `Visual Studio Code <https://code.visualstudio.com/>`_ and the Colang highlighting extension (`Github link <../../../vscode_extension>`_) to help with highlighting Colang code.
-- You can use the Visual Studio Code launch setting to run a Colang story with nemoguardrails in a python environment by pressing F5 (`launch.json <../../../.vscode/launch.json>`_)
+- We suggest using `Visual Studio Code <https://code.visualstudio.com/>`_ and the Colang highlighting extension (`Github link <https://github.com/NVIDIA/NeMo-Guardrails/tree/main/vscode_extension>`_) to help with highlighting Colang code.
+- You can use the Visual Studio Code launch setting to run a Colang story with nemoguardrails in a python environment by pressing F5 (`launch.json <https://github.com/NVIDIA/NeMo-Guardrails/blob/main/.vscode/launch.json>`_)
 - You can show generated and received events by adding the ``--verbose`` flag when starting nemoguardrails, that will also show all generated LLM prompts and responses
 - To see even more details and show the internal run-time logs use ``--debug-level=INFO`` or set it equal to ``DEBUG``
 
@@ -37,7 +37,7 @@ To help debugging your Colang flows you can use the print statement ``print <exp
 
     Hi
 
-Alternatively, use the log statement ``log <expression>`` to append to the logging shown in the verbose mode, which will appear as "Colang debug info: <expression>".
+Alternatively, use the log statement ``log <expression>`` to append to the logging shown in the verbose mode, which will appear as "Colang Log <flow_instance_uid> :: <expression>".
 
 Furthermore, the Colang function ``flows_info`` can be used to return more information about a flow instance:
 
@@ -70,6 +70,49 @@ Furthermore, the Colang function ``flows_info`` can be used to return more infor
     }
 
 Where ``pretty_str`` converts the returned dictionary object to a nicely formatted string. If no parameter is provided to the function it will return a dictionary containing all the currently active flow instances.
+
+-------------------------
+CLI Debugging Commands
+-------------------------
+
+The NeMo Guardrail CLI provides a couple of additional debugging commands that always start with the ``!`` character, e.g.:
+
+.. code-block:: text
+
+    > !list-flows
+    ┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ID ┃ Flow Name                                 ┃ Loop                            ┃ Flow Instances          ┃ Source                          ┃
+    ┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ 1  │ tracking visual choice selection state    │ named ('state_tracking')        │ 924ad                   │ /colang/v2_x/library/avatars.co │
+    │ 2  │ tracking bot talking state                │ named ('state_tracking')        │ 28804                   │ /colang/v2_x/library/core.co    │
+    │ 3  │ wait                                      │ new                             │ 9e18b                   │ /colang/v2_x/library/timing.co  │
+    │ 4  │ user was silent                           │ named ('user_was_silent')       │ c1dfd                   │ /colang/v2_x/library/timing.co  │
+    │ 5  │ polling llm request response              │ named ('llm_response_polling')  │ a003b                   │ /colang/v2_x/library/llm.co     │
+    │ 6  │ continuation on unhandled user utterance  │ parent                          │ 342c6                   │ /colang/v2_x/library/llm.co     │
+    │ 7  │ automating intent detection               │ parent                          │ c5c0a                   │ /colang/v2_x/library/llm.co     │
+    │ 8  │ marking user intent flows                 │ named ('intent_log')            │ ad2b4                   │ /colang/v2_x/library/llm.co     │
+    │ 9  │ logging marked user intent flows          │ named ('intent_log')            │ a5dd9                   │ /colang/v2_x/library/llm.co     │
+    │ 10 │ marking bot intent flows                  │ named ('intent_log')            │ 8873e                   │ /colang/v2_x/library/llm.co     │
+    │ 11 │ logging marked bot intent flows           │ named ('intent_log')            │ 3d331                   │ /colang/v2_x/library/llm.co     │
+    │ 12 │ user has selected choice                  │ parent                          │ 78b3b,783b6,c4186,cd667 │ /colang/v2_x/library/avatars.co │
+    │ 13 │ user interrupted bot talking              │ parent                          │ 6e576                   │ /colang/v2_x/library/avatars.co │
+    │ 14 │ bot posture                               │ parent                          │ d9f32                   │ /colang/v2_x/library/avatars.co │
+    │ 15 │ handling bot talking interruption         │ named ('bot_interruption')      │ 625f1                   │ /colang/v2_x/library/avatars.co │
+    │ 16 │ managing idle posture                     │ named ('managing_idle_posture') │ 0bfe3                   │ /colang/v2_x/library/avatars.co │
+    │ 17 │ _user_said                                │ parent                          │ db5e4,d2cb3,b7b85,095e0 │ /colang/v2_x/library/core.co    │
+    │ 18 │ _user_said_something_unexpected           │ parent                          │ cb676                   │ /colang/v2_x/library/core.co    │
+    │ 19 │ user said                                 │ parent                          │ c4a05,45f2c,cd4ab,fecc2 │ /colang/v2_x/library/core.co    │
+    │ 20 │ bot started saying something              │ parent                          │ fc2a7,8d5f1             │ /colang/v2_x/library/core.co    │
+    │ 21 │ notification of colang errors             │ named ('colang_errors_warning') │ cd5a8                   │ /colang/v2_x/library/core.co    │
+    │ 22 │ notification of undefined flow start      │ parent                          │ 20d10                   │ /colang/v2_x/library/core.co    │
+    │ 23 │ wait indefinitely                         │ parent                          │ 3713b                   │ /colang/v2_x/library/core.co    │
+    └────┴───────────────────────────────────────────┴─────────────────────────────────┴─────────────────────────┴─────────────────────────────────┘
+
+.. code-block:: colang
+    :caption: All CLI debugging commands
+
+    list-flows [--all] [--order_by_name] # Shows all active flows in a table in order of their interaction loop priority and name
+    tree # Shows the flow hierarchy tree of all active flows
 
 -------------
 Useful Flows

--- a/docs/colang_2/language_reference/development-and-debugging.rst
+++ b/docs/colang_2/language_reference/development-and-debugging.rst
@@ -31,7 +31,7 @@ To help debugging your Colang flows you can use the print statement ``print <exp
         user said something as $flow
         print $flow.transcript
 
-.. code-block:: text
+.. code-block:: console
 
     > Hi
 
@@ -75,44 +75,100 @@ Where ``pretty_str`` converts the returned dictionary object to a nicely formatt
 CLI Debugging Commands
 -------------------------
 
-The NeMo Guardrail CLI provides a couple of additional debugging commands that always start with the ``!`` character, e.g.:
+The NeMo Guardrail CLI provides a couple of additional debugging commands that always start with the ``!`` character:
 
-.. code-block:: text
+.. code-block:: console
 
     > !list-flows
-    ┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-    ┃ ID ┃ Flow Name                                 ┃ Loop                            ┃ Flow Instances          ┃ Source                          ┃
-    ┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-    │ 1  │ tracking visual choice selection state    │ named ('state_tracking')        │ 924ad                   │ /colang/v2_x/library/avatars.co │
-    │ 2  │ tracking bot talking state                │ named ('state_tracking')        │ 28804                   │ /colang/v2_x/library/core.co    │
-    │ 3  │ wait                                      │ new                             │ 9e18b                   │ /colang/v2_x/library/timing.co  │
-    │ 4  │ user was silent                           │ named ('user_was_silent')       │ c1dfd                   │ /colang/v2_x/library/timing.co  │
-    │ 5  │ polling llm request response              │ named ('llm_response_polling')  │ a003b                   │ /colang/v2_x/library/llm.co     │
-    │ 6  │ continuation on unhandled user utterance  │ parent                          │ 342c6                   │ /colang/v2_x/library/llm.co     │
-    │ 7  │ automating intent detection               │ parent                          │ c5c0a                   │ /colang/v2_x/library/llm.co     │
-    │ 8  │ marking user intent flows                 │ named ('intent_log')            │ ad2b4                   │ /colang/v2_x/library/llm.co     │
-    │ 9  │ logging marked user intent flows          │ named ('intent_log')            │ a5dd9                   │ /colang/v2_x/library/llm.co     │
-    │ 10 │ marking bot intent flows                  │ named ('intent_log')            │ 8873e                   │ /colang/v2_x/library/llm.co     │
-    │ 11 │ logging marked bot intent flows           │ named ('intent_log')            │ 3d331                   │ /colang/v2_x/library/llm.co     │
-    │ 12 │ user has selected choice                  │ parent                          │ 78b3b,783b6,c4186,cd667 │ /colang/v2_x/library/avatars.co │
-    │ 13 │ user interrupted bot talking              │ parent                          │ 6e576                   │ /colang/v2_x/library/avatars.co │
-    │ 14 │ bot posture                               │ parent                          │ d9f32                   │ /colang/v2_x/library/avatars.co │
-    │ 15 │ handling bot talking interruption         │ named ('bot_interruption')      │ 625f1                   │ /colang/v2_x/library/avatars.co │
-    │ 16 │ managing idle posture                     │ named ('managing_idle_posture') │ 0bfe3                   │ /colang/v2_x/library/avatars.co │
-    │ 17 │ _user_said                                │ parent                          │ db5e4,d2cb3,b7b85,095e0 │ /colang/v2_x/library/core.co    │
-    │ 18 │ _user_said_something_unexpected           │ parent                          │ cb676                   │ /colang/v2_x/library/core.co    │
-    │ 19 │ user said                                 │ parent                          │ c4a05,45f2c,cd4ab,fecc2 │ /colang/v2_x/library/core.co    │
-    │ 20 │ bot started saying something              │ parent                          │ fc2a7,8d5f1             │ /colang/v2_x/library/core.co    │
-    │ 21 │ notification of colang errors             │ named ('colang_errors_warning') │ cd5a8                   │ /colang/v2_x/library/core.co    │
-    │ 22 │ notification of undefined flow start      │ parent                          │ 20d10                   │ /colang/v2_x/library/core.co    │
-    │ 23 │ wait indefinitely                         │ parent                          │ 3713b                   │ /colang/v2_x/library/core.co    │
-    └────┴───────────────────────────────────────────┴─────────────────────────────────┴─────────────────────────┴─────────────────────────────────┘
+    ┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ ID ┃ Flow Name                                 ┃ Loop (Priority | Type | Id)   ┃ Flow Instances    ┃ Source                                    ┃
+    ┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ 1  │ tracking bot talking state                │ 10 │ Named │ 'state_tracking' │ 4d0cb,3ea17,b3b49 │ /colang/v2_x/library/core.co              │
+    │ 2  │ tracking user talking state               │ 10 │ Named │ 'state_tracking' │                   │ /colang/v2_x/library/core.co              │
+    │ 3  │ tracking visual choice selection state    │ 10 │ Named │ 'state_tracking' │ fa0f8,196ad       │ /colang/v2_x/library/avatars.co           │
+    │ 4  │ _bot_say                                  │ 0 │ parent                    │ b6036             │ /colang/v2_x/library/core.co              │
+    │ 5  │ _user_said                                │ 0 │ parent                    │ 303c3,565f7,cca80 │ /colang/v2_x/library/core.co              │
+    │ 6  │ _user_said_something_unexpected           │ 0 │ parent                    │ 1b5f7,41f02       │ /colang/v2_x/library/core.co              │
+    │ 7  │ _user_saying                              │ 0 │ parent                    │ a65e9             │ /colang/v2_x/library/core.co              │
+    │ 8  │ automating intent detection               │ 0 │ parent                    │ c7ead             │ /colang/v2_x/library/llm.co               │
+    │ 9  │ await_flow_by_name                        │ 0 │ parent                    │ 5f7ef             │ /colang/v2_x/library/core.co              │
+    │ 10 │ bot answer question about france          │ 0 │ parent                    │                   │ llm_example_flows.co                      │
+    │ 11 │ bot ask                                   │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 12 │ bot ask how are you                       │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 13 │ bot ask user for age                      │ 0 │ parent                    │                   │ llm_example_flows.co                      │
+    │ 14 │ bot ask user to pick a color              │ 0 │ parent                    │                   │ llm_example_flows.co                      │
+    │ 15 │ bot asked something                       │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 16 │ bot asks email address                    │ 0 │ parent                    │                   │ show_case_back_channelling_interaction.co │
+    │ 17 │ bot asks user how the day was             │ 0 │ parent                    │                   │ show_case_back_channelling_interaction.co │
+    │ 18 │ bot attract user                          │ 0 │ parent                    │                   │ llm_example_flows.co                      │
+    │ 19 │ bot clarified something                   │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 20 │ bot clarify                               │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 21 │ bot count from a number to another number │ 0 │ parent                    │                   │ llm_example_flows.co                      │
+    │ 22 │ bot express                               │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 23 │ bot express feeling bad                   │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 24 │ bot express feeling well                  │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 25 │ bot express greeting                      │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 26 │ bot expressed something                   │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 27 │ bot gesture                               │ 0 │ parent                    │ a2528             │ /colang/v2_x/library/avatars.co           │
+    │ 28 │ bot gesture with delay                    │ 0 │ parent                    │                   │ /colang/v2_x/library/avatars.co           │
+    │ 29 │ bot inform                                │ 0 │ parent                    │ da186             │ /colang/v2_x/library/core.co              │
+    │ 30 │ bot inform about service                  │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 31 │ bot informed something                    │ 0 │ parent                    │                   │ /colang/v2_x/library/core.co              │
+    │ 32 │ bot make long pause                       │ 0 │ parent                    │                   │ demo.co                                   │
+    │ 33 │ bot make short pause                      │ 0 │ parent                    │                   │ demo.co                                   │
+    └────┴───────────────────────────────────────────┴───┴───────────────────────────┴───────────────────┴───────────────────────────────────────────┴
+
+.. code-block:: console
+
+    > !tree
+    main
+    ├── notification of undefined flow start `Excuse me, what did you say?` (fdb... ,started)
+    ├── notification of colang errors `Excuse me, what did you say?` (69c... ,started)
+    ├── automating intent detection (c7e... ,started)
+    │   ├── logging marked user intent flows (d84... ,started)
+    │   └── logging marked bot intent flows (462... ,started)
+    ├── showcase selector (742... ,started)
+    │   ├── handling bot talking interruption `inform` `stop|cancel` (dea... ,started)
+    │   │   └── > user interrupted bot talking `15` `stop|cancel` (109... ,started)
+    │   │       └── > bot started saying something (561... ,started)
+    │   ├── > user was silent `15.0` (40f... ,started)
+    │   │   └── > wait `15.0` `wait_timer_1f499f52-9634-4925-b18a-579fef485d5e` (ae4... ,started)
+    │   ├── > user picked number guessing game showcase (6bc... ,started)
+    │   │   ├── > user has selected choice `game` (b88... ,started)
+    │   │   ├── > user said `I want to play the number guessing game` (448... ,started)
+    │   │   │   └── > _user_said `I want to play the number guessing game` (303... ,started)
+    │   │   ├── > user said `Show me the game` (d32... ,started)
+    │   │   │   └── > _user_said `Show me the game` (565... ,started)
+    │   │   ├── > user said `showcase A` (3fd... ,started)
+    │   │   │   └── > _user_said `showcase A` (cca... ,started)
+    │   │   ├── > user said `First showcase` (013... ,started)
+    │   │   │   └── > _user_said `First showcase` (9d4... ,started)
+    │   │   └── > user said `re.compile('(?i)guessing game', re.IGNORECASE)` (af9... ,started)
+    │   │       └── > _user_said `re.compile('(?i)guessing game', re.IGNORECASE)` (966... ,started)
+    │   ├── > user picked multimodality showcase (e2d... ,started)
+    │   │   ├── > user has selected choice `multimodality` (f69... ,started)
+    │   │   ├── > user said `Show me the multimodality showcase` (9be... ,started)
+    │   │   │   └── > _user_said `Show me the multimodality showcase` (33f... ,started)
+    │   │   ├── > user said `multimodality` (dfe... ,started)
+    │   │   │   └── > _user_said `multimodality` (18f... ,started)
+    │   │   ├── > user said `showcase B` (aa6... ,started)
+    │   │   │   └── > _user_said `showcase B` (4c5... ,started)
+    │   │   ├── > user said `Second showcase` (205... ,started)
+    │   │   │   └── > _user_said `Second showcase` (92a... ,started)
+    │   │   └── > user said `re.compile('(?i)multimodality', re.IGNORECASE)` (b10... ,started)
+    │   │       └── > _user_said `re.compile('(?i)multimodality', re.IGNORECASE)` (d86... ,started)
+
 
 .. code-block:: colang
     :caption: All CLI debugging commands
 
-    list-flows [--all] [--order_by_name] # Shows all active flows in a table in order of their interaction loop priority and name
-    tree # Shows the flow hierarchy tree of all active flows
+    flows [--all] [--order_by_name] # Shows all (active) flows in a table in order of their interaction loop priority and name
+    tree # Shows the flow hierarchy tree of all (active) flows
+    flow [<flow_name>|<flow_instance_uid>] # Show flow or flow instance details
+    pause # Pause timer event processing such that interaction does not continue on its own
+    resume # Resume timer event processing, including the ones trigger during paus
+    restart # Reset interaction and restart the Colang script
+
 
 -------------
 Useful Flows

--- a/docs/colang_2/language_reference/more-on-flows.rst
+++ b/docs/colang_2/language_reference/more-on-flows.rst
@@ -297,12 +297,12 @@ So far, any concurrently progressing flows that resulted in different event gene
 
     .. code-block:: colang
 
-        @loop("<loop_name>")
+        @loop([id=]"<loop_name>"[,[priority=]<integer_number>])
         flow <name of flow> ...
 
     Hint: To generate a new loop name for each flow call use the loop name "NEW"
 
-By default, any flow without an explicit interaction loop inherits the interaction loop of its parent flow. Let's see now an example of a second interaction loop to design flows that augment the main interaction rather than compete with it:
+By default, any flow without an explicit interaction loop inherits the interaction loop of its parent flow and has priority level 0. Let's see now an example of a second interaction loop to design flows that augment the main interaction rather than compete with it:
 
 .. code-block:: colang
     :caption: more_on_flows/interaction_loops/main.co
@@ -355,6 +355,8 @@ The example implements two bot reaction flows that listen to the user saying "Hi
     Gesture: frown
 
     Goodbye
+
+By default, parallel flows in different interaction loops advance in order of their start or activation. This might be an important detail if e.g a global variable is set in one flow and read in another. If the order is wrong, the global variable will not be set yet when read by the other flow. In order to enforce the processing order independent of the start or activation order, you can define the interaction loop priority level using an integer. By default, any interaction loop has priority 0. A higher number defines a higher priority, and lower (negative) number a lower processing priority.
 
 
 .. _more-on-flows-flow-conflict-resolution-prioritization:

--- a/nemoguardrails/cli/debugger.py
+++ b/nemoguardrails/cli/debugger.py
@@ -76,15 +76,19 @@ def list_flows(
 
     table.add_column("ID", style="dim", width=9)
     table.add_column("Flow Name")
-    table.add_column("Loop")
+    table.add_column("Loop (Priority | Type | Id)")
     table.add_column("Flow Instances")
     table.add_column("Source")
 
-    def get_loop_type(flow_config: FlowConfig) -> str:
+    def get_loop_info(flow_config: FlowConfig) -> str:
         if flow_config.loop_type == InteractionLoopType.NAMED:
-            return flow_config.loop_type.value + f" ('{flow_config.loop_id}')"
+            return (
+                f"{flow_config.loop_priority} │ "
+                + flow_config.loop_type.value.capitalize()
+                + f" │ '{flow_config.loop_id}'"
+            )
         else:
-            return flow_config.loop_type.value
+            return f"{flow_config.loop_priority} │ " + flow_config.loop_type.value
 
     rows = []
     for flow_id, flow_config in state.flow_configs.items():
@@ -103,7 +107,7 @@ def list_flows(
                     rows.append(
                         [
                             flow_id,
-                            get_loop_type(state.flow_configs[flow_id]),
+                            get_loop_info(state.flow_configs[flow_id]),
                             ",".join(active_instances),
                             source,
                         ]
@@ -117,7 +121,7 @@ def list_flows(
             rows.append(
                 [
                     flow_id,
-                    get_loop_type(state.flow_configs[flow_id]),
+                    get_loop_info(state.flow_configs[flow_id]),
                     ",".join(instances),
                     source,
                 ]
@@ -126,7 +130,7 @@ def list_flows(
     if order_by_name:
         rows.sort(key=lambda x: x[0])
     else:
-        rows.sort(key=lambda x: -state.flow_configs[x[0]].loop_priority)
+        rows.sort(key=lambda x: (-state.flow_configs[x[0]].loop_priority, x[0]))
 
     for i, row in enumerate(rows):
         table.add_row(f"{i+1}", *row)

--- a/nemoguardrails/cli/debugger.py
+++ b/nemoguardrails/cli/debugger.py
@@ -45,6 +45,11 @@ def set_output_state(_state: State):
 
 
 @app.command()
+def restart():
+    """Restart the current Colang script."""
+
+
+@app.command()
 def list_flows(
     active: bool = typer.Option(default=False, help="Only show active flows.")
 ):

--- a/nemoguardrails/colang/v2_x/library/avatars.co
+++ b/nemoguardrails/colang/v2_x/library/avatars.co
@@ -146,7 +146,7 @@ flow bot started an action -> $action
 # State Tracking Flows
 # -----------------------------------
 
-@loop("state_tracking")
+@loop("state_tracking", 10)
 flow tracking visual choice selection state
   global $choice_selection_state
   when VisualChoiceSceneAction.Started()

--- a/nemoguardrails/colang/v2_x/library/core.co
+++ b/nemoguardrails/colang/v2_x/library/core.co
@@ -174,7 +174,7 @@ flow bot refuse to respond
 # State Tracking Flows
 # -----------------------------------
 
-@loop("state_tracking")
+@loop("state_tracking", 10)
 flow tracking bot talking state
   """tracking bot talking state in global variable $bot_talking_state."""
   global $bot_talking_state
@@ -192,7 +192,7 @@ flow tracking bot talking state
   $last_bot_script = $bot_said_flow.text
   $last_bot_message = $bot_said_flow.text
 
-@loop("state_tracking")
+@loop("state_tracking", 10)
 flow tracking user talking state
   """Track user utterance state in global variables: $user_talking_state, $last_user_transcript."""
   global $user_talking_state

--- a/nemoguardrails/colang/v2_x/runtime/flows.py
+++ b/nemoguardrails/colang/v2_x/runtime/flows.py
@@ -394,6 +394,17 @@ class FlowConfig:
         return None
 
     @property
+    def loop_priority(self) -> int:
+        """Return the interaction loop priority (default: 0)."""
+        if "loop" in self.decorators:
+            parameters = self.decorators["loop"]
+            if "priority" in parameters:
+                return parameters["priority"]
+            elif "$1" in parameters:
+                return parameters["$1"]
+        return 0
+
+    @property
     def loop_type(self) -> InteractionLoopType:
         """Return the interaction loop type."""
         loop_id = self.loop_id
@@ -803,7 +814,7 @@ class State:
     # Helper dictionary that maps from flow_id (name) to all available flow states
     flow_id_states: Dict[str, List[FlowState]] = field(default_factory=dict)
 
-    # Helper dictionary () that maps active event matchers (by event names) to relevant heads (flow_state_uid, head_uid)
+    # Helper dictionary that maps active event matchers (by event names) to relevant heads (flow_state_uid, head_uid)
     event_matching_heads: Dict[str, List[Tuple[str, str]]] = field(default_factory=dict)
 
     # Helper dictionary that maps active heads (flow_state_uid, head_uid) to event matching names

--- a/nemoguardrails/colang/v2_x/runtime/statemachine.py
+++ b/nemoguardrails/colang/v2_x/runtime/statemachine.py
@@ -691,10 +691,13 @@ def _get_all_head_candidates(state: State, event: Event) -> List[Tuple[str, str]
             state.event_matching_heads.get(InternalEvents.FLOW_FINISHED, [])
         )
 
-    # Ensure that event order is related to flow hierarchy
+    # Ensure that event order is related to interaction loop priority and secondly the flow hierarchy
     sorted_head_candidates = sorted(
         head_candidates,
-        key=lambda s: state.flow_states[s[0]].hierarchy_position,
+        key=lambda s: (
+            -1 * state.flow_configs[state.flow_states[s[0]].flow_id].loop_priority,
+            state.flow_states[s[0]].hierarchy_position,
+        ),
     )
 
     return sorted_head_candidates


### PR DESCRIPTION
Depends on https://github.com/NVIDIA/NeMo-Guardrails/pull/712. Merge that firs please.

Improves the `!list-flows` CLI debug command:
* Adds all related flow instances and interaction loop types to table
* Only show active flows ordered by loop priority by default
