### PR TITLE
fix(library): Update Cleanlab's return type

### DIFF
--- a/nemoguardrails/library/cleanlab/actions.py
+++ b/nemoguardrails/library/cleanlab/actions.py
@@ -45,9 +45,10 @@ async def call_cleanlab_api(
     cleanlab_tlm = studio.TLM()
 
     if bot_response:
-        trustworthiness_score = await cleanlab_tlm.get_trustworthiness_score_async(
+        trustworthiness_result = await cleanlab_tlm.get_trustworthiness_score_async(
             user_input, response=bot_response
         )
+        trustworthiness_score = trustworthiness_result["trustworthiness_score"]
     else:
         raise ValueError(
             "Cannot compute trustworthiness score without a valid response from the LLM"


### PR DESCRIPTION
Cleanlab's latest release (v2.5 on 09/20) to `cleanlab-studio` pypi package updates the return type of `get_trustworthiness_score_async()` method from `float` to `typeddict`. Therefore, the `trustworthiness_score` is indexed out from the typed dict.

The fix is verified after updating `pip install -U cleanlab-studio`.