### PR TITLE
fix(ci): add missing event types for PR trigger

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -5,6 +5,7 @@ on:
     types: [review_requested, ready_for_review]
     paths-ignore:
       - "**/*.md"
+      - ".github/**"
   push:
     tags:
       - "v*"

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,7 +4,7 @@ name: PR Tests
 on:
   push:
     paths-ignore:
-      - ".github/workflows/**"
+      - ".github/**"
 
 jobs:
   call-tests:

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -2,6 +2,7 @@ name: Build and Test Python Wheel
 
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
     paths-ignore:
       - "**/*.md"
   push:


### PR DESCRIPTION
## Description

add missing event types for PR triggers in 
- `build-and-test-wheel` workflow to avoid running this test on push events. And on workflow changes in `.github`
- full tests on workflow changes in `.github`

