### PR TITLE
Fix typos in the example prompts to remove some of the IDE warnings

### DIFF
--- a/examples/configs/content_safety/prompts.yml
+++ b/examples/configs/content_safety/prompts.yml
@@ -1,4 +1,4 @@
-# These are the default prompts released by Meta, with the exception of policy O7, which was added to address direct insults.
+# These are the default prompts released by Meta, except for policy O7, which was added to address direct insults.
 prompts:
   - task: content_safety_check_input $model=llama_guard
     content: |
@@ -136,7 +136,7 @@ prompts:
   - task: content_safety_check_output $model=shieldgemma
     content: |
       You are a policy expert trying to help determine whether a chatbot response to the user is in
-      violdation of the defined safety policies:
+      violation of the defined safety policies:
 
       <start_of_turn>
       Human Question: {{ user_input }}


### PR DESCRIPTION
## Description

This PR contains a very small change in the example prompts, where a few typos are fixed in order to get rid of some of the IDE warnings.

Hi @Pouyanpi, thank you for the comments on [PR-808](https://github.com/NVIDIA/NeMo-Guardrails/pull/808). This is a new PR with the same changes as in [PR-808](https://github.com/NVIDIA/NeMo-Guardrails/pull/808), incorporating your feedback.

## Related Issue(s)

NA

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
