### PR TITLE
Fix else if parsing problem

### DIFF
--- a/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
+++ b/nemoguardrails/colang/v2_x/lang/grammar/colang.lark
@@ -205,7 +205,7 @@ doc_string: LONG_STRING
 _FLOW.1: /(?<!\.)flow(?!(\s*\(|[a-zA-Z0-9_]))/
 
 _IF.1: /if/
-_ELSE_IF.1: /(elif|else\s+if)/
+_ELSE_IF.1: /(elif|else[^\S\r\n]+if)/
 _OR_WHEN.1: /(or ?when)/
 _AND.1: /(and[ \t]|(\r?\n[\t ]*)+and[ \t])/
 _OR.1: /(or[ \t]|(\r?\n[\t ]*)+or[ \t]+(?!when))/


### PR DESCRIPTION
## Description

This PR fixes a problem related to parsing nested if/else in Colang 2. The problem is that whenever there is an `if` inside an `else`, the parser considers that as an `elif` node. However, this could be problematic, as the `if` might not meant to be an `elif` to the outer `if`. Consider the following examples:
```colang
flow main
  $t = 1
  if $t == 1
    print "t is 1"
  else
    if $t == 1
      print "t is really 1"
    else
      print "t may not be 1"
```
This example results in parsing error. This is because the `else` statement of the outer `if`, is combined with the `if` after that and is considered as `elif`. Therefore, the last `else` statement is not parseable, because there is no `if` related to that anymore! If you add anything between `else` and the `if`, even an optional `:` or a comment, it will fix the parsing issue.

In this PR, I changed the `_ELSE_IF.1` definition, so it will capture any whitespace, **except newline**, between an `else` and `if`.

I have also attached the parsed tree, corresponding to the following code (removing the very last `else` from the above, so that it could be parsed).
```colang
flow main
  $t = 1
  if $t == 1
    print "t is 1"
  else
    if $t == 1
      print "t is really 1"
```
As you can see in the tree, the inner `if` is parsed as `elif`, not a nested `if`. 
![tree_incorrect](https://github.com/user-attachments/assets/6085960c-e22f-4dde-95bb-0a22f4122dbe)

The correct form, which is the result of this PR, is this:
![tree_fixed](https://github.com/user-attachments/assets/55bf65ed-2eb5-4293-a80a-bed4dc60619c)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
@Pouyanpi @drazvan @schuellc-nvidia 
