### PR TITLE
Doc: Fix incorrect folder name & pre-commit setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To get started quickly, follow the steps below.
 3. Navigate to the project directory:
 
    ```bash
-   cd nemoguardrails
+   cd NeMo-Guardrails
    ```
 
 4. Create a virtual environment to isolate your project's dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ To get started quickly, follow the steps below.
 7. Set up pre-commit hooks:
 
    ```
-   python -m pre-commit install
+   pre-commit install
    ```
 
    This will ensure that the pre-commit checks, including Black, are run before each commit.


### PR DESCRIPTION
## Description

This PR contains a very small documentation change in the `CONTRIBUTING.md` file. The folder name in the command after cloning the repository was incorrect and facing error with pre-commit setup, and I have fixed it to reflect the correct name and command.

## Related Issue(s)

While running this:
```
python -m pre-commit install
```
/Users/.../OSS/NeMo-Guardrails/venv/bin/python: No module named pre-commit

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [X] I've updated the documentation if applicable.
- [X] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
