### PR TITLE
refactor: use SandboxedEnvironment for Jinja2 templates

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -27,7 +27,8 @@ from functools import lru_cache
 from time import time
 from typing import Callable, List, Optional, cast
 
-from jinja2 import Environment, meta
+from jinja2 import meta
+from jinja2.sandbox import SandboxedEnvironment
 from langchain.llms import BaseLLM
 
 from nemoguardrails.actions.actions import ActionResult, action
@@ -114,7 +115,7 @@ class LLMGenerationActions:
         self.llm_task_manager = llm_task_manager
 
         # We also initialize the environment for rendering bot messages
-        self.env = Environment()
+        self.env = SandboxedEnvironment()
 
         # If set, in passthrough mode, this function will be used instead of
         # calling the LLM with the user input.

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -17,7 +17,8 @@ import logging
 from ast import literal_eval
 from typing import Any, Callable, List, Optional, Union
 
-from jinja2 import Environment, meta
+from jinja2 import meta
+from jinja2.sandbox import SandboxedEnvironment
 
 from nemoguardrails.llm.filters import (
     co_v2,
@@ -57,7 +58,7 @@ class LLMTaskManager:
         self.config = config
 
         # Initialize the environment for rendering templates.
-        self.env = Environment()
+        self.env = SandboxedEnvironment()
 
         # Register the default filters.
         self.env.filters["colang"] = colang


### PR DESCRIPTION
## Description

use SandboxedEnvironment when rendering prompt templates


- [ ] check the impact on performance (expecting to be minimal)

## Related Issue(s)

None

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
