### PR TITLE
Download nltk's punkt_tab in align_score Dockerfile

### DIFF
--- a/nemoguardrails/library/factchecking/align_score/Dockerfile
+++ b/nemoguardrails/library/factchecking/align_score/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Download the punkt model to speed up start time
-RUN python -c "import nltk; nltk.download('punkt')"
+RUN python -c "import nltk; nltk.download('punkt_tab')"
 
 # Set the ALIGN_SCORE_PATH environment variable
 ENV ALIGN_SCORE_PATH=/app/AlignScore


### PR DESCRIPTION
## Description

Fixes an issue where `alignscore-server` (defined in [nemoguardrails/library/factchecking/align_score/Dockerfile](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/nemoguardrails/library/factchecking/align_score/Dockerfile)) throws a runtime `LookupError(resource_not_found)` error. This error seems to be due to a [breaking change in `nltk`](https://github.com/nltk/nltk/issues/3293). Please see steps below to reproduce.

cc: @drazvan 

## Steps to reproduce the error

Build `alignscore-server` Docker Image:
```sh
# from the root of NeMo-Guardrails
cd nemoguardrails/library/factchecking/align_score
docker build -t alignscore-server .
```

Run `alignscore-server`:
```sh
docker run -p 5123:5000 alignscore-server
# ...
# INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
```

Send a request to `alignscore-server` (executed from a local notebook):
```python
from nemoguardrails.library.factchecking.align_score.request import alignscore_request

await alignscore_request(
	api_url="http://localhost:5123/alignscore_base",
	evidence="Hello, world!",
	response="Hello, world!",
)
# Output: "AlignScore API request failed with status 500"
```
* Note: I get a similar behavior when `LLMRails` invokes the `alignscore_check_facts` action; which is how I encountered this issue in the first place.

Logs from `alignscore-server`:
```
INFO:     172.17.0.1:60146 - "POST /alignscore_base HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 406, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  [...]
  File "/usr/local/lib/python3.10/site-packages/nltk/tokenize/punkt.py", line 1749, in load_lang
    lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
  File "/usr/local/lib/python3.10/site-packages/nltk/data.py", line 579, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource punkt_tab not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt_tab')

  For more information see: https://www.nltk.org/data.html

  Attempted to load tokenizers/punkt_tab/english/

  Searched in:
    - '/root/nltk_data'
    - '/usr/local/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/local/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```

### After this commit

Re-build and re-run container:
```
docker build -t alignscore-server .
docker run -p 5123:5000 alignscore-server
```

Request:
```python
await alignscore_request(
	api_url="http://localhost:5123/alignscore_base",
	evidence="Hello, world!",
	response="Hello, world!",
)
# Output: 0.9991656541824341
```

Logs from `alignscore-server`:
```
INFO:     172.17.0.1:61214 - "POST /alignscore_base HTTP/1.1" 200 OK
```


## Related Issue(s)

https://github.com/nltk/nltk/issues/3293

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
