### PR TITLE
Fix repeating timer flow doc test.

### DIFF
--- a/docs/colang-2/examples/test_csl.py
+++ b/docs/colang-2/examples/test_csl.py
@@ -535,8 +535,8 @@ flow main
     activate reacting to my timer
 
     user said something
-    start repeating timer "my_timer" 0.4
-    wait 1.0
+    repeating timer "my_timer" 0.4 or wait 1.0
+    wait indefinitely
 
 # COLANG_END: test_repeating_timer
     """


### PR DESCRIPTION
## Description

Ensure that the main flow is not finishing before the two "tick" utterances are completed.

## Related Issue(s)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
