### PR TITLE
Remove the user intent from llm library module

### DIFF
--- a/nemoguardrails/colang/v2_x/library/llm.co
+++ b/nemoguardrails/colang/v2_x/library/llm.co
@@ -322,6 +322,17 @@ flow tracking unhandled user intent state
 # Experimental flows (undocumented)
 # ----------------------------------
 
+# @meta(user_intent=True)
+# flow user requested a task
+#   user said "do something"
+#     or user said "can you do something"
+#     or user said "please do"
+
+flow custom instructions
+  user requested a task
+  $instructions = await GetLastUserMessageAction()
+  execute llm instruction $instructions
+
 flow execute llm instruction $instructions
   """This will create a new flow based on the provided instructions and start it."""
   activate polling llm request response
@@ -334,16 +345,3 @@ flow execute llm instruction $instructions
   match FlowStarted(flow_id=$flow_info.name, flow_instance_uid=$new_flow_instance_uid) as $event_ref
   match $event_ref.flow.Finished()
   await RemoveFlowsAction(flow_ids=[$flow_info.name])
-
-
-@meta(user_intent=True)
-flow user requested a task
-  user said "do something"
-    or user said "can you do something"
-    or user said "please do"
-
-
-flow custom instructions
-  user requested a task
-  $instructions = await GetLastUserMessageAction()
-  execute llm instruction $instructions

--- a/nemoguardrails/colang/v2_x/library/llm.co
+++ b/nemoguardrails/colang/v2_x/library/llm.co
@@ -322,17 +322,6 @@ flow tracking unhandled user intent state
 # Experimental flows (undocumented)
 # ----------------------------------
 
-# @meta(user_intent=True)
-# flow user requested a task
-#   user said "do something"
-#     or user said "can you do something"
-#     or user said "please do"
-
-flow custom instructions
-  user requested a task
-  $instructions = await GetLastUserMessageAction()
-  execute llm instruction $instructions
-
 flow execute llm instruction $instructions
   """This will create a new flow based on the provided instructions and start it."""
   activate polling llm request response


### PR DESCRIPTION
We need to remove it since otherwise it will be prompted as potential user intent in all intent derivations when llm module is included that leads to unexpected behaviours.