### PR TITLE
Feat: Upgrade LangChain to Version 0.3

### DIFF
--- a/examples/configs/rag/custom_rag_output_rails/config.py
+++ b/examples/configs/rag/custom_rag_output_rails/config.py
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from langchain.llms.base import BaseLLM
 from langchain.prompts import PromptTemplate
+from langchain_core.language_models.llms import BaseLLM
 from langchain_core.output_parsers import StrOutputParser
 
 from nemoguardrails import LLMRails

--- a/examples/configs/rag/multi_kb/config.py
+++ b/examples/configs/rag/multi_kb/config.py
@@ -23,9 +23,9 @@ import torch
 from gpt4pandas import GPT4Pandas
 from langchain.chains import RetrievalQA
 from langchain.embeddings import HuggingFaceEmbeddings
-from langchain.llms import BaseLLM
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores import FAISS
+from langchain_core.language_models.llms import BaseLLM
 from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
 
 from nemoguardrails import LLMRails, RailsConfig

--- a/examples/configs/rag/pinecone/config.py
+++ b/examples/configs/rag/pinecone/config.py
@@ -21,8 +21,8 @@ import pinecone
 from langchain.chains import RetrievalQA
 from langchain.docstore.document import Document
 from langchain.embeddings.openai import OpenAIEmbeddings
-from langchain.llms import BaseLLM
 from langchain.vectorstores import Pinecone
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import LLMRails
 from nemoguardrails.actions import action

--- a/examples/scripts/demo_llama_index_guardrails.py
+++ b/examples/scripts/demo_llama_index_guardrails.py
@@ -15,7 +15,7 @@
 
 from typing import Any, Callable, Coroutine
 
-from langchain.llms.base import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import LLMRails, RailsConfig
 

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -28,7 +28,7 @@ from time import time
 from typing import Callable, List, Optional, cast
 
 from jinja2 import Environment, meta
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.actions.llm.utils import (

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -21,7 +21,7 @@ import textwrap
 from ast import literal_eval
 from typing import Any, List, Optional, Tuple
 
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 from rich.text import Text
 
 from nemoguardrails.actions.actions import action

--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Dict, Optional
 
-from langchain.llms.base import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions.actions import action
 from nemoguardrails.actions.llm.utils import llm_call

--- a/nemoguardrails/library/factchecking/align_score/actions.py
+++ b/nemoguardrails/library/factchecking/align_score/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Optional
 
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action

--- a/nemoguardrails/library/hallucination/actions.py
+++ b/nemoguardrails/library/hallucination/actions.py
@@ -17,8 +17,8 @@ import logging
 from typing import Optional
 
 from langchain.chains import LLMChain
-from langchain.llms.base import BaseLLM
 from langchain.prompts import PromptTemplate
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action

--- a/nemoguardrails/library/llama_guard/actions.py
+++ b/nemoguardrails/library/llama_guard/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import List, Optional, Tuple
 
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call

--- a/nemoguardrails/library/patronusai/actions.py
+++ b/nemoguardrails/library/patronusai/actions.py
@@ -17,7 +17,7 @@ import logging
 import re
 from typing import List, Optional, Tuple, Union
 
-from langchain.llms.base import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call

--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Optional
 
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Optional
 
-from langchain.llms.base import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Optional
 
-from langchain.llms.base import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action

--- a/nemoguardrails/llm/helpers.py
+++ b/nemoguardrails/llm/helpers.py
@@ -19,7 +19,7 @@ from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
-from langchain.llms.base import LLM, BaseLLM
+from langchain_core.language_models.llms import LLM, BaseLLM
 
 
 def get_llm_instance_wrapper(

--- a/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
+++ b/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
@@ -21,8 +21,8 @@ from langchain_core.callbacks.manager import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import generate_from_stream
 from langchain_core.messages import BaseMessage
 from langchain_core.outputs import ChatResult
-from langchain_core.pydantic_v1 import Field
 from langchain_nvidia_ai_endpoints import ChatNVIDIA as ChatNVIDIAOriginal
+from pydantic.v1 import Field
 
 log = logging.getLogger(__name__)
 

--- a/nemoguardrails/llm/providers/nemollm.py
+++ b/nemoguardrails/llm/providers/nemollm.py
@@ -24,15 +24,15 @@ from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
-from langchain.llms.base import BaseLLM
-from langchain.pydantic_v1 import BaseModel, root_validator
 from langchain.schema import Generation
 from langchain.schema.output import GenerationChunk, LLMResult
+from langchain_core.language_models.llms import BaseLLM
+from pydantic.v1 import root_validator
 
 log = logging.getLogger(__name__)
 
 
-class NeMoLLM(BaseLLM, BaseModel):
+class NeMoLLM(BaseLLM):
     """Wrapper around NeMo LLM large language models.
 
     If NGC_API_HOST, NGC_API_KEY and NGC_ORGANIZATION_ID environment variables are set,

--- a/nemoguardrails/llm/providers/trtllm/llm.py
+++ b/nemoguardrails/llm/providers/trtllm/llm.py
@@ -21,8 +21,8 @@ from functools import partial
 from typing import Any, Dict, List, Optional
 
 from langchain.callbacks.manager import CallbackManagerForLLMRun
-from langchain.llms.base import LLM
-from langchain.pydantic_v1 import Field, root_validator
+from langchain_core.language_models.llms import BaseLLM
+from pydantic.v1 import Field, root_validator
 
 from nemoguardrails.llm.providers.trtllm.client import TritonClient
 
@@ -31,7 +31,7 @@ BAD_WORDS = [""]
 RANDOM_SEED = 0
 
 
-class TRTLLM(LLM):
+class TRTLLM(BaseLLM):
     """A custom Langchain LLM class that integrates with TRTLLM triton models.
 
     Arguments:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -25,8 +25,8 @@ import time
 import warnings
 from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type, Union, cast
 
-from langchain.llms.base import BaseLLM
 from langchain_core.language_models import BaseLanguageModel
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
 from nemoguardrails.actions.llm.utils import get_colang_history

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,9 @@ dependencies = [
   "httpx>=0.24.1",
   "jinja2>=3.1.4",
   # The 0.1.9 has a bug related to SparkLLM which breaks everything.
-  "langchain>=0.2.14,<0.3.0,!=0.1.9",
-  "langchain-core>=0.2.14,<0.3.0,!=0.1.26",
-  "langchain-community>=0.0.16,<0.3.0",
+  "langchain>=0.2.14,<0.4.0,!=0.1.9",
+  "langchain-core>=0.2.14,<0.4.0,!=0.1.26",
+  "langchain-community>=0.0.16,<0.4.0",
   "lark~=1.1.7",
   "nest-asyncio>=1.5.6",
   "prompt-toolkit>=3.0",

--- a/tests/test_configs/with_custom_llm_prompt_action_v2_x/actions.py
+++ b/tests/test_configs/with_custom_llm_prompt_action_v2_x/actions.py
@@ -16,7 +16,7 @@
 from ast import literal_eval
 from typing import Optional
 
-from langchain.llms import BaseLLM
+from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ from langchain.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
 )
-from langchain.llms.base import LLM
+from langchain_core.language_models.llms import LLM
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.colang import parse_colang_file


### PR DESCRIPTION
This pull request makes the necessary changes to upgrade LangChain to version 0.3. 

1. **Update Pydantic Import Paths**:
   - Update import paths for `pydantic.v1` to ensure compatibility with the latest version of Pydantic.
   - Suppress specific warnings related to protected namespaces in Pydantic models by adding filter to ignore them. 

2. **Update LangChain Version Constraints**:
   - Update version constraints for `langchain`, `langchain-core`, and `langchain-community` to allow versions up to <0.4.0.

3. **Refactor Import Paths for BaseLLM**:
   - Update import paths for `BaseLLM` to `langchain_core.language_models.llms` across multiple files to align with the latest version of LangChain.
   
- [x] automated test passed
- [x] run e2e tests using various configs
