### PR TITLE
fix: handle multiple output parsers in generation

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -906,7 +906,7 @@ class LLMGenerationActions:
 
                 if streaming_handler:
                     # TODO: Figure out a more generic way to deal with this
-                    if prompt_config.output_parser == "verbose_v1":
+                    if prompt_config.output_parser in ["verbose_v1", "bot_message"]:
                         streaming_handler.set_pattern(
                             prefix='Bot message: "', suffix='"'
                         )


### PR DESCRIPTION
Updated the condition to check if `prompt_config.output_parser` is in the list `["verbose_v1", "bot_message"]`

Currently this part of code needs to be updated once new output_parsers get registered.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

#850 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
