### PR TITLE
chore: pin fastembed to 4.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -868,19 +868,19 @@ standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "htt
 
 [[package]]
 name = "fastembed"
-version = "0.3.6"
+version = "0.4.0"
 description = "Fast, light, accurate library built for retrieval embedding generation"
 optional = false
 python-versions = "<3.13,>=3.8.0"
 files = [
-    {file = "fastembed-0.3.6-py3-none-any.whl", hash = "sha256:2bf70edae28bb4ccd9e01617098c2075b0ba35b88025a3d22b0e1e85b2c488ce"},
-    {file = "fastembed-0.3.6.tar.gz", hash = "sha256:c93c8ec99b8c008c2d192d6297866b8d70ec7ac8f5696b34eb5ea91f85efd15f"},
+    {file = "fastembed-0.4.0-py3-none-any.whl", hash = "sha256:92dff5f53aef55df40f8c403411e08a9ed66e1c4138773acacc6b945a71973e4"},
+    {file = "fastembed-0.4.0.tar.gz", hash = "sha256:428867d91cd775e939f8650af1fcdc312f66359c5d39a0006b4ef991115905f5"},
 ]
 
 [package.dependencies]
 huggingface-hub = ">=0.20,<1.0"
 loguru = ">=0.7.2,<0.8.0"
-mmh3 = ">=4.0,<5.0"
+mmh3 = ">=4.1.0,<5.0.0"
 numpy = {version = ">=1.21,<2", markers = "python_version < \"3.12\""}
 onnx = ">=1.15.0,<2.0.0"
 onnxruntime = ">=1.17.0,<2.0.0"
@@ -5427,4 +5427,4 @@ trace = ["aiofiles", "opentelemetry-api", "opentelemetry-sdk"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.9.7 || >3.9.7,<3.12"
-content-hash = "9d2dd9d8ddabafde1d666ab60976209a7c9d70d52b9258e419cd72fe9a6aeae5"
+content-hash = "e1acea9e49b257277aeb71de8aebd6a82a2b2d02c70f61f11186eaeca2773756"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ python = ">=3.9,<3.9.7 || >3.9.7,<3.12"
 aiohttp = ">=3.9.2"
 annoy = ">=1.17.3"
 fastapi = ">=0.103.0,"
-fastembed = ">=0.2.2, <0.4.0"
+fastembed = ">=0.2.2, <0.4.1"
 httpx = "^0.24.1"
 jinja2 = ">=3.1.4"
 langchain = ">=0.2.14,<0.4.0"
@@ -75,7 +75,7 @@ langchain-openai = { version = ">=0.0.5", optional = true }
 tqdm = { version = ">=4.65,<5.0", optional = true }
 numpy = { version = ">=1.24,<2.0", optional = true }
 streamlit = { version = "^1.37.0", optional = true, python = ">=3.9,<3.9.7 || >3.9.7,<3.12" }
-pandas = { version = ">=1.4.0,<3", optional = true}
+pandas = { version = ">=1.4.0,<3", optional = true }
 
 # sdd
 presidio-analyzer = { version = ">=2.2", optional = true }


### PR DESCRIPTION
4.1.0 instroduces rust-pystemmer which does not have any license

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->


