### PR TITLE
Fix multiline LLM output syntax error for dynamic flow generation

### DIFF
--- a/nemoguardrails/rails/llm/default_config_v2.yml
+++ b/nemoguardrails/rails/llm/default_config_v2.yml
@@ -38,6 +38,12 @@ sample_conversation: |
     bot intent: bot respond provide information about NVIDIA history
     bot action: bot say "NVIDIA is a technology company that specializes in designing and manufacturing graphics processing units (GPUs) and other computer hardware. The company was founded in 1993 by Jen-Hsun Huang, Chris Malachowsky, and Curtis Priem."
 
+    user action: user said "Give me a list of NVIDIA's major breakthroughs"
+    user intent: user asked about nvidia breakthroughs
+
+    bot intent: bot respond provide information about NVIDIA breakthroughs
+    bot action: bot say "1. GPU invention (1999): Revolutionized graphics and parallel computing.\n2. CUDA (2006): Enabled GPUs for general-purpose computing.\n3. Deep learning breakthrough (2012): Powered AlexNet's ImageNet win.\n4. RTX technology (2018): Introduced real-time ray tracing for graphics.\n5. NVIDIA AI supercomputing (2020s): Dominates AI and machine learning advancements."
+
     user action: user said "So, you are also producing keyboards?"
     user intent: user asked about keyboards
 


### PR DESCRIPTION
This PR adds one more demonstration to the sample conversation default prompts of v2 for multiline text output with `bot say` flow. Before this PR, any dynamic code generation with LLMs that needed more than one line resulted in syntax error.
Example Colang application:
```colang
import core
import llm

flow main
  activate llm continuation
```
Example application trace:
```bash
> Give a list of car manufacturers                                                                                                                                                                          
⠙ Working ...WARNING:nemoguardrails.colang.v2_x.runtime.runtime:Failed parsing a generated flow
@meta(bot_intent="bot respond provide a list of car manufacturers")
flow _dynamic_e8e6537a bot respond provide a list of car manufacturers
  bot say "Sure! Here’s a list of some well-known car manufacturers:
  1. Toyota
  2. Ford
  3. Volkswagen
  4. Honda
  5. General Motors (Chevrolet, GMC, Cadillac, Buick)
  6. BMW
  7. Mercedes-Benz
  8. Audi
  9. Nissan
  10. Hyundai
  11. Kia
  12. Subaru
  13. Tesla
  14. Fiat Chrysler Automobiles (now part of Stellantis)
  15. Volvo
  16. Land Rover
  17. Mazda
  18. Mitsubishi
  19. Jaguar
  20. Porsche
No terminal matches '"' in the current parser context, at line 3 col 11

  bot say "Sure! Here’s a list of some well-known 
          ^
Expected one of: 
	* LPAR
	* PLUS
	* COLON
	* TILDE
	* EQUAL
	* LBRACE
	* DEC_NUMBER
	* "->"
	* _AND
	* VAR_NAME
	* MINUS
	* NAME
	* _NEWLINE
	* LONG_STRING
	* RPAR
	* FLOAT_NUMBER
	* STRING
	* DOT
	* _OR
	* LSQB

Previous tokens: Token('NAME', 'say')
:
  bot say "Sure! Here’s a list of some well-known car manufacturers:
          ^
Parsing failed for LLM generated flow: `_dynamic_e8e6537a bot respond provide a list of car manufacturers`
                                                                                                                                                                                                            
>
```

By adding one more sample conversation which demonstrates that multiline outputs should be concatenated with `\n`, the aforementioned problem is mostly fixed.

There could be another workaround, which is post-processing the LLM generated flow. However, I think it's up to the LLMs discretion to generate more valid Colang flows.