### PR TITLE
feat: add relevant chunks prompts 

### DIFF
--- a/nemoguardrails/llm/prompts/llama3.yml
+++ b/nemoguardrails/llm/prompts/llama3.yml
@@ -194,6 +194,15 @@ prompts:
           content: "This is the current conversation between the user and the bot:"
         - "{{ history | colang | to_messages_v2}}"
 
+        - type: system
+          content: |
+            {% if context.relevant_chunks %}
+            # This is some additional context:
+            ```markdown
+            {{ context.relevant_chunks }}
+            ```
+            {% endif %}
+
         - type: user
           content: "user action: {{ user_action }}"
 
@@ -286,6 +295,15 @@ prompts:
         - type: system
           content: "This is the current conversation between the user and the bot:"
         - "{{ history | colang | to_messages_v2 }}"
+
+        - type: system
+          content: |
+            {% if context.relevant_chunks %}
+            # This is some additional context:
+            ```markdown
+            {{ context.relevant_chunks }}
+            ```
+            {% endif %}
 
         - type: system
           content: "Continuation of interaction:"

--- a/nemoguardrails/llm/prompts/llama3.yml
+++ b/nemoguardrails/llm/prompts/llama3.yml
@@ -186,15 +186,6 @@ prompts:
         - "{{ sample_conversation | to_messages_v2 }}"
 
         - type: system
-          content: |-
-              "These are the most likely user intents:"
-              {{ examples }}
-
-        - type: system
-          content: "This is the current conversation between the user and the bot:"
-        - "{{ history | colang | to_messages_v2}}"
-
-        - type: system
           content: |
             {% if context.relevant_chunks %}
             # This is some additional context:
@@ -202,6 +193,15 @@ prompts:
             {{ context.relevant_chunks }}
             ```
             {% endif %}
+
+        - type: system
+          content: |-
+              "These are the most likely user intents:"
+              {{ examples }}
+
+        - type: system
+          content: "This is the current conversation between the user and the bot:"
+        - "{{ history | colang | to_messages_v2}}"
 
         - type: user
           content: "user action: {{ user_action }}"

--- a/nemoguardrails/llm/prompts/openai-chatgpt.yml
+++ b/nemoguardrails/llm/prompts/openai-chatgpt.yml
@@ -178,15 +178,6 @@ prompts:
       - "{{ sample_conversation | to_messages_v2 }}"
 
       - type: system
-        content: |-
-          "These are the most likely user intents:"
-          {{ examples }}
-
-      - type: system
-        content: "This is the current conversation between the user and the bot:"
-      - "{{ history | colang | to_messages_v2}}"
-
-      - type: system
         content: |
           {% if context.relevant_chunks %}
           # This is some additional context:
@@ -194,6 +185,15 @@ prompts:
           {{ context.relevant_chunks }}
           ```
           {% endif %}
+
+      - type: system
+        content: |-
+          "These are the most likely user intents:"
+          {{ examples }}
+
+      - type: system
+        content: "This is the current conversation between the user and the bot:"
+      - "{{ history | colang | to_messages_v2}}"
 
       - type: user
         content: "user action: {{ user_action }}"

--- a/nemoguardrails/llm/prompts/openai-chatgpt.yml
+++ b/nemoguardrails/llm/prompts/openai-chatgpt.yml
@@ -186,6 +186,15 @@ prompts:
         content: "This is the current conversation between the user and the bot:"
       - "{{ history | colang | to_messages_v2}}"
 
+      - type: system
+        content: |
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
+
       - type: user
         content: "user action: {{ user_action }}"
 
@@ -276,6 +285,15 @@ prompts:
       - type: system
         content: "This is the current conversation between the user and the bot:"
       - "{{ history | colang | to_messages_v2 }}"
+
+      - type: system
+        content: |
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
 
       - type: system
         content: "Continuation of interaction:"

--- a/nemoguardrails/llm/prompts/openai.yml
+++ b/nemoguardrails/llm/prompts/openai.yml
@@ -164,6 +164,14 @@ prompts:
           # These are the most likely user intents:
           {{ examples }}
 
+
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
+
           # This is the current conversation between the user and the bot:
           {{ history | colang }}
 
@@ -232,6 +240,13 @@ prompts:
 
           # This is the current conversation between the user and the bot:
           {{ history | colang }}
+
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
 
           bot intent:
 


### PR DESCRIPTION
Add relevant chunks for `generate_flow_continuation` and `generate_user_intent_and_bot_action_from_user_action` tasks

tested with abc_v2 config (also for meta/llama3-70b-instruct) without kb folder.

```python
from nemoguardrails import LLMRails, RailsConfig

config = RailsConfig.from_path("./examples/bots/abc_v2")
rails = LLMRails(config)

response = rails.generate(messages=[{
    "role": "context",
    "content": {
        "relevant_chunks": """
            Employees are eligible for the following time off:
              * Vacation: 15 days per year, accrued monthly.
              * Sick leave: 25 days per year, accrued monthly.
              * Personal days: 5 days per year, accrued monthly.
              * Paid holidays: New Year's Day, Memorial Day, Independence Day, Thanksgiving Day, Christmas Day.
              * Bereavement leave: 3 days paid leave for immediate family members, 1 day for non-immediate family members. """
    }
},{
    "role": "user",
   
    "content": "How many sick leaves do employees have?"
}])
``` 

response["content"] must contain 25 days.