### PR TITLE
chore: drop support for Python 3.8

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.9', '3.10', '3.11' ]
     steps:
       - uses: actions/checkout@v4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Welcome to the NeMo Guardrails contributing guide. We're excited to have you her
 
 To get started quickly, follow the steps below.
 
-1. Ensure you have Python 3.8+ and [Git](https://git-scm.com/) installed on your system. You can check your Python version by running:
+1. Ensure you have Python 3.9+ and [Git](https://git-scm.com/) installed on your system. You can check your Python version by running:
 
    ```bash
    python --version

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ NeMo Guardrails is an open-source toolkit for easily adding *programmable guardr
 
 ## Requirements
 
-Python 3.8, 3.9, 3.10 or 3.11.
+Python 3.9, 3.10 or 3.11.
 
 NeMo Guardrails uses [annoy](https://github.com/spotify/annoy) which is a C++ library with Python bindings. To install NeMo Guardrails you will need to have the C++ compiler and dev tools installed. Check out the [Installation Guide](https://docs.nvidia.com/nemo/guardrails/getting_started/installation-guide.html#prerequisites) for platform-specific instructions.
 

--- a/docs/getting_started/installation-guide.md
+++ b/docs/getting_started/installation-guide.md
@@ -10,7 +10,7 @@ This guide walks you through the following steps to install NeMo Guardrails:
 
 ## Prerequisites
 
-Python 3.8, 3.9 or 3.10.
+Python 3.9, 3.10 or 3.11.
 
 ## Additional dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,11 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 dependencies = [
   "aiohttp>=3.9.2",


### PR DESCRIPTION
## Description

Dropping Python 3.8 support as it has reached its EOL on 2024-10-07 (https://peps.python.org/pep-0569/)


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
