### PR TITLE
Feature/improve llm logs

### DIFF
--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -114,7 +114,11 @@ class LoggingCallbackHandler(AsyncCallbackHandler, StdOutCallbackHandler):
         )
 
         log.info("Invocation Params :: %s", kwargs.get("invocation_params", {}))
-        log.info("Prompt Messages :: %s", prompt, extra={"id": llm_call_info.id})
+        log.info(
+            "Prompt Messages :: %s",
+            prompt,
+            extra={"id": llm_call_info.id, "task": llm_call_info.task},
+        )
         llm_call_info.prompt = prompt
         llm_call_info.started_at = time()
 
@@ -156,7 +160,7 @@ class LoggingCallbackHandler(AsyncCallbackHandler, StdOutCallbackHandler):
         log.info(
             "Completion :: %s",
             response.generations[0][0].text,
-            extra={"id": llm_call_info.id},
+            extra={"id": llm_call_info.id, "task": llm_call_info.task},
         )
 
         llm_stats = llm_stats_var.get()
@@ -169,7 +173,9 @@ class LoggingCallbackHandler(AsyncCallbackHandler, StdOutCallbackHandler):
             for i, generation in enumerate(response.generations[0][1:]):
                 log.info("--- :: Completion %d", i + 2)
                 log.info(
-                    "Completion :: %s", generation.text, extra={"id": llm_call_info.id}
+                    "Completion :: %s",
+                    generation.text,
+                    extra={"id": llm_call_info.id, "task": llm_call_info.task},
                 )
 
         log.info("Output Stats :: %s", response.llm_output)

--- a/nemoguardrails/logging/callbacks.py
+++ b/nemoguardrails/logging/callbacks.py
@@ -60,7 +60,11 @@ class LoggingCallbackHandler(AsyncCallbackHandler, StdOutCallbackHandler):
             explain_info.llm_calls.append(llm_call_info)
 
         log.info("Invocation Params :: %s", kwargs.get("invocation_params", {}))
-        log.info("Prompt :: %s", prompts[0])
+        log.info(
+            "Prompt :: %s",
+            prompts[0],
+            extra={"id": llm_call_info.id, "task": llm_call_info.task},
+        )
         llm_call_info.prompt = prompts[0]
 
         llm_call_info.started_at = time()

--- a/nemoguardrails/logging/explain.py
+++ b/nemoguardrails/logging/explain.py
@@ -43,6 +43,7 @@ class LLMCallSummary(BaseModel):
 
 
 class LLMCallInfo(LLMCallSummary):
+    id: Optional[str] = Field(default=None, description="The unique prompt identifier.")
     prompt: Optional[str] = Field(
         default=None, description="The prompt that was used for the LLM call."
     )

--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -54,7 +54,9 @@ class VerboseHandler(logging.StreamHandler):
                 skip_print = True
                 if verbose_llm_calls:
                     console.print("")
-                    console.print(f"[cyan]LLM {title} ({record.id[:5]}..)[/]")
+                    console.print(
+                        f"[cyan]LLM {title} ({getattr(record, 'id', 'unknown')[:5]}..)[/]"
+                    )
                     for line in body.split("\n"):
                         text = Text(line, style="black on #006600", end="\n")
                         text.pad_right(console.width)
@@ -67,7 +69,7 @@ class VerboseHandler(logging.StreamHandler):
                     skip_print = True
                     console.print("")
                     console.print(
-                        f"[cyan]LLM Prompt ({record.id[:5]}..) - {record.task}[/]"
+                        f"[cyan]LLM Prompt ({getattr(record, 'id', 'unknown')[:5]}..) - {getattr(record, 'task', 'unknown')}[/]"
                     )
 
                     for line in body.split("\n"):

--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -54,7 +54,7 @@ class VerboseHandler(logging.StreamHandler):
                 skip_print = True
                 if verbose_llm_calls:
                     console.print("")
-                    console.print(f"[cyan]LLM {title}[/]")
+                    console.print(f"[cyan]LLM {title} ({record.id[:5]}..)[/]")
                     for line in body.split("\n"):
                         text = Text(line, style="black on #006600", end="\n")
                         text.pad_right(console.width)
@@ -66,6 +66,7 @@ class VerboseHandler(logging.StreamHandler):
                 if verbose_llm_calls:
                     skip_print = True
                     console.print("")
+                    console.print(f"[cyan]LLM Prompt ({record.id[:5]}..)[/]")
 
                     for line in body.split("\n"):
                         if line.strip() == "[/]":

--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -54,9 +54,7 @@ class VerboseHandler(logging.StreamHandler):
                 skip_print = True
                 if verbose_llm_calls:
                     console.print("")
-                    console.print(
-                        f"[cyan]LLM {title} ({getattr(record, 'id', 'unknown')[:5]}..)[/]"
-                    )
+                    console.print(f"[cyan]LLM {title} ({record.id[:5]}..)[/]")
                     for line in body.split("\n"):
                         text = Text(line, style="black on #006600", end="\n")
                         text.pad_right(console.width)
@@ -69,7 +67,7 @@ class VerboseHandler(logging.StreamHandler):
                     skip_print = True
                     console.print("")
                     console.print(
-                        f"[cyan]LLM Prompt ({getattr(record, 'id', 'unknown')[:5]}..) - {getattr(record, 'task', 'unknown')}[/]"
+                        f"[cyan]LLM Prompt ({record.id[:5]}..) - {record.task}[/]"
                     )
 
                     for line in body.split("\n"):

--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -66,7 +66,9 @@ class VerboseHandler(logging.StreamHandler):
                 if verbose_llm_calls:
                     skip_print = True
                     console.print("")
-                    console.print(f"[cyan]LLM Prompt ({record.id[:5]}..)[/]")
+                    console.print(
+                        f"[cyan]LLM Prompt ({record.id[:5]}..) - {record.task}[/]"
+                    )
 
                     for line in body.split("\n"):
                         if line.strip() == "[/]":


### PR DESCRIPTION
## Description

This will add a unique hash and the name of the used prompt template to each LLM request/response pair in the logging such that one can relate them when multiple request overlap each other.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
