### PR TITLE
Fix/cache embeddings filesystem

### DIFF
--- a/nemoguardrails/embeddings/cache.py
+++ b/nemoguardrails/embeddings/cache.py
@@ -302,11 +302,11 @@ def cache_embeddings(func):
     async def wrapper_decorator(self, texts):
         results = []
 
-        embeddings_cache = EmbeddingsCache.from_config(self.cache_config)
-
         if not self.cache_config.enabled:
             # if cache is not enabled compute embeddings for the whole input
             return await func(self, texts)
+
+        embeddings_cache = EmbeddingsCache.from_config(self.cache_config)
 
         cached_texts = {}
         uncached_texts = []


### PR DESCRIPTION
This PR prevents unnecessary initialization of the cache when it is not enabled, thus avoiding `.cache/embeddings` creation.

It partially resolves #655 