### PR TITLE
ci: add changelog enforcement

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip-changelog')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,20 @@
+name: "Check CHANGELOG.md"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    paths-ignore:
+      - "docs/colang-2/**"
+      - "nemoguardrails/colang/v2_x/**"
+      - "cli/**"
+      - ".github/**"
+      - "tests/**"
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dangoslen/changelog-enforcer@v2
+        with:
+          changeLogPath: "CHANGELOG.md"


### PR DESCRIPTION
## Description

Enforce change log update for NeMo Guardrails changes

- [ ] @schuellc-nvidia to ensure that we are not distrubing Colang workflows
- [x] maintainers should be allowed to suppress it using `skip-changelog` label
![image](https://github.com/user-attachments/assets/27f79f1c-bc38-4e2a-95ee-72f0115b52c4)
