### PR TITLE
fix(dependencies): add pandas version constraint for eval

### DIFF
--- a/docs/getting_started/installation-guide.md
+++ b/docs/getting_started/installation-guide.md
@@ -52,7 +52,7 @@ To experiment with NeMo Guardrails from scratch, use a fresh virtual environment
  > source venv/bin/activate
  ```
 
- ### Setting up a virtual environment on Windows
+### Setting up a virtual environment on Windows
 
 1. Open a new CMD prompt (Windows Key + R, **cmd.exe**)
 2. Install **virtualenv** using the command `pip install virtualenv`
@@ -103,6 +103,22 @@ To keep the footprint of `nemoguardrails` as small as possible, these are not in
 ```
 
 ## Optional dependencies
+>
+> [!IMPORTANT]
+> pip fails to resolve dependencies for **v0.10.0** and **v0.10.1**. We recommend using a `constraints.txt` file to ensure compatible versions of dependencies. This only concerns you when you want to install the `[all]` extra dependencies.
+>
+> **Example `constraints.txt`**:
+>
+> ```
+> pandas>=1.4.0,<3
+> ```
+>
+> **Installation Instructions**:
+> To install the package with the specified constraints, use the following command:
+>
+> ```sh
+> pip install "nemoguardrails[all]" -c constraints.txt
+> ```
 
 To use OpenAI, just use the `openai` extra dependency that ensures that all required packages are installed.
 Make sure the `OPENAI_API_KEY` environment variable is set,
@@ -111,7 +127,7 @@ as shown in the following example, where *YOUR_KEY* is your OpenAI key.
  ```bash
  > pip install nemoguardrails[openai]
  > export OPENAI_API_KEY=YOUR_KEY
- ```
+```
 
 Some NeMo Guardrails LLMs and features have specific installation requirements, including a more complex set of steps. For example, [AlignScore](../user_guides/advanced/align_score_deployment.md) fact-checking, using [Llama-2](../../examples/configs/llm/hf_pipeline_llama2/README.md) requires two additional packages.
 For each feature or LLM example, check the readme file associated with it.
@@ -122,6 +138,6 @@ NeMo Guardrails can also be used through Docker. For details on how to build and
 
 ## What's next?
 
-* Check out the [Getting Started Guide](../getting_started/README.md) and start with the ["Hello World" example](../getting_started/1_hello_world/README.md).
-* Explore more examples in the [examples](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/examples) folder.
-* Review the [User Guides](../README.md).
+- Check out the [Getting Started Guide](../getting_started/README.md) and start with the ["Hello World" example](../getting_started/1_hello_world/README.md).
+- Explore more examples in the [examples](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/examples) folder.
+- Review the [User Guides](../README.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,10 @@ dependencies = [
 eval = [
   "tqdm~=4.65",
   "numpy~=1.24",
-  "streamlit>=1.37.0"
+  "streamlit>=1.37.0",
+  # Explicitly pinning the version of pandas to avoid pip resolution issues.
+  # This the exact version that streamlit requires.
+  "pandas>=1.4.0,<3"
 ]
 openai = [
   "langchain-openai>=0.0.5"


### PR DESCRIPTION

## Description

Explicitly pinning the version of pandas to avoid pip resolution issues. This ensures compatibility with streamlit, which requires pandas>=1.4.0,<3.
For v0.10.0 and v0.10.1, and the head of the develop branch prior to commit d69a7e882cc66bfe8fe9b9728d9c0b367211beb5, pip fails to resolve dependencies. This issue is due to a problem with pip's dependency resolution.



## Fix
For v0.10.0 and v0.10.1, and the head of the develop branch prior to commit d69a7e882cc66bfe8fe9b9728d9c0b367211beb5, pip fails to resolve dependencies. This issue is due to a problem with pip's dependency resolution. 
```sh
pip install "nemoguardrails[all]"
```

To avoid these conflicts, we recommend using a `constraints.txt` file to specify the exact version of `pandas`.

**Example `constraints.txt`**:
```
pandas>=1.4.0,<3
``` 

**Installation Instructions**:
To install the package with the specified constraints, use the following command:
```sh
pip install "nemoguardrails[all]" -c constraints.txt
```

Current PR fixes this issue so you don't need to use the constraints.txt.


## Updated Documentation

Please refer to the updated [installation guide](https://github.com/NVIDIA/NeMo-Guardrails/blob/fix/optional-dependencies-resolution/docs/getting_started/installation-guide.md#optional-dependencies).



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
