### PR TITLE
Add try-catch block around rails.generate function for error handling…

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ from nemoguardrails import LLMRails, RailsConfig
 config = RailsConfig.from_path("PATH/TO/CONFIG")
 rails = LLMRails(config)
 
-completion = rails.generate(
-    messages=[{"role": "user", "content": "Hello world!"}]
-)
+try:
+  completion = rails.generate(
+      messages=[{"role": "user", "content": "Hello world!"}]
+  )
+except Exception as e:
+    completion = None
 ```
 
 Sample output:


### PR DESCRIPTION
Hey @Pouyanpi , @drazvan 

… in Readme file

## Description


"Added a try/catch block to handle errors from LLMs in Nemoguard Rails. For example, AzureModels have default security checks, and if a request fails (e.g., due to flagged content like violence), it throws an error, breaking the flow. By wrapping the rails.generate function in a try/catch block, we can prevent flow disruption and handle such errors gracefully."

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
