### PR TITLE
docs: add deprecation notice for Got It AI integration

### DIFF
--- a/docs/user_guides/community/gotitai.md
+++ b/docs/user_guides/community/gotitai.md
@@ -1,5 +1,8 @@
 # Got It AI Integration
 
+!!! warning "Deprecation Notice"
+    The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
+
 NeMo Guardrails integrates with [Got It AI's Hallucination Manager](https://www.app.got-it.ai/hallucination-manager) for hallucination detection in RAG systems. The Hallucination Manager's TruthChecker API is designed to detect and manage hallucinations in AI models, specifically for real-world RAG applications.
 
 Existing fact-checking methods are not sufficient to detect hallucinations in AI models for real-world RAG applications. The TruthChecker API performs a dual task to determine whether a response is a `hallucination` or not:

--- a/docs/user_guides/community/gotitai.md
+++ b/docs/user_guides/community/gotitai.md
@@ -1,7 +1,7 @@
 # Got It AI Integration
 
-!!! warning "Deprecation Notice"
-    The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
+>:warning: **Deprecation Notice:**
+>The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
 
 NeMo Guardrails integrates with [Got It AI's Hallucination Manager](https://www.app.got-it.ai/hallucination-manager) for hallucination detection in RAG systems. The Hallucination Manager's TruthChecker API is designed to detect and manage hallucinations in AI models, specifically for real-world RAG applications.
 

--- a/docs/user_guides/guardrails-library.md
+++ b/docs/user_guides/guardrails-library.md
@@ -610,6 +610,9 @@ For more details, check out the [ActiveFence Integration](./community/active-fen
 
 ### Got It AI
 
+!!! warning "Deprecation Notice"
+    The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
+
 NeMo Guardrails integrates with [Got It AI's Hallucination Manager](https://www.app.got-it.ai/hallucination-manager) for hallucination detection in RAG systems. To integrate the TruthChecker API with NeMo Guardrails, the `GOTITAI_API_KEY` environment variable needs to be set.
 
 #### Example usage

--- a/docs/user_guides/guardrails-library.md
+++ b/docs/user_guides/guardrails-library.md
@@ -610,8 +610,8 @@ For more details, check out the [ActiveFence Integration](./community/active-fen
 
 ### Got It AI
 
-!!! warning "Deprecation Notice"
-    The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
+>:warning: **Deprecation Notice:**
+>The Got It AI integration has been deprecated and will be discontinued on 15th December, 2024.
 
 NeMo Guardrails integrates with [Got It AI's Hallucination Manager](https://www.app.got-it.ai/hallucination-manager) for hallucination detection in RAG systems. To integrate the TruthChecker API with NeMo Guardrails, the `GOTITAI_API_KEY` environment variable needs to be set.
 


### PR DESCRIPTION
## Description

Issues a deprecation notice for the Got It AI integration. Got It AI's RAG Truthchecking service will be discontinued on 15th December, 2024.

Changes:

- Issued deprecation notice in gotitai.md
- Issued deprecation notice in guardrails-library.md


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

@cparisien @drazvan 