### PR TITLE
Fix/import path colang 2

### DIFF
--- a/examples/bots/abc_v2/rails.co
+++ b/examples/bots/abc_v2/rails.co
@@ -1,5 +1,6 @@
 import guardrails
-import nemoguardrails.library
+import nemoguardrails.library.self_check.output_check
+import nemoguardrails.library.self_check.input_check
 
 flow input rails $input_text
     self check input

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -51,7 +51,13 @@ colang_path_dirs = [
 standard_library_path = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "colang", "v2_x", "library")
 )
+
+# nemoguardrails/lobrary
+guardrails_stdlib_path = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
 colang_path_dirs.append(standard_library_path)
+colang_path_dirs.append(guardrails_stdlib_path)
 
 
 class Model(BaseModel):
@@ -653,7 +659,10 @@ def _load_imported_paths(raw_config: dict, colang_files: List[Tuple[str, str]]):
                 actual_path = import_path
 
             if actual_path is None:
-                raise ValueError(f"Import path `{import_path}` could not be resolved.")
+                formated_import_path = import_path.replace("/", ".")
+                raise ValueError(
+                    f"Import path '{formated_import_path}' could not be resolved.",
+                )
 
             _raw_config, _colang_files = _load_path(actual_path)
 


### PR DESCRIPTION
## Description

If you import nemoguardrails standard library in a Colang 2.x config `_load_imported_path` function fails.

**WAR**: export path to root of nemoguardrails as "COLANGPATH" env var.

**Limitation**: the standard library must be included by default, also if the user install the wheel it does not work because it needs to be set to its location in a virtual environment

**Steps to reproduce:**

```sh
cd ./examples/bots/abc_v2
nemoguardrails chat --config=.
```
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
