### PR TITLE
Feat/migration tool sample converstaion syntax conversion

### DIFF
--- a/tests/test_cli_migration.py
+++ b/tests/test_cli_migration.py
@@ -17,7 +17,10 @@ import textwrap
 
 import pytest
 
-from nemoguardrails.cli.migration import convert_colang_2alpha_syntax
+from nemoguardrails.cli.migration import (
+    convert_colang_1_syntax,
+    convert_colang_2alpha_syntax,
+)
 
 
 class TestColang2AlphaSyntaxConversion:
@@ -117,3 +120,153 @@ class TestColang2AlphaSyntaxConversion:
         output_lines = textwrap.dedent(output_1).strip().split("\n")
 
         assert convert_colang_2alpha_syntax(input_lines) == output_lines
+
+
+class TestColang1SyntaxConversion:
+    def test_define_flow_conversion(self):
+        input_lines = ["define flow express greeting"]
+        expected_output = ["flow express greeting"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_define_subflow_conversion(self):
+        input_lines = ["define subflow my_subflow"]
+        expected_output = ["flow my_subflow"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_execute_to_await_and_pascal_case_action(self):
+        input_lines = ["execute some_action"]
+        expected_output = ["await SomeAction"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_stop_to_abort(self):
+        input_lines = ["stop"]
+        expected_output = ["abort"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_anonymous_flow_revised(self):
+        input_lines = ["flow", "user said hello"]
+        # because the flow is anonymous and only 'flow' is given, it will be converted to 'flow said hello' based on the first message
+        expected_output = ["flow said hello", "user said hello"]
+        output = convert_colang_1_syntax(input_lines)
+        # strip newline characters from the strings in the output list
+        output = [line.rstrip("\n") for line in output]
+        assert output == expected_output
+
+    def test_global_variable_assignment(self):
+        input_lines = ["$variable = value"]
+        expected_output = ["global $variable\n$variable = value"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_variable_assignment_in_await(self):
+        input_lines = ["$result = await some_action"]
+        expected_output = ["$result = await SomeAction"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_bot_say_conversion(self):
+        input_lines = ["define bot", '"Hello!"', '"How can I help you?"']
+        expected_output = [
+            "flow bot",
+            'bot say "Hello!"',
+            'or bot say "How can I help you?"',
+        ]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_user_said_conversion(self):
+        input_lines = ["define user", '"I need assistance."', '"Can you help me?"']
+        expected_output = [
+            "flow user",
+            'user said "I need assistance."',
+            'or user said "Can you help me?"',
+        ]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_create_event_to_send(self):
+        input_lines = ["    create event user_asked_question"]
+        expected_output = ["    send user_asked_question"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_config_variable_replacement(self):
+        # TODO(Rdinu): Need to see if this conversion is correct
+        input_lines = ["$config.setting = true"]
+        expected_output = [
+            "global $system.config.setting\n$system.config.setting = true"
+        ]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_flow_with_special_characters(self):
+        input_lines = ["define flow my-flow's_test"]
+        expected_output = ["flow my flow s_test"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_ellipsis_variable_assignment(self):
+        input_lines = ["# User's name", "$name = ...", "await greet_user"]
+        expected_output = [
+            "# User's name",
+            "global $name\n$name = ...",
+            "await GreetUserAction",
+        ]
+
+        expected_output = [
+            "# User's name",
+            'global $name\n$name = ... "User\'s name"',
+            "await GreetUserAction",
+        ]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    @pytest.mark.skip("not implemented conversion")
+    def test_complex_conversion(self):
+        # TODO: add bot $response to bot say $response conversion
+        input_script = """
+        define flow greeting_flow
+            when user express greeting
+                $response = execute generate_greeting
+                bot $response
+        """
+        expected_output_script = """
+        flow greeting_flow
+            when user express greeting
+                $response = await GenerateGreetingAction
+                bot say $response
+        """
+        input_lines = textwrap.dedent(input_script).strip().split("\n")
+        expected_output = textwrap.dedent(expected_output_script).strip().split("\n")
+
+        print(convert_colang_1_syntax(input_lines))
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_flow_with_execute_and_stop(self):
+        input_lines = [
+            "define flow sample_flow",
+            '    when user "Cancel"',
+            "        execute cancel_operation",
+            "        stop",
+        ]
+        expected_output = [
+            "flow sample_flow",
+            '    when user "Cancel"',
+            "        await CancelOperationAction",
+            "        abort",
+        ]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_await_camelcase_conversion(self):
+        input_lines = ["await sample_action"]
+        expected_output = ["await SampleAction"]
+        assert convert_colang_1_syntax(input_lines) == expected_output
+
+    def test_nested_flow_conversion(self):
+        input_script = """
+        define flow outer_flow
+            when condition_met
+                define subflow inner_flow
+                    execute inner_action
+        """
+        expected_output_script = """
+        flow outer_flow
+            when condition_met
+                flow inner_flow
+                    await InnerAction
+        """
+        input_lines = textwrap.dedent(input_script).strip().split("\n")
+        expected_output = textwrap.dedent(expected_output_script).strip().split("\n")
+        assert convert_colang_1_syntax(input_lines) == expected_output


### PR DESCRIPTION
This PR implements conversion logic of `sample_conversations` in config.yml as part of the migration tool.

To verify it works:

Do the migration
```sh
nemoguardrails convert --from-version '1.0' "./examples/bots/abc" --validate
```

then 
```sh
nemoguardrails chat --config=./examples/bots/abc
```

query_1: what can you do?
query_2: you are stupid