### PR TITLE
Fix/retrieve chunk action newline

### DIFF
--- a/nemoguardrails/actions/retrieve_relevant_chunks.py
+++ b/nemoguardrails/actions/retrieve_relevant_chunks.py
@@ -26,6 +26,7 @@ log = logging.getLogger(__name__)
 async def retrieve_relevant_chunks(
     context: Optional[dict] = None,
     kb: Optional[KnowledgeBase] = None,
+    is_colang_2: Optional[bool] = False,
 ):
     """Retrieve relevant knowledge chunks and update the context.
 
@@ -70,7 +71,14 @@ async def retrieve_relevant_chunks(
 
     else:
         # No KB is set up, we keep the existing relevant_chunks if we have them.
-        context_updates["relevant_chunks"] = context.get("relevant_chunks", "") + "\n"
+        if is_colang_2:
+            context_updates["relevant_chunks"] = context.get("relevant_chunks", "")
+            if context_updates["relevant_chunks"]:
+                context_updates["relevant_chunks"] += "\n"
+        else:
+            context_updates["relevant_chunks"] = (
+                context.get("relevant_chunks", "") + "\n"
+            )
         context_updates["relevant_chunks_sep"] = context.get("relevant_chunks_sep", [])
         context_updates["retrieved_for"] = None
 

--- a/nemoguardrails/colang/v2_x/library/llm.co
+++ b/nemoguardrails/colang/v2_x/library/llm.co
@@ -100,7 +100,7 @@ flow continuation on unhandled user utterance
 
   # retrieve relevant chunks from KB if user_message is not empty
 
-  await RetrieveRelevantChunksAction()
+  await RetrieveRelevantChunksAction(is_colang_2=True)
 
 
   #await GenerateUserIntentAction(user_action=$action, max_example_flows=20) as $action_ref
@@ -218,7 +218,7 @@ flow llm generate interaction continuation flow -> $flow_name
 
 
   # retrieve relevant chunks from KB if user_message is not empty
-  await RetrieveRelevantChunksAction()
+  await RetrieveRelevantChunksAction(is_colang_2=True)
 
 
   log 'start generating flow continuation...'

--- a/tests/test_retrieve_relevant_chunks.py
+++ b/tests/test_retrieve_relevant_chunks.py
@@ -75,3 +75,25 @@ def test_relevant_chunk_inserted_in_prompt():
     info = rails.explain()
     assert len(info.llm_calls) == 2
     assert "Test Body" in info.llm_calls[1].prompt
+
+    assert "markdown" in info.llm_calls[1].prompt
+    assert "context" in info.llm_calls[1].prompt
+
+
+def test_relevant_chunk_inserted_in_prompt_no_kb():
+    chat = TestChat(
+        config,
+        llm_completions=[
+            " user express greeting",
+            ' bot respond to aditional context\nbot action: "Hello is there anything else" ',
+        ],
+    )
+    rails = chat.app
+    messages = [
+        {"role": "user", "content": "Hi!"},
+    ]
+    new_message = rails.generate(messages=messages)
+    info = rails.explain()
+    assert len(info.llm_calls) == 2
+    assert "markdown" not in info.llm_calls[1].prompt
+    assert "context" not in info.llm_calls[1].prompt


### PR DESCRIPTION
## Description

The existence of `\n` in the relevant_chunks was introducing the context in prompts, which interfered with the behavior of CoLang 2.x. This PR adds an optional `is_colang_2` flag to handle context updates differently based on its value. 

This optional argument is necessary as the existence of `\n` was not clear to me at the time of writing this PR.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
