### PR TITLE
fix activefence rail docs

### DIFF
--- a/docs/user-guides/community/active-fence.md
+++ b/docs/user-guides/community/active-fence.md
@@ -31,7 +31,7 @@ ActiveFence’s ActiveScore API gives flexibility in controlling the behavior of
 
 ```colang
 define flow activefence input moderation detailed
-  $result = execute call activefence api(text=$user_message)
+  $result = execute call activefence api
 
   if $result.violations.get("abusive_or_harmful.hate_speech", 0) > 0.8
     bot inform cannot engage in abusive or harmful behavior


### PR DESCRIPTION

 With the current [action](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/nemoguardrails/library/activefence/actions.py#L29) expected input, the docs are out of date.