### PR TITLE
Fix asyncio loop issue in combination with enable_input event

### DIFF
--- a/nemoguardrails/cli/chat.py
+++ b/nemoguardrails/cli/chat.py
@@ -30,7 +30,7 @@ from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
 from nemoguardrails.logging import verbose
 from nemoguardrails.logging.verbose import console
 from nemoguardrails.streaming import StreamingHandler
-from nemoguardrails.utils import new_event_dict, new_uuid
+from nemoguardrails.utils import get_or_create_event_loop, new_event_dict, new_uuid
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
@@ -662,6 +662,7 @@ def run_chat(
         )
     elif rails_config.colang_version == "2.x":
         rails_app = LLMRails(rails_config, verbose=verbose)
-        asyncio.run(_run_chat_v2_x(rails_app))
+        loop = get_or_create_event_loop()
+        loop.run_until_complete(_run_chat_v2_x(rails_app))
     else:
         raise Exception(f"Invalid colang version: {rails_config.colang_version}")


### PR DESCRIPTION
## Description

This fixes an asyncio loop issue in the chat CLI with Python 3.8.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
