### PR TITLE
chore: Upgrade langchain-core and jinja

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,10 @@ dependencies = [
   "fastapi>=0.103.0",
   "fastembed>=0.2.2",
   "httpx>=0.24.1",
-  "jinja2>=3.1.3",
+  "jinja2>=3.1.4",
   # The 0.1.9 has a bug related to SparkLLM which breaks everything.
-  "langchain>=0.1.0,<0.3.0,!=0.1.9",
-  "langchain-core>=0.1.0,<0.3.0,!=0.1.26",
+  "langchain>=0.2.14,<0.3.0,!=0.1.9",
+  "langchain-core>=0.2.14,<0.3.0,!=0.1.26",
   "langchain-community>=0.0.16,<0.3.0",
   "lark~=1.1.7",
   "nest-asyncio>=1.5.6",


### PR DESCRIPTION
Because of known vulnerabilities, Jinja2 and Langchain have been upgraded.

- The current version of the Langchain package contains several critical and high vulnerabilities. It must be upgraded to at least version 0.2.14.

- The current Jinja2 version exposes a high-severity vulnerability that is fixed in version 3.1.4.
