### PR TITLE
Make `source_uid` of events configurable.

### DIFF
--- a/nemoguardrails/colang/v2_x/runtime/statemachine.py
+++ b/nemoguardrails/colang/v2_x/runtime/statemachine.py
@@ -71,6 +71,7 @@ from nemoguardrails.colang.v2_x.runtime.flows import (
     InternalEvents,
     State,
 )
+from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.utils import console, new_event_dict, new_readable_uuid, new_uuid
 
 log = logging.getLogger(__name__)
@@ -1829,7 +1830,7 @@ def _is_done_flow(flow_state: FlowState) -> bool:
 
 
 def _generate_umim_event(state: State, event: Event) -> Dict[str, Any]:
-    umim_event = create_umim_event(event, event.arguments)
+    umim_event = create_umim_event(event, event.arguments, state.rails_config)
     state.outgoing_events.append(umim_event)
     log.info("[bold violet]<- Action[/]: %s", event)
 
@@ -2385,10 +2386,14 @@ def create_internal_event(
     return event
 
 
-def create_umim_event(event: Event, event_args: Dict[str, Any]) -> Dict[str, Any]:
+def create_umim_event(
+    event: Event, event_args: Dict[str, Any], config: Optional[RailsConfig]
+) -> Dict[str, Any]:
     """Returns an outgoing UMIM event for the provided action data"""
     new_event_args = dict(event_args)
-    new_event_args["source_uid"] = "NeMoGuardrails-Colang-2.x"
+    new_event_args.setdefault(
+        "source_uid", config.event_source_uid if config else "NeMoGuardrails-Colang-2.x"
+    )
     if isinstance(event, ActionEvent) and event.action_uid is not None:
         if "action_uid" in new_event_args:
             event.action_uid = new_event_args["action_uid"]

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -508,6 +508,7 @@ def _join_config(dest_config: dict, additional_config: dict):
         "lowest_temperature",
         "enable_multi_step_generation",
         "colang_version",
+        "event_source_uid",
         "custom_data",
         "prompting_mode",
         "knowledge_base",
@@ -861,6 +862,11 @@ class RailsConfig(BaseModel):
         default=None,
         description="Weather the original prompt should pass through the guardrails configuration as is. "
         "This means it will not be altered in any way. ",
+    )
+
+    event_source_uid: str = Field(
+        default="NeMoGuardrails-Colang-2.x",
+        description="The source ID of events sent by the Colang Runtime. Useful to identify the component that has sent an event.",
     )
 
     tracing: TracingConfig = Field(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -306,7 +306,7 @@ def is_data_in_events(
     return True
 
 
-def _init_state(colang_content) -> State:
+def _init_state(colang_content, yaml_content: Optional[str] = None) -> State:
     config = create_flow_configs_from_flow_list(
         parse_colang_file(
             filename="",
@@ -316,8 +316,11 @@ def _init_state(colang_content) -> State:
         )["flows"]
     )
 
+    rails_config = None
+    if yaml_content:
+        rails_config = RailsConfig.from_content(colang_content, yaml_content)
     json.dump(config, sys.stdout, indent=4, cls=EnhancedJsonEncoder)
-    state = State(flow_states=[], flow_configs=config)
+    state = State(flow_states=[], flow_configs=config, rails_config=rails_config)
     initialize_state(state)
     print("---------------------------------")
     json.dump(state.flow_configs, sys.stdout, indent=4, cls=EnhancedJsonEncoder)

--- a/tests/v2_x/test_event_mechanics.py
+++ b/tests/v2_x/test_event_mechanics.py
@@ -57,6 +57,32 @@ def test_send_umim_action_event():
     )
 
 
+def test_change_umim_event_source_id():
+    """Test to send an UMIM event."""
+
+    content = """
+    flow main
+      send StartUtteranceBotAction(script="Hello world")
+    """
+
+    config = """
+    colang_version: "2.x"
+    event_source_uid : agent-1
+    """
+
+    state = run_to_completion(_init_state(content, config), start_main_flow_event)
+    assert is_data_in_events(
+        state.outgoing_events,
+        [
+            {
+                "type": "StartUtteranceBotAction",
+                "script": "Hello world",
+                "source_uid": "agent-1",
+            }
+        ],
+    )
+
+
 def test_match_umim_action_event():
     """Test to match an UMIM event."""
 


### PR DESCRIPTION
## Description

Provides a new rails configuration setting `event_source_uid` that if set allows users to change the default source_uid of events sent out by the Colang Runtime. This is needed to differentiate differentiate the Colang Runtime in setups with multiple runtimes (e.g. a multi-agent system).


## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
