### PR TITLE
fix(pyproject.toml): remove eval from all dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get install -y gcc g++
 # Copy and install NeMo Guardrails
 WORKDIR /nemoguardrails
 COPY . /nemoguardrails
+# pip cannot resolve dependencies if eval is part of all
 RUN pip install --no-cache-dir -e .[all]
+RUN pip install --no-cache-dir -e .[eval]
 
 # Make port 8000 available to the world outside this container
 EXPOSE 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ tracing = [
 ]
 
 all = [
-  "nemoguardrails[eval,sdd,openai,gcp, tracing]",
+  "nemoguardrails[sdd,openai,gcp,tracing]",
 ]
 dev = [
   "black==23.3.0",


### PR DESCRIPTION
## Description
Setuptools is unable to resolve the dependency graph when eval is included  in the all dependencies list. This issue is primarily caused by a limitation of pip and a conflict with streamlit. Removing eval from the all dependencies list resolves this issue. Eval can be installed separately if needed.


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
