### PR TITLE
Fix/cli server command

### DIFF
--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -28,7 +28,6 @@ from nemoguardrails.cli.chat import run_chat
 from nemoguardrails.cli.migration import migrate
 from nemoguardrails.eval import cli
 from nemoguardrails.logging.verbose import set_verbose
-from nemoguardrails.server import api
 from nemoguardrails.utils import init_random_seed
 
 app = typer.Typer()
@@ -137,6 +136,9 @@ def server(
     ),
 ):
     """Start a NeMo Guardrails server."""
+
+    from nemoguardrails.server import api
+
     if config:
         # We make sure there is no trailing separator, as that might break things in
         # single config mode.

--- a/nemoguardrails/utils.py
+++ b/nemoguardrails/utils.py
@@ -266,7 +266,7 @@ def get_data_path(package_name: str, file_path: str) -> str:
     if os.path.exists(path):
         return path
 
-    raise FileNotFoundError(f"File not found: {file_path}")
+    raise FileNotFoundError(f"File not found: {path}")
 
 
 def get_examples_data_path(file_path: str) -> str:


### PR DESCRIPTION
Move import to server function scope. This prevents errors when the default `examples` or `chat-ui` folders do not exist for any reason and the user intends to use other commands like `chat`, `migrate` or `eval`.


It also improves the FileNotFoundError message
