### PR TITLE
Automated Colang Standard Library (CSL) documentation tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,7 +44,10 @@
     "python.envFile": "${workspaceFolder}/.venv",
     "python.languageServer": "Pylance",
     "python.testing.pytestEnabled": true,
-    "python.testing.pytestArgs": ["${workspaceFolder}/tests"],
+    "python.testing.pytestArgs": [
+        "${workspaceFolder}/tests",
+        "${workspaceFolder}/docs/colang_2/examples"
+    ],
     "python.testing.unittestEnabled": false,
     //"python.envFile": "${workspaceFolder}/python_release.env",
 

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -7,7 +7,7 @@ pathlib.Path(__file__).parent.parent.parent.resolve()
 sys.path.append(str(pathlib.Path(__file__).parent.parent.parent.parent.resolve()))
 print(sys.path)
 
-from utils import compare_interaction_with_script
+from utils import compare_interaction_with_test_script
 
 ########################################################################################################################
 # CORE
@@ -37,7 +37,7 @@ hi
 # USAGE_END: test_user_said
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -59,7 +59,7 @@ You said: I can say whatever I want
 # USAGE_END: test_user_said_something
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -86,7 +86,7 @@ oooh
 # USAGE_END: test_user_saying
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -109,7 +109,7 @@ Gesture: nod
 # USAGE_END: test_user_saying_something
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ bot posture (stop)
 # USAGE_END: test_user_started_saying_something
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -171,7 +171,7 @@ you said something unexpected
 # USAGE_END: test_user_said_something_unexpected
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 # Bot Action Flows
@@ -194,7 +194,7 @@ Hello world!
 # USAGE_END: test_bot_say
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 # Bot Event Flows
@@ -224,7 +224,7 @@ Event: CustomEvent
 # USAGE_END: test_bot_started_saying_example
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -256,7 +256,7 @@ bot posture (stop)
 # USAGE_END: test_bot_started_saying_something
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -298,7 +298,7 @@ Gesture: shake head
 # USAGE_END: test_bot_said
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -327,7 +327,7 @@ responding to user question
 # USAGE_END: test_tracking_bot_talking_state
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -353,7 +353,7 @@ I remembered my favorite color is red
 # USAGE_END: test_tracking_user_talking_state
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -386,7 +386,7 @@ Excuse me, there was an internal Colang error.
 # USAGE_END: test_notification_of_colang_errors
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -412,7 +412,7 @@ Failed to start an undefined flow!
 # USAGE_END: test_notification_of_undefined_flow_start
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -441,7 +441,7 @@ I don't know how to respond to that!
 # USAGE_END: test_notification_of_unexpected_user_utterance
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -464,7 +464,7 @@ hello
 # USAGE_END: test_wait_indefinitely
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 ########################################################################################################################
@@ -499,7 +499,7 @@ I say this later
 # USAGE_END: test_wait
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -530,7 +530,7 @@ tick
 # USAGE_END: test_repeating_timer
         """
 
-    await compare_interaction_with_script(test_script, colang_code)
+    await compare_interaction_with_test_script(test_script, colang_code)
 
 
 @pytest.mark.asyncio
@@ -564,7 +564,7 @@ Can I help you with anything else?
 # USAGE_END: test_user_was_silent
         """
 
-    await compare_interaction_with_script(test_script, colang_code, 7.0)
+    await compare_interaction_with_test_script(test_script, colang_code, 7.0)
 
 
 @pytest.mark.asyncio
@@ -601,7 +601,7 @@ How can I help you today?
 # USAGE_END: test_user_didnt_respond
         """
 
-    await compare_interaction_with_script(test_script, colang_code, 7.0)
+    await compare_interaction_with_test_script(test_script, colang_code, 7.0)
 
 
 @pytest.mark.asyncio
@@ -638,7 +638,371 @@ order was placed successfully
 # USAGE_END: test_bot_was_silent
         """
 
-    await compare_interaction_with_script(test_script, colang_code, 5.0)
+    await compare_interaction_with_test_script(test_script, colang_code, 5.0)
+
+
+########################################################################################################################
+# LLM
+########################################################################################################################
+@pytest.mark.asyncio
+async def test_bot_say_something_like():
+    colang_code = """
+# COLANG_START: test_bot_say_something_like
+import core
+import llm
+
+flow main
+    user said something
+    bot say something like "How are you"
+
+
+# COLANG_END: test_bot_say_something_like
+    """
+
+    test_script = """
+# USAGE_START: test_bot_say_something_like
+> hi
+Hi there, how are you today?
+# USAGE_END: test_bot_say_something_like
+        """
+
+    await compare_interaction_with_test_script(
+        test_script, colang_code, llm_responses=['"Hi there, how are you today?"']
+    )
+
+
+@pytest.mark.asyncio
+async def test_polling_llm_request_response():
+    colang_code = """
+# COLANG_START: test_polling_llm_request_response
+import core
+import llm
+
+flow main
+    # Normally you don't need to activate this flow, as it is activated by llm based flows where needed.
+    activate polling llm request response
+
+    user said something
+
+    # While the response is generated the polling mechanism ensures that
+    $value = ..."ten minus one"
+    bot say $value
+
+
+# COLANG_END: test_polling_llm_request_response
+    """
+
+    test_script = """
+# USAGE_START: test_polling_llm_request_response
+> compute the value
+nine
+# USAGE_END: test_polling_llm_request_response
+        """
+
+    await compare_interaction_with_test_script(
+        test_script, colang_code, llm_responses=['"nine"']
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_continuation():
+    colang_code = """
+# COLANG_START: test_llm_continuation
+import core
+import llm
+
+flow user expressed greeting
+    user said "hi" or user said "hello"
+
+flow bot express greeting
+    bot say "Hello and welcome"
+
+flow handling greeting
+    user expressed greeting
+    bot express greeting
+
+flow main
+    activate handling greeting
+    activate llm continuation
+
+
+# COLANG_END: test_llm_continuation
+    """
+
+    test_script = """
+# USAGE_START: test_llm_continuation
+> hi there how are you
+Hello and welcome
+> what is the difference between lemons and limes
+Limes are green and lemons are yellow
+# USAGE_END: test_llm_continuation
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            "user intent: user expressed greeting",
+            "user intent: user asked fruit question",
+            'bot action: bot say "Limes are green and lemons are yellow"',
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_generating_user_intent_for_unhandled_user_utterance():
+    colang_code = """
+# COLANG_START: test_generating_user_intent_for_unhandled_user_utterance
+import core
+import llm
+
+flow user expressed goodbye
+    user said "bye" or user said "i will go now"
+
+flow bot express goodbye
+    bot say "hope to see you again soon"
+
+flow handling goodbye
+    user expressed goodbye
+    bot express goodbye
+
+flow main
+    activate generating user intent for unhandled user utterance
+    activate handling goodbye
+
+
+# COLANG_END: test_generating_user_intent_for_unhandled_user_utterance
+    """
+
+    test_script = """
+# USAGE_START: test_generating_user_intent_for_unhandled_user_utterance
+> what can you do for me
+> ok I'll leave
+hope to see you again soon
+# USAGE_END: test_generating_user_intent_for_unhandled_user_utterance
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            "user intent: user expressed greeting",
+            "user intent: user expressed goodbye",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_unhandled_user_intent():
+    colang_code = """
+# COLANG_START: test_unhandled_user_intent
+import core
+import llm
+
+flow user expressed greeting
+    user said "hi" or user said "hello"
+
+flow bot express greeting
+    bot say "Hello and welcome"
+
+flow handling greeting
+    user expressed greeting
+    bot express greeting
+
+flow main
+    activate generating user intent for unhandled user utterance
+    activate handling greeting
+
+    while True:
+        unhandled user intent as $ref
+        bot say "got intent: {$ref.intent}"
+
+
+# COLANG_END: test_unhandled_user_intent
+    """
+
+    test_script = """
+# USAGE_START: test_unhandled_user_intent
+> hi there how are you
+Hello and welcome
+> what is the difference between lemons and limes
+got intent: user asked fruit question
+# USAGE_END: test_unhandled_user_intent
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            "user intent: user expressed greeting",
+            "user intent: user asked fruit question",
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_continuation_on_unhandled_user_intent():
+    colang_code = """
+# COLANG_START: test_continuation_on_unhandled_user_intent
+import core
+import llm
+
+flow user asked political question
+    user said "who is the best president"
+
+flow user insulted bot
+    user said "you are stupid"
+
+flow safeguarding conversation
+    user asked political question or user insulted bot
+    bot say "Sorry but I will not respond to that"
+
+flow main
+    activate generating user intent for unhandled user utterance
+    activate continuation on unhandled user intent
+    activate safeguarding conversation
+
+
+# COLANG_END: test_continuation_on_unhandled_user_intent
+    """
+
+    test_script = """
+# USAGE_START: test_continuation_on_unhandled_user_intent
+> i hate you
+Sorry but I will not respond to that
+> what party should I vote for
+Sorry but I will not respond to that
+> tell me a joke
+Why don't scientists trust atoms? Because they make up everything!
+# USAGE_END: test_continuation_on_unhandled_user_intent
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            "user insulted bot",
+            "user asked political question",
+            "user requested a joke",
+            'bot action: bot say "Why don\'t scientists trust atoms? Because they make up everything!"',
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_continuation_on_unhandled_user_intent():
+    colang_code = """
+# COLANG_START: test_continuation_on_unhandled_user_intent
+import core
+import llm
+
+flow user asked political question
+    user said "who is the best president"
+
+flow user insulted bot
+    user said "you are stupid"
+
+flow safeguarding conversation
+    user asked political question or user insulted bot
+    bot say "Sorry but I will not respond to that"
+
+flow main
+    activate generating user intent for unhandled user utterance
+    activate continuation on unhandled user intent
+    activate safeguarding conversation
+
+
+# COLANG_END: test_continuation_on_unhandled_user_intent
+    """
+
+    test_script = """
+# USAGE_START: test_continuation_on_unhandled_user_intent
+> i hate you
+Sorry but I will not respond to that
+> what party should I vote for
+Sorry but I will not respond to that
+> tell me a joke
+Why don't scientists trust atoms? Because they make up everything!
+# USAGE_END: test_continuation_on_unhandled_user_intent
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            "user insulted bot",
+            "user asked political question",
+            "user requested a joke",
+            'bot action: bot say "Why don\'t scientists trust atoms? Because they make up everything!"',
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_continuation_on_undefined_flow():
+    colang_code = """
+# COLANG_START: test_continuation_on_undefined_flow
+import core
+import llm
+
+flow main
+    activate continuation on undefined flow
+
+    user said something
+    # Await a flow that does not exist will create an LLM generated flow
+    bot ask about hobbies
+
+# COLANG_END: test_continuation_on_undefined_flow
+    """
+
+    test_script = """
+# USAGE_START: test_continuation_on_undefined_flow
+> hi there
+What are your hobbies?
+# USAGE_END: test_continuation_on_undefined_flow
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            '    bot ask "What are your hobbies?"',
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_continue_interaction():
+    colang_code = """
+# COLANG_START: test_llm_continue_interaction
+import core
+import llm
+
+flow main
+    user said "i have a question"
+    bot say "happy to help, what is it"
+    user said "do you know what the largest animal is on earth"
+    llm continue interaction
+
+# COLANG_END: test_llm_continue_interaction
+    """
+
+    test_script = """
+# USAGE_START: test_llm_continue_interaction
+> i have a question
+happy to help, what is it
+> do you know what the largest animal is on earth
+The largest animal on earth is the blue whale
+# USAGE_END: test_llm_continue_interaction
+        """
+
+    await compare_interaction_with_test_script(
+        test_script,
+        colang_code,
+        llm_responses=[
+            ' bot provide information about the largest animal on earth\nbot action: bot say "The largest animal on earth is the blue whale" ',
+        ],
+    )
 
 
 ########################################################################################################################
@@ -669,4 +1033,4 @@ Gesture: bowing
 # USAGE_END: test_bot_gesture_with_delay
         """
 
-    await compare_interaction_with_script(test_script, colang_code, 5.0)
+    await compare_interaction_with_test_script(test_script, colang_code, 5.0)

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -700,7 +700,7 @@ import core
 import llm
 
 flow main
-    # Normally you don't need to activate this flow, as it is activated by llm based flows where needed.
+    # Normally you don't need to activate this flow, as it is activated by LLM based flows where needed.
     activate polling llm request response
 
     user said something
@@ -744,8 +744,8 @@ flow handling greeting
     bot express greeting
 
 flow main
-    activate handling greeting
     activate llm continuation
+    activate handling greeting
 
 
 # COLANG_END: test_llm_continuation
@@ -789,6 +789,7 @@ flow handling goodbye
     bot express goodbye
 
 flow main
+    activate automating intent detection
     activate generating user intent for unhandled user utterance
     activate handling goodbye
 
@@ -832,6 +833,7 @@ flow handling greeting
     bot express greeting
 
 flow main
+    activate automating intent detection
     activate generating user intent for unhandled user utterance
     activate handling greeting
 
@@ -880,6 +882,7 @@ flow safeguarding conversation
     bot say "Sorry but I will not respond to that"
 
 flow main
+    activate automating intent detection
     activate generating user intent for unhandled user utterance
     activate continuation on unhandled user intent
     activate safeguarding conversation

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -86,9 +86,9 @@ import core
 flow main
     # Provide verbal feedback while the user is writing / speaking
     while True
-        when user saying (regex("sad|lonely"))
+        when user saying "sad"
             bot say "oooh"
-        or when user saying (regex("great|awesome"))
+        or when user saying "great"
             bot say "nice!"
 # COLANG_END: test_user_saying
     """
@@ -98,6 +98,8 @@ flow main
 > /UtteranceUserAction.TranscriptUpdated(interim_transcript="this is a ")
 > /UtteranceUserAction.TranscriptUpdated(interim_transcript="this is a sad story")
 oooh
+> /UtteranceUserAction.TranscriptUpdated(interim_transcript="this is a sad story that has a great ending")
+nice!
 # USAGE_END: test_user_saying
         """
 
@@ -488,7 +490,7 @@ hello
 @pytest.mark.asyncio
 async def test_wait():
     colang_code = """
-# COLANG_START: test_wait
+# COLANG_START: test_wait_time
 import timing
 import core
 
@@ -503,15 +505,15 @@ flow main
 
     wait indefinitely
 
-# COLANG_END: test_wait
+# COLANG_END: test_wait_time
     """
 
     test_script = """
-# USAGE_START: test_wait
+# USAGE_START: test_wait_time
 > hello
 I say this first
 I say this later
-# USAGE_END: test_wait
+# USAGE_END: test_wait_time
         """
 
     await compare_interaction_with_test_script(test_script, colang_code)
@@ -704,6 +706,7 @@ flow main
     user said something
 
     # While the response is generated the polling mechanism ensures that
+    # the Colang runtime is getting polled.
     $value = ..."ten minus one"
     bot say $value
 

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pathlib
 import sys
 

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -894,55 +894,6 @@ Why don't scientists trust atoms? Because they make up everything!
 
 
 @pytest.mark.asyncio
-async def test_continuation_on_unhandled_user_intent():
-    colang_code = """
-# COLANG_START: test_continuation_on_unhandled_user_intent
-import core
-import llm
-
-flow user asked political question
-    user said "who is the best president"
-
-flow user insulted bot
-    user said "you are stupid"
-
-flow safeguarding conversation
-    user asked political question or user insulted bot
-    bot say "Sorry but I will not respond to that"
-
-flow main
-    activate generating user intent for unhandled user utterance
-    activate continuation on unhandled user intent
-    activate safeguarding conversation
-
-
-# COLANG_END: test_continuation_on_unhandled_user_intent
-    """
-
-    test_script = """
-# USAGE_START: test_continuation_on_unhandled_user_intent
-> i hate you
-Sorry but I will not respond to that
-> what party should I vote for
-Sorry but I will not respond to that
-> tell me a joke
-Why don't scientists trust atoms? Because they make up everything!
-# USAGE_END: test_continuation_on_unhandled_user_intent
-        """
-
-    await compare_interaction_with_test_script(
-        test_script,
-        colang_code,
-        llm_responses=[
-            "user insulted bot",
-            "user asked political question",
-            "user requested a joke",
-            'bot action: bot say "Why don\'t scientists trust atoms? Because they make up everything!"',
-        ],
-    )
-
-
-@pytest.mark.asyncio
 async def test_continuation_on_undefined_flow():
     colang_code = """
 # COLANG_START: test_continuation_on_undefined_flow

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -448,7 +448,7 @@ I don't know how to respond to that!
 async def test_wait_indefinitely():
     colang_code = """
 # COLANG_START: test_wait_indefinitely
-import timing
+import core
 
 flow main
     bot say "hello"
@@ -515,6 +515,8 @@ flow reacting to my timer
     bot say "tick"
 
 flow main
+    activate reacting to my timer
+
     user said something
     start repeating timer "my_timer" 0.4
     wait 1.0
@@ -530,7 +532,9 @@ tick
 # USAGE_END: test_repeating_timer
         """
 
-    await compare_interaction_with_test_script(test_script, colang_code)
+    await compare_interaction_with_test_script(
+        test_script, colang_code, wait_time_s=2.0
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -299,3 +299,58 @@ Gesture: shake head
         """
 
     await compare_interaction_with_script(test_script, colang_code)
+
+
+@pytest.mark.asyncio
+async def test_tracking_bot_talking_state():
+    colang_code = """
+# COLANG_START: test_tracking_bot_talking_state
+import core
+
+flow main
+    global $bot_talking_state
+    activate tracking bot talking state
+
+    user said something
+    if $bot_talking_state
+        bot gesture "show ignorance to user speech"
+    else
+        bot say "responding to user question"
+
+# COLANG_END: test_tracking_bot_talking_state
+    """
+
+    test_script = """
+# USAGE_START: test_tracking_bot_talking_state
+> hello there
+responding to user question
+# USAGE_END: test_tracking_bot_talking_state
+        """
+
+    await compare_interaction_with_script(test_script, colang_code)
+
+
+@pytest.mark.asyncio
+async def test_tracking_user_talking_state():
+    colang_code = """
+# COLANG_START: test_tracking_user_talking_state
+import core
+
+flow main
+    global $last_user_transcript
+    activate tracking user talking state
+
+    user said something
+    bot say "I remembered {$last_user_transcript}"
+
+# COLANG_END: test_tracking_user_talking_state
+    """
+
+    test_script = """
+# USAGE_START: test_tracking_user_talking_state
+> my favorite color is red
+I remembered my favorite color is red
+# USAGE_END: test_tracking_user_talking_state
+        """
+
+    await compare_interaction_with_script(test_script, colang_code)

--- a/docs/colang_2/examples/test_csl.py
+++ b/docs/colang_2/examples/test_csl.py
@@ -354,3 +354,91 @@ I remembered my favorite color is red
         """
 
     await compare_interaction_with_script(test_script, colang_code)
+
+
+@pytest.mark.asyncio
+async def test_notification_of_colang_errors():
+    colang_code = """
+# COLANG_START: test_notification_of_colang_errors
+import core
+
+# We need to create an artificial error.
+# We need to create this in a separate flow as otherwise the main flow will fail upon the error.
+flow creating an error
+    user said something
+    $number = 3
+    print $number.error
+
+flow main
+    activate notification of colang errors
+
+    creating an error
+    wait indefinitely
+
+
+# COLANG_END: test_notification_of_colang_errors
+    """
+
+    test_script = """
+# USAGE_START: test_notification_of_colang_errors
+> test
+Excuse me, there was an internal Colang error.
+# USAGE_END: test_notification_of_colang_errors
+        """
+
+    await compare_interaction_with_script(test_script, colang_code)
+
+
+@pytest.mark.asyncio
+async def test_notification_of_undefined_flow_start():
+    colang_code = """
+# COLANG_START: test_notification_of_undefined_flow_start
+import core
+
+flow main
+    activate notification of undefined flow start
+
+    # We are misspelling the `bot say` flow to trigger a undefined flow start.
+    user said something
+    bot sayy "hello"
+
+# COLANG_END: test_notification_of_undefined_flow_start
+    """
+
+    test_script = """
+# USAGE_START: test_notification_of_undefined_flow_start
+> test
+Failed to start an undefined flow!
+# USAGE_END: test_notification_of_undefined_flow_start
+        """
+
+    await compare_interaction_with_script(test_script, colang_code)
+
+
+@pytest.mark.asyncio
+async def test_notification_of_unexpected_user_utterance():
+    colang_code = """
+# COLANG_START: test_notification_of_unexpected_user_utterance
+import core
+
+flow reacting to user requests
+    user said "hi" or user said "hello"
+    bot say "hi there"
+
+flow main
+    activate notification of unexpected user utterance
+    activate reacting to user requests
+
+# COLANG_END: test_notification_of_unexpected_user_utterance
+    """
+
+    test_script = """
+# USAGE_START: test_notification_of_unexpected_user_utterance
+> hello
+hi there
+> what is your name
+I don't know how to respond to that!
+# USAGE_END: test_notification_of_unexpected_user_utterance
+        """
+
+    await compare_interaction_with_script(test_script, colang_code)

--- a/docs/colang_2/examples/utils.py
+++ b/docs/colang_2/examples/utils.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 from typing import Optional
 
@@ -8,11 +23,6 @@ from tests.v2_x.chat import ChatInterface
 
 YAML_CONFIG = """
 colang_version: "2.x"
-
-models:
-  - type: main
-    engine: openai
-    model: gpt-3.5-turbo-instruct
 """
 
 

--- a/docs/colang_2/examples/utils.py
+++ b/docs/colang_2/examples/utils.py
@@ -14,7 +14,7 @@ models:
 """
 
 
-async def run_chat_interface_based_on_script(script, colang) -> str:
+async def run_chat_interface_based_on_script(script, colang, wait_time) -> str:
     rails_config = RailsConfig.from_content(
         colang_content=colang,
         yaml_content=YAML_CONFIG,
@@ -31,7 +31,7 @@ async def run_chat_interface_based_on_script(script, colang) -> str:
             interaction_log.append(line)
             user_input = line.replace("> ", "")
             print(f"sending '{user_input}' to process")
-            response = await chat.process(user_input)
+            response = await chat.process(user_input, wait_time)
             interaction_log.append(response)
 
     chat.should_terminate = True
@@ -58,8 +58,8 @@ def cleanup(content):
     return "\n".join(output)
 
 
-async def compare_interaction_with_script(test_script, colang):
-    result = await run_chat_interface_based_on_script(test_script, colang)
+async def compare_interaction_with_script(test_script, colang, wait_time=1.0):
+    result = await run_chat_interface_based_on_script(test_script, colang, wait_time)
     clean_test_script = cleanup(test_script)
     clean_result = cleanup(result)
     assert (

--- a/docs/colang_2/examples/utils.py
+++ b/docs/colang_2/examples/utils.py
@@ -1,0 +1,67 @@
+import asyncio
+
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.llmrails import LLMRails
+from tests.v2_x.chat import ChatInterface
+
+YAML_CONFIG = """
+colang_version: "2.x"
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-3.5-turbo-instruct
+"""
+
+
+async def run_chat_interface_based_on_script(script, colang) -> str:
+    rails_config = RailsConfig.from_content(
+        colang_content=colang,
+        yaml_content=YAML_CONFIG,
+    )
+    interaction_log = []
+    rails_app = LLMRails(rails_config, verbose=True)
+    chat = ChatInterface(rails_app)
+
+    lines = script.split("\n")
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        if line.startswith(">"):
+            interaction_log.append(line)
+            user_input = line.replace("> ", "")
+            print(f"sending '{user_input}' to process")
+            response = await chat.process(user_input)
+            interaction_log.append(response)
+
+    chat.should_terminate = True
+    await asyncio.sleep(0.5)
+
+    return "\n".join(interaction_log)
+
+
+def cleanup(content):
+    output = []
+    lines = content.split("\n")
+    for line in lines:
+        if len(line.strip()) == 0:
+            continue
+        if line.strip() == ">":
+            continue
+        if line.startswith("#"):
+            continue
+        if "Starting the chat" in line:
+            continue
+
+        output.append(line.strip())
+
+    return "\n".join(output)
+
+
+async def compare_interaction_with_script(test_script, colang):
+    result = await run_chat_interface_based_on_script(test_script, colang)
+    clean_test_script = cleanup(test_script)
+    clean_result = cleanup(result)
+    assert (
+        clean_test_script == clean_result
+    ), f"\n----\n{clean_result}\n----\n\ndoes not match test script\n\n----\n{clean_test_script}\n----"

--- a/nemoguardrails/cli/chat.py
+++ b/nemoguardrails/cli/chat.py
@@ -535,13 +535,18 @@ async def _run_chat_v2_x(rails_app: LLMRails):
                     else:
                         chat_state.input_events = [event]
                 else:
+                    action_uid = new_uuid()
                     chat_state.input_events = [
+                        new_event_dict(
+                            "UtteranceUserActionStarted",
+                            action_uid=action_uid,
+                        ),
                         new_event_dict(
                             "UtteranceUserActionFinished",
                             final_transcript=user_message,
                             action_uid=new_uuid(),
                             is_success=True,
-                        )
+                        ),
                     ]
 
             await _process_input_events()

--- a/nemoguardrails/colang/v2_x/library/core.co
+++ b/nemoguardrails/colang/v2_x/library/core.co
@@ -134,13 +134,13 @@ flow bot suggest $text
 # ----------------------------------
 
 flow bot started saying $text
-  match FlowStarted(flow_id="_bot_say", script=$text)
+  match FlowStarted(flow_id="_bot_say", text=$text)
 
 flow bot started saying something
   match FlowStarted(flow_id="_bot_say")
 
 flow bot said $text
-  match FlowFinished(flow_id="_bot_say", script=$text) as $event
+  match FlowFinished(flow_id="_bot_say", text=$text) as $event
 
 flow bot said something -> $text
   match FlowFinished(flow_id="_bot_say") as $event

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,7 @@ log_level = DEBUG
 # There are some race conditions with how the logging streams are closed in the teardown
 # phase, which will cause tests to fail or "magically" ignored.
 log_cli = False
+
+testpaths =
+    tests
+    docs/colang_2/examples

--- a/tests/v2_x/chat.py
+++ b/tests/v2_x/chat.py
@@ -1,0 +1,347 @@
+import asyncio
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.cli.chat import extract_scene_text_content, parse_events_inputs
+from nemoguardrails.colang.v2_x.runtime.flows import State
+from nemoguardrails.utils import new_event_dict, new_uuid
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+enable_input = asyncio.Event()
+enable_input.set()
+
+
+@dataclass
+class ChatState:
+    state: Optional[State] = None
+    waiting_user_input: bool = False
+    paused: bool = False
+    running_timer_tasks: Dict[str, asyncio.Task] = field(default_factory=dict)
+    input_events: List[dict] = field(default_factory=list)
+    output_events: List[dict] = field(default_factory=list)
+    output_state: Optional[State] = None
+    events_counter = 0
+    first_time: bool = False
+
+
+class ChatInterface:
+    def __init__(self, rails_app: LLMRails):
+        self.chat_state = ChatState()
+        self.rails_app = rails_app
+        self.input_queue = asyncio.Queue()
+        self.loop = asyncio.get_event_loop()
+        asyncio.create_task(self.run())
+        self.output_summary: list[str] = []
+        self.should_terminate = False
+
+    # Start an asynchronous timer
+    async def _start_timer(
+        self, timer_name: str, delay_seconds: float, action_uid: str
+    ):
+        await asyncio.sleep(delay_seconds)
+        self.chat_state.input_events.append(
+            new_event_dict(
+                "TimerBotActionFinished",
+                action_uid=action_uid,
+                is_success=True,
+                timer_name=timer_name,
+            )
+        )
+        self.chat_state.running_timer_tasks.pop(action_uid)
+
+        # Pause here until chat is resumed
+        while self.chat_state.paused:
+            await asyncio.sleep(0.1)
+
+        if self.chat_state.waiting_user_input:
+            await self._process_input_events()
+
+    def _add_to_output_summary(self, message: str):
+        self.output_summary.append(message)
+
+    def _process_output(self):
+        """Helper to process the output events."""
+
+        # We detect any "StartUtteranceBotAction" events, show the message, and
+        # generate the corresponding Finished events as new input events.
+        for event in self.chat_state.output_events:
+            if event["type"] == "StartUtteranceBotAction":
+                self._add_to_output_summary(f"{event['script']}")
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "UtteranceBotActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "UtteranceBotActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                        final_script=event["script"],
+                    )
+                )
+            elif event["type"] == "StartGestureBotAction":
+                self._add_to_output_summary(f"Gesture: {event['gesture']}")
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "GestureBotActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "GestureBotActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                    )
+                )
+
+            elif event["type"] == "StartPostureBotAction":
+                self._add_to_output_summary(f"Posture: {event['posture']}.")
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "PostureBotActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+
+            elif event["type"] == "StopPostureBotAction":
+                self._add_to_output_summary(
+                    f"bot posture (stop): (action_uid={event['action_uid']})"
+                )
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "PostureBotActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                    )
+                )
+
+            elif event["type"] == "StartVisualInformationSceneAction":
+                options = extract_scene_text_content(event["content"])
+                self._add_to_output_summary(
+                    f"Scene information: {event['title']}{options}"
+                )
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualInformationSceneActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+
+            elif event["type"] == "StopVisualInformationSceneAction":
+                self._add_to_output_summary(
+                    f"scene information (stop): (action_uid={event['action_uid']})"
+                )
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualInformationSceneActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                    )
+                )
+
+            elif event["type"] == "StartVisualFormSceneAction":
+                self._add_to_output_summary(f"Scene form: {event['prompt']}")
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualFormSceneActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+
+            elif event["type"] == "StopVisualFormSceneAction":
+                self._add_to_output_summary(
+                    f"scene form (stop): (action_uid={event['action_uid']})"
+                )
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualFormSceneActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                    )
+                )
+
+            elif event["type"] == "StartVisualChoiceSceneAction":
+
+                options = extract_scene_text_content(event["options"])
+                self._add_to_output_summary(f"Scene choice: {event['prompt']}{options}")
+
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualChoiceSceneActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+
+            elif event["type"] == "StopVisualChoiceSceneAction":
+                self._add_to_output_summary(
+                    f"scene choice (stop): (action_uid={event['action_uid']})"
+                )
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "VisualChoiceSceneActionFinished",
+                        action_uid=event["action_uid"],
+                        is_success=True,
+                    )
+                )
+
+            elif event["type"] == "StartTimerBotAction":
+                action_uid = event["action_uid"]
+                timer = self._start_timer(
+                    event["timer_name"], event["duration"], action_uid
+                )
+                # Manage timer tasks
+                if action_uid not in self.chat_state.running_timer_tasks:
+                    task = asyncio.create_task(timer)
+                    self.chat_state.running_timer_tasks.update({action_uid: task})
+                self.chat_state.input_events.append(
+                    new_event_dict(
+                        "TimerBotActionStarted",
+                        action_uid=event["action_uid"],
+                    )
+                )
+
+            elif event["type"] == "StopTimerBotAction":
+                action_uid = event["action_uid"]
+                if action_uid in self.chat_state.running_timer_tasks:
+                    self.chat_state.running_timer_tasks[action_uid].cancel()
+                    self.chat_state.running_timer_tasks.pop(action_uid)
+
+            elif event["type"] == "TimerBotActionFinished":
+                action_uid = event["action_uid"]
+                if action_uid in self.chat_state.running_timer_tasks:
+                    self.chat_state.running_timer_tasks[action_uid].cancel()
+                    self.chat_state.running_timer_tasks.pop(action_uid)
+            elif event["type"].endswith("Exception"):
+                if event["type"].endswith("Exception"):
+                    self._add_to_output_summary(f"Event: {event}")
+            elif event["type"] == "LocalAsyncCounter":
+                # self._add_to_output_summary(f"Event: {event}")
+                pass
+            else:
+                self._add_to_output_summary(f"Event: {event['type']}")
+
+        # TODO: deserialize the output state
+        # state = State.from_dict(output_state)
+        # Simulate serialization for testing
+        # data = pickle.dumps(output_state)
+        # output_state = pickle.loads(data)
+        self.chat_state.state = self.chat_state.output_state
+
+    async def _process_input_events(self):
+        while self.chat_state.input_events or self.chat_state.first_time:
+            # We need to copy input events to prevent race condition
+            input_events_copy = self.chat_state.input_events.copy()
+            self.chat_state.input_events = []
+            (
+                self.chat_state.output_events,
+                self.chat_state.output_state,
+            ) = await self.rails_app.process_events_async(
+                input_events_copy, self.chat_state.state
+            )
+
+            self._process_output()
+            # If we don't have a check task, we start it
+            if self.check_task is None:
+                self.check_task = asyncio.create_task(self._check_local_async_actions())
+
+            self.chat_state.first_time = False
+
+    async def _check_local_async_actions(self):
+
+        while True:
+            # We only run the check when we wait for user input, but not the first time.
+            if not self.chat_state.waiting_user_input or self.chat_state.first_time:
+                await asyncio.sleep(0.1)
+                continue
+
+            if len(self.chat_state.input_events) == 0:
+                self.chat_state.input_events = [new_event_dict("CheckLocalAsync")]
+
+            # We need to copy input events to prevent race condition
+            input_events_copy = self.chat_state.input_events.copy()
+            self.chat_state.input_events = []
+            (
+                self.chat_state.output_events,
+                self.chat_state.output_state,
+            ) = await self.rails_app.process_events_async(
+                input_events_copy, self.chat_state.state
+            )
+
+            # Process output_events and potentially generate new input_events
+            self._process_output()
+
+            if (
+                len(self.chat_state.output_events) == 1
+                and self.chat_state.output_events[0]["type"] == "LocalAsyncCounter"
+                and self.chat_state.output_events[0]["counter"] == 0
+            ):
+                # If there are no pending actions, we stop
+                self.check_task.cancel()
+                self.check_task = None
+                enable_input.set()
+                return
+
+            self.chat_state.output_events.clear()
+            await asyncio.sleep(0.2)
+
+    async def run(self):
+        # Start the task for checking async actions
+        self.check_task = asyncio.create_task(self._check_local_async_actions())
+
+        self.chat_state.first_time = True
+        while not self.should_terminate:
+            if self.chat_state.first_time:
+                self.chat_state.input_events = []
+            else:
+                self.chat_state.waiting_user_input = True
+                await enable_input.wait()
+
+                user_message = ""
+                if not self.input_queue.empty():
+                    user_message = self.input_queue.get_nowait()
+                enable_input.clear()
+                self.chat_state.events_counter = 0
+                self.chat_state.waiting_user_input = False
+                if user_message == "":
+                    self.chat_state.input_events = [new_event_dict("CheckLocalAsync")]
+                elif user_message.startswith("/"):
+                    # Non-UtteranceBotAction actions
+                    event_input = user_message.lstrip("/")
+                    event = parse_events_inputs(event_input)
+                    if event is None:
+                        self._add_to_output_summary(f"Invalid event: {event_input}")
+                    else:
+                        self.chat_state.input_events = [event]
+                else:
+                    self.chat_state.input_events = [
+                        new_event_dict(
+                            "UtteranceUserActionFinished",
+                            final_transcript=user_message,
+                            action_uid=new_uuid(),
+                            is_success=True,
+                        )
+                    ]
+
+            await self._process_input_events()
+
+    def user(self, message: str) -> None:
+        self.input_queue.put_nowait(message)
+
+    async def process(self, message: str, wait_time=1.0) -> str:
+        self.output_summary = []
+        self.user(message)
+        await asyncio.sleep(wait_time)
+        response = "\n".join(self.output_summary)
+        return response

--- a/tests/v2_x/chat.py
+++ b/tests/v2_x/chat.py
@@ -101,7 +101,7 @@ class ChatInterface:
                 )
 
             elif event["type"] == "StartPostureBotAction":
-                self._add_to_output_summary(f"Posture: {event['posture']}.")
+                self._add_to_output_summary(f"Posture: {event['posture']}")
 
                 self.chat_state.input_events.append(
                     new_event_dict(
@@ -111,9 +111,7 @@ class ChatInterface:
                 )
 
             elif event["type"] == "StopPostureBotAction":
-                self._add_to_output_summary(
-                    f"bot posture (stop): (action_uid={event['action_uid']})"
-                )
+                self._add_to_output_summary("bot posture (stop)")
 
                 self.chat_state.input_events.append(
                     new_event_dict(

--- a/tests/v2_x/chat.py
+++ b/tests/v2_x/chat.py
@@ -322,13 +322,18 @@ class ChatInterface:
                     else:
                         self.chat_state.input_events = [event]
                 else:
+                    action_uid = new_uuid()
                     self.chat_state.input_events = [
+                        new_event_dict(
+                            "UtteranceUserActionStarted",
+                            action_uid=action_uid,
+                        ),
                         new_event_dict(
                             "UtteranceUserActionFinished",
                             final_transcript=user_message,
-                            action_uid=new_uuid(),
+                            action_uid=action_uid,
                             is_success=True,
-                        )
+                        ),
                     ]
 
             await self._process_input_events()


### PR DESCRIPTION
## Description

This PR introduces necessary additions to the testing framework to allow for automated testing of Colang example snippets in the Colang 2 documentation. As an intial use case for this this PR also contains a reworked standard library documentation that adds concrete examples to most flows in `core.co`, `timing.co`, and `llm.co`.

Additional changes:
- Fix in `core.co` for the `bot started saying $text` and `bot said $text` flows
- Generate `UtteranceUserActionStarted` events in chat CLI
- Add Colang Doc tests to pytest.ini such that they are run in CI

## Related Issue(s)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
