### PR TITLE
fix(tests): mock PromptSession to prevent console error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+
+def pytest_configure(config):
+    patch("prompt_toolkit.PromptSession", autospec=True).start()


### PR DESCRIPTION
## Description
The tests in `tests/test_cli.py` and `tests/test_cli_migration.py` were failing with the following error:
```
prompt_toolkit.output.win32.NoConsoleScreenBufferError: Found xterm-256color, while expecting a Windows console. Maybe try to run this program using "winpty" or run it in cmd.exe instead. Or otherwise, in case of Cygwin, use the Python executable that is compiled for Cygwin.
```
This error occurs because the `prompt_toolkit` library expects a Windows console but find `xterm-256color` instead. This happens when running tests in an environment that doesn't have a proper console buffer. This issue occurs in Windows GitHub runners when the runner is `windows-latest`.



#### Root Cause
The `PromptSession` class from the `prompt_toolkit` library attempts to create a console application, which fails in environments without a proper console buffer, leading to the `NoConsoleScreenBufferError`.

#### Fix
To resolve this issue, the `PromptSession` class is mocked during the tests to avoid initialization. This prevents the `NoConsoleScreenBufferError` from occurring. 

#### Testing
- Verified that the tests in `tests/test_cli.py` and `tests/test_cli_migration.py` pass successfully in both local and [CI](https://github.com/NVIDIA/NeMo-Guardrails/actions/runs/11792963053).
- Ensured that the mocking does not interfere with the actual functionality being tested.

## Related Issue(s)

https://github.com/prompt-toolkit/python-prompt-toolkit/issues/406

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
