### PR TITLE
Fix/nemollm test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
   "pytest>=7.2.2",
   "pytest-asyncio>=0.21.0",
   "pytest-cov>=4.1.0",
-  "pytest-httpx>=0.22.0,<0.32.0",
+  "pytest-httpx>=0.22.0",
   "streamlit>=1.37.0"
 ]
 

--- a/tests/llm_providers/test_nemollm.py
+++ b/tests/llm_providers/test_nemollm.py
@@ -127,6 +127,7 @@ async def test_greeting_async(httpx_mock):
     await chat.bot_async("Hello! How can I assist you today?")
 
 
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
 @pytest.mark.asyncio
 async def test_capabilities_async(httpx_mock):
     """
@@ -202,6 +203,7 @@ async def test_input_self_check(httpx_mock):
     await chat.bot_async("I'm sorry, I can't respond to that.")
 
 
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
 @pytest.mark.asyncio
 async def test_output_self_check(httpx_mock):
     """


### PR DESCRIPTION


version 0.32.0 of `pytest-httpx` caused `test_nemollm` to fail. Temporarily the version was constrained. This PR fixes the test to avoid such problem.

Reference:

https://github.com/Colin-b/pytest_httpx/blob/master/README.md#allow-to-register-a-response-for-more-than-one-request