### PR TITLE
feat: add score threshold to AnalyzerEngine

### DIFF
--- a/docs/user-guides/community/presidio.md
+++ b/docs/user-guides/community/presidio.md
@@ -94,6 +94,34 @@ rails:
       - ...
 ```
 
+## Score Threshold
+
+To avoid false positives when detecting sensitive data entities, you can adjust the `score_threshold` parameter. This threshold defines the minimum confidence value required for a detected entity to be returned. By setting a higher `score_threshold`, you can reduce false positives by requiring a higher confidence level for detected entities. The default value for this parameter is 0.2.
+
+The `score_threshold` parameter can be configured for any of the above sources (input, output and retrieval) to filter out sensitive data entities with a score above the defined threshold. Below is an example configuration that adjusts the `score_threshold` for a specific case:
+
+```yaml
+
+rails:
+  config:
+    sensitive_data_detection:
+      input:
+        score_threshold: 0.6
+        entities:
+          - PERSON
+          - EMAIL_ADDRESS
+          - ...
+      output:
+        score_threshold: 0.6
+        entities:
+          - PERSON
+          - EMAIL_ADDRESS
+          - ...
+
+```
+
+For additional guidance on handling undetected PII entities and minimizing false negatives, refer to the [Presidio FAQ](https://microsoft.github.io/presidio/faq/#what-can-i-do-if-presidio-does-not-detect-some-of-the-pii-entities-in-my-data-false-negatives).
+
 ## Custom Recognizers
 
 If you have custom entities that you want to detect, you can define custom *recognizers*.

--- a/docs/user-guides/community/presidio.md
+++ b/docs/user-guides/community/presidio.md
@@ -125,7 +125,7 @@ For additional guidance on handling undetected PII entities and minimizing false
 ## Custom Recognizers
 
 If you have custom entities that you want to detect, you can define custom *recognizers*.
-For more details, check out this [tutorial](https://microsoft.github.io/presidio/tutorial/08_no_code/) and this [example](https://github.com/microsoft/presidio/blob/main/presidio-analyzer/conf/example_recognizers.yaml).
+For more details, check out this [tutorial](https://microsoft.github.io/presidio/tutorial/08_no_code/) and this [example](https://github.com/microsoft/presidio/blob/main/presidio-analyzer/presidio_analyzer/conf/example_recognizers.yaml).
 
 Below is an example of configuring a `TITLE` entity and detecting it inside the input rail.
 

--- a/nemoguardrails/library/sensitive_data_detection/actions.py
+++ b/nemoguardrails/library/sensitive_data_detection/actions.py
@@ -99,7 +99,8 @@ async def detect_sensitive_data(source: str, text: str, config: RailsConfig):
     """
     # Based on the source of the data, we use the right options
     sdd_config = config.rails.config.sensitive_data_detection
-    assert source in ["input", "output", "retrieval"]
+    if source not in ["input", "output", "retrieval"]:
+        raise ValueError("source must be one of 'input', 'output', or 'retrieval'")
     options: SensitiveDataDetectionOptions = getattr(sdd_config, source)
     score_threshold = getattr(options, "score_threshold", 0.4)
 

--- a/nemoguardrails/library/sensitive_data_detection/actions.py
+++ b/nemoguardrails/library/sensitive_data_detection/actions.py
@@ -36,7 +36,9 @@ log = logging.getLogger(__name__)
 
 
 @lru_cache
-def _get_analyzer():
+def _get_analyzer(score_threshold: float = 0.4):
+    if not 0.0 <= score_threshold <= 1.0:
+        raise ValueError("score_threshold must be a float between 0 and 1 (inclusive).")
     try:
         from presidio_analyzer import AnalyzerEngine
 
@@ -69,7 +71,10 @@ def _get_analyzer():
     provider = NlpEngineProvider(nlp_configuration=configuration)
     nlp_engine = provider.create_engine()
 
-    return AnalyzerEngine(nlp_engine=nlp_engine)
+    # TODO: One needs to experiment with the score threshold to get the right value
+    return AnalyzerEngine(
+        nlp_engine=nlp_engine, default_score_threshold=score_threshold
+    )
 
 
 def _get_ad_hoc_recognizers(sdd_config: SensitiveDataDetection):
@@ -96,12 +101,13 @@ async def detect_sensitive_data(source: str, text: str, config: RailsConfig):
     sdd_config = config.rails.config.sensitive_data_detection
     assert source in ["input", "output", "retrieval"]
     options: SensitiveDataDetectionOptions = getattr(sdd_config, source)
+    score_threshold = getattr(options, "score_threshold", 0.4)
 
     # If we don't have any entities specified, we stop
     if len(options.entities) == 0:
         return False
 
-    analyzer = _get_analyzer()
+    analyzer = _get_analyzer(default_score_threshold=score_threshold)
     results = analyzer.analyze(
         text=text,
         language="en",

--- a/nemoguardrails/library/sensitive_data_detection/actions.py
+++ b/nemoguardrails/library/sensitive_data_detection/actions.py
@@ -102,13 +102,13 @@ async def detect_sensitive_data(source: str, text: str, config: RailsConfig):
     if source not in ["input", "output", "retrieval"]:
         raise ValueError("source must be one of 'input', 'output', or 'retrieval'")
     options: SensitiveDataDetectionOptions = getattr(sdd_config, source)
-    score_threshold = getattr(options, "score_threshold", 0.4)
+    default_score_threshold = getattr(options, "score_threshold")
 
     # If we don't have any entities specified, we stop
     if len(options.entities) == 0:
         return False
 
-    analyzer = _get_analyzer(default_score_threshold=score_threshold)
+    analyzer = _get_analyzer(score_threshold=default_score_threshold)
     results = analyzer.analyze(
         text=text,
         language="en",

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -108,6 +108,11 @@ class SensitiveDataDetectionOptions(BaseModel):
         description="The token that should be used to mask the sensitive data.",
     )
 
+    score_threshold: float = Field(
+        default=0.2,
+        description="The score threshold that should be used to detect the sensitive data.",
+    )
+
 
 class SensitiveDataDetection(BaseModel):
     """Configuration of what sensitive data should be detected."""


### PR DESCRIPTION
## Description

Currently the `AnalyzerEngine` uses `default_score_threshold` of 0. This PR adds `score_threshold` to `SensitiveDataDetectionOptions` so that the user can set it in the `config.yml`. The default value is set to `0.2` but it requires further experimentation.

Example configuration:

```yaml
rails:
  config:
    sensitive_data_detection:
      input:
        score_threshold: 0.4
        entities:
          - PHONE_NUMBER
          - EMAIL_ADDRESS
          - IN_PAN
          - IN_AADHAAR

      output:
        entities:
          - PHONE_NUMBER
          - EMAIL_ADDRESS
          - IN_PAN
          - IN_AADHAAR


```

## Related Issue(s)

  - Fixes #818 


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
