### PR TITLE
fix(colang): use input rails output for intent generation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{co,py}]
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/examples/v2_x/other/query_rewriting/README.md
+++ b/examples/v2_x/other/query_rewriting/README.md
@@ -1,0 +1,13 @@
+# Query Rewriting
+
+## Run the example
+
+1. Set environment:
+   ```shell
+   export OPENAI_API_KEY=sk-xxx
+    ```
+
+2. Start the NeMo Guardrails chat:
+   ```shell
+   $ python -m nemoguardrails.__main__ chat --streaming --config . --verbose
+   ```

--- a/examples/v2_x/other/query_rewriting/config.py
+++ b/examples/v2_x/other/query_rewriting/config.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from nemoguardrails import LLMRails
+from nemoguardrails.llm.output_parsers import _replace_prefix
+
+
+def user_intent_parser(output: str) -> str:
+    return _replace_prefix(output.strip().lower(), "user intent: ", "")
+
+
+def init(app: LLMRails):
+    app.register_output_parser(user_intent_parser, "my_user_intent")

--- a/examples/v2_x/other/query_rewriting/config.yml
+++ b/examples/v2_x/other/query_rewriting/config.yml
@@ -1,0 +1,55 @@
+colang_version: 2.x
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini-2024-07-18
+
+prompts:
+  - task: generate_user_intent_from_user_action
+    models:
+      - openai/gpt-4o-mini-2024-07-18
+    messages:
+      - type: system
+        content: |-
+          ## Instructions:
+
+          1. Given the current conversation below and a follow-up input, rephrase the follow-up input to be a
+             standalone `user action:`, in its original language. Use this for the next step, but do not include it in
+             your final answer.
+
+          2. Derive `user intent:` from the user action by considering the intents from the 'Most likely intents'
+             section.
+
+          **Note**: Your final answer should only include the "user intent:" followed by your chosen intent, e.g.:
+
+          user intent: <<the intent>>
+
+          ### Example:
+
+          - **Current conversation:**
+            user said "Do you have any bikes?"
+            bot say "Yes, we have a wide range of bikes. Would you like to see them?"
+            user said "sure"
+
+          - **Follow-up input:**
+            user said "sure"
+
+          - **Rephrased user action:**
+            user said "Show me some bikes!"
+
+          - **Derived user intent:**
+            user intent: user asked about bikes
+
+          ## Current conversation:
+          {{ history | co_v2 }}
+
+          ## Follow-up input:
+          {{ user_action }}
+
+          ## Most likely intents:
+          {{ examples }}
+
+          Your answer:
+
+    output_parser: "my_user_intent"

--- a/examples/v2_x/other/query_rewriting/main.co
+++ b/examples/v2_x/other/query_rewriting/main.co
@@ -1,0 +1,165 @@
+import core
+import llm
+import guardrails
+
+flow input rails $input_text
+    rephrase user message $input_text
+
+flow rephrase user message $input_text
+    """Given the following conversation and a follow up input, rephrase the follow up input to be a standalone input,
+    in its original language. Generate the output in the following format:
+
+    $rephrased_user_message = '''<<the response>>'''
+
+    Conversation:
+    {{ history | co_v2 }}
+
+    Follow-up input:
+    {{ input_text }}
+
+    Your Response:"""
+    global $user_message
+    global $last_user_message
+    ...
+    $user_message = $rephrased_user_message
+    $last_user_message = $rephrased_user_message
+
+# The following comment contains the current workaround:
+# 1. match UtteranceUserActionFinished
+# 2. Rewrite the transcript.
+# 3. send UtteranceUserActionFinished with same `action_uid` and `is_success` but with updated transcript
+#
+#@override
+#flow _user_said_something_unexpected -> $event
+#    """Given the following conversation and a follow up input, rephrase the follow up input to be a standalone input,
+#    in its original language. Generate the output in the following format:
+#
+#    $rephrased_user_message = '''<<the response>>'''
+#
+#    Conversation:
+#    {{ history | co_v2 }}
+#
+#    Question: {{ question }}
+#
+#    Your Response:"""
+#    global $user_message
+#    global $last_user_message
+#    match UnhandledEvent(event="UtteranceUserActionFinished", loop_ids={$self.loop_id}) as $e
+#    $question = $e.final_transcript
+#    ...
+#    send UtteranceUserActionFinished(
+#        final_transcript=$rephrased_user_message, action_uid=$e.action_uid, is_success=$e.is_success
+#    ) as $event
+#    $user_message = $rephrased_user_message
+#    $last_user_message = $rephrased_user_message
+
+flow main
+    activate llm continuation
+
+    while True
+        when user greeted
+            reaction to user greeting
+        or when user said goodbye
+            handling user leaving
+        or when user asked about bikes
+            answering bike questions
+        or when unhandled user intent
+            bot say "My apologies, I can't answer your question"
+
+##################################################
+# Intents                                        #
+##################################################
+
+flow user greeted
+    user said "Hi"
+        or user said "Hello"
+        or user said "Hey"
+        or user said "Good morning"
+        or user said "Good afternoon"
+        or user said "Good evening"
+        or user said "Hi there"
+        or user said "Howdy"
+        or user said "What's up?"
+        or user said "Greetings"
+        or user said "Hey there"
+        or user said "Hiya"
+        or user said "Yo"
+        or user said "Hi, how are you?"
+        or user said "Hello, how's it going?"
+        or user said "What's good?"
+        or user said "Hey, how have you been?"
+        or user said "Hello, anyone there?"
+        or user said "Hey, you around?"
+
+flow user said goodbye
+    user said "Bye"
+        or user said "See you"
+        or user said "Goodbye"
+        or user said "Catch you later"
+        or user said "Talk to you soon"
+        or user said "See you later"
+        or user said "I'm out"
+        or user said "Peace"
+        or user said "Take care"
+        or user said "Farewell"
+        or user said "See you next time"
+        or user said "Later"
+        or user said "I'm heading out"
+        or user said "See you soon"
+        or user said "Bye for now"
+        or user said "Have a good one"
+        or user said "Goodnight"
+        or user said "Till next time"
+        or user said "I'm signing off"
+
+flow user asked about bikes
+    user said "Show me bikes"
+        or user said "I want to see bikes"
+        or user said "Do you have any bicycles?"
+        or user said "Can you show me some bikes?"
+        or user said "I'm looking for bikes"
+        or user said "Bicycles available?"
+        or user said "What bicycles do you have?"
+        or user said "Can you display bikes for me?"
+        or user said "I'd like to see your bikes"
+        or user said "Do you sell bicycles?"
+        or user said "Bike options?"
+        or user said "What kinds of bikes do you have?"
+        or user said "Show me your bicyles collection"
+        or user said "Can I browse your bikes?"
+        or user said "What bikes do you offer?"
+        or user said "I'm interested in buying a bike"
+        or user said "Any bicycles for sale?"
+        or user said "What's in your bicycle inventory?"
+        or user said "Do you have a bike catalog?"
+        or user said "I'd like to look at bikes"
+
+##################################################
+# Handler                                        #
+##################################################
+
+flow reaction to user greeting
+    global $name
+
+    if $name
+        bot say "Hi {$name}!"
+    else
+        bot say "Hi there! What's your name?"
+        await user said something as $name_ref
+        $name = $name_ref.transcript
+
+        start_new_flow_instance: # Start a new instance of the flow and continue with this one
+
+flow handling user leaving
+    bot say "Goodbye, see you next time!"
+
+flow answering bike questions
+    """You are an assistant that should talk to the user about bikes.
+    Politely decline to talk about anything else.
+
+    Last user question is: "{{ last_user_message }}"
+    Generate the output in the following format:
+
+    bot say '''<<the response>>'''
+    """
+    ...

--- a/nemoguardrails/colang/v2_x/library/llm.co
+++ b/nemoguardrails/colang/v2_x/library/llm.co
@@ -49,6 +49,7 @@ flow generating user intent for unhandled user utterance
   activate polling llm request response
   activate tracking bot talking state
   global $bot_talking_state
+  global $user_message
 
   await _user_said_something_unexpected as $user_said
   $event = $user_said.event
@@ -58,9 +59,9 @@ flow generating user intent for unhandled user utterance
     log 'flow aborted since bot is in talking state'
     abort
 
-  log 'unexpected user utterance: "{$event.final_transcript}"'
+  log 'unexpected user utterance: "{$user_message}"'
   log 'start generating user intent...'
-  $action = 'user said "{$event.final_transcript}"'
+  $action = 'user said "{$user_message}"'
   $intent = await GenerateUserIntentAction(user_action=$action, max_example_flows=20)
   log 'generated user intent: {$intent}'
 
@@ -68,7 +69,7 @@ flow generating user intent for unhandled user utterance
   send FinishFlow(flow_id=$intent)
 
   # We need to log the user action
-  send UserActionLog(flow_id="user said", parameter=$event.final_transcript, intent_flow_id=$intent)
+  send UserActionLog(flow_id="user said", parameter=$user_message, intent_flow_id=$intent)
   # And we also need to log the generated user intent if not done by another mechanism
   when UserIntentLog(flow_id=$intent)
     return


### PR DESCRIPTION
Related to https://github.com/NVIDIA/NeMo-Guardrails/discussions/866

## Description

Hi @drazvan,

I am creating an AI solution based on the interaction loop of Colang v2. To improve the intent detection for user messages like confirmations ("yes", "no", etc.) I'd like to add Query Rewriting; basically an LLM call prompting to rephrase the user message with context from the conversation.

Example:

User: Do you have any bikes?
Bot: Yes, we have a wide range of bikes. Would you like to see them?
User: sure

Now, query rewriting would transform the "sure" into "Show me some bikes!".

## The Problem

The action `generate_user_intent` is called with `user_action` which is the final transcript of the `UtteranceUserActionFinished`. However, the input rails set the `$user_message` and `$last_user_message` through the context.

Here's my debugger:

![Bildschirmfoto 2024-11-22 um 14 10 00](https://github.com/user-attachments/assets/1494bbb8-feda-4c80-b1da-0d3e4245852d)

The action has a typo: "Sho**e** me bikes", whereas the context has been rewritten to "sho**w** me bikes".

## The solution

Let me first show my debugger again:

Same user input as above with typo: "Shoe me bikes".

![Bildschirmfoto 2024-11-22 um 14 11 47](https://github.com/user-attachments/assets/36f6dc4e-9a96-47b2-9ad6-ea31a2151076)

Now, the context is consistent, and the example lookup works on the rewritten query.

## Example and current workaround.

Currently, I am working around this issue by overriding `flow _user_said_something_unexpected` and performing three new steps:
1. match UtteranceUserActionFinished
2. Rewrite the transcript.
3. send UtteranceUserActionFinished with same `action_uid` and `is_success` as before but with updated transcript

Here's the code:

```Colang
@override
flow _user_said_something_unexpected -> $event
    """Given the following conversation and a follow up input, rephrase the follow up input to be a standalone input,
    in its original language. Generate the output in the following format:

    $rephrased_user_message = '''<<the response>>'''

    Conversation:
    {{ history | co_v2 }}

    Question: {{ question }}

    Your Response:"""
    global $user_message
    global $last_user_message
    match UnhandledEvent(event="UtteranceUserActionFinished", loop_ids={$self.loop_id}) as $e
    $question = $e.final_transcript
    ...
    send UtteranceUserActionFinished(
        final_transcript=$rephrased_user_message, action_uid=$e.action_uid, is_success=$e.is_success
    ) as $event
    $user_message = $rephrased_user_message
    $last_user_message = $rephrased_user_message
```

**Note**: Please also refer to the custom prompt in `config.yml`, where I tried to do query rewriting and intent matching in one step, but `examples` would still be wrong without this fix.

**Note**: I'll gladly enhance the README of the query rewriting example once we find a solution.

Happy to hear your feedback!

Cheers,
Niels

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
