### PR TITLE
Update action to support output rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ rails:
     flows:
       - self check facts
       - self check hallucination
-      - activefence moderation
+      - activefence moderation on input
 
   config:
     # Configure the types of entities that should be masked on user input.

--- a/docs/user-guides/community/active-fence.md
+++ b/docs/user-guides/community/active-fence.md
@@ -1,6 +1,6 @@
 # ActiveFence Integration
 
-NeMo Guardrails supports using the [ActiveFence ActiveScore API](https://docs.activefence.com/index.html) as an input rail out-of-the-box (you need to have the `ACTIVEFENCE_API_KEY` environment variable set).
+NeMo Guardrails supports using the [ActiveFence ActiveScore API](https://docs.activefence.com/index.html) as an input and output rail out-of-the-box (you need to have the `ACTIVEFENCE_API_KEY` environment variable set).
 
 ```yaml
 rails:
@@ -13,7 +13,7 @@ rails:
       # - activefence moderation detailed
 ```
 
-The `activefence moderation` flow uses the maximum risk score with an 0.85 threshold to decide if the input should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation detailed` has individual scores per category of violation.
+The `activefence moderation` flow uses the maximum risk score with an 0.85 threshold to decide if the text should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation detailed` has individual scores per category of violation.
 
 To customize the scores, you have to overwrite the [default flows](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/nemoguardrails/library/activefence/flows.co) in your config. For example, to change the threshold for `activefence moderation` you can add the following flow to your config:
 

--- a/docs/user-guides/community/active-fence.md
+++ b/docs/user-guides/community/active-fence.md
@@ -7,18 +7,18 @@ rails:
   input:
     flows:
       # The simplified version
-      - activefence moderation
+      - activefence moderation on input
 
       # The detailed version with individual risk scores
-      # - activefence moderation detailed
+      # - activefence moderation on input detailed
 ```
 
-The `activefence moderation` flow uses the maximum risk score with an 0.85 threshold to decide if the text should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation detailed` has individual scores per category of violation.
+The `activefence moderation` flow uses the maximum risk score with an 0.85 threshold to decide if the text should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation on input detailed` has individual scores per category of violation.
 
-To customize the scores, you have to overwrite the [default flows](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/nemoguardrails/library/activefence/flows.co) in your config. For example, to change the threshold for `activefence moderation` you can add the following flow to your config:
+To customize the scores, you have to overwrite the [default flows](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/nemoguardrails/library/activefence/flows.co) in your config. For example, to change the threshold for `activefence moderation on input` you can add the following flow to your config:
 
 ```colang
-define subflow activefence moderation
+define subflow activefence moderation on input
   """Guardrail based on the maximum risk score."""
   $result = execute call activefence api
 

--- a/docs/user-guides/community/active-fence.md
+++ b/docs/user-guides/community/active-fence.md
@@ -13,7 +13,7 @@ rails:
       # - activefence moderation on input detailed
 ```
 
-The `activefence moderation` flow uses the maximum risk score with an 0.85 threshold to decide if the text should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation on input detailed` has individual scores per category of violation.
+The `activefence moderation on input` flow uses the maximum risk score with an 0.85 threshold to decide if the text should be allowed or not (i.e., if the risk score is above the threshold, it is considered a violation). The `activefence moderation on input detailed` has individual scores per category of violation.
 
 To customize the scores, you have to overwrite the [default flows](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/nemoguardrails/library/activefence/flows.co) in your config. For example, to change the threshold for `activefence moderation on input` you can add the following flow to your config:
 

--- a/docs/user-guides/guardrails-library.md
+++ b/docs/user-guides/guardrails-library.md
@@ -692,10 +692,10 @@ NeMo Guardrails supports using the [ActiveFence ActiveScore API](https://docs.ac
 rails:
   input:
     flows:
-      - activefence moderation
+      - activefence moderation on input
   output:
     flows:
-      - activefence moderation
+      - activefence moderation on output
 ```
 
 For more details, check out the [ActiveFence Integration](./community/active-fence.md) page.

--- a/docs/user-guides/guardrails-library.md
+++ b/docs/user-guides/guardrails-library.md
@@ -684,13 +684,16 @@ This category of rails relies on 3rd party APIs for various guardrailing tasks.
 
 ### ActiveFence
 
-NeMo Guardrails supports using the [ActiveFence ActiveScore API](https://docs.activefence.com/index.html) as an input rail out-of-the-box (you need to have the `ACTIVEFENCE_API_KEY` environment variable set).
+NeMo Guardrails supports using the [ActiveFence ActiveScore API](https://docs.activefence.com/index.html) as an input and output rail out-of-the-box (you need to have the `ACTIVEFENCE_API_KEY` environment variable set).
 
 #### Example usage
 
 ```yaml
 rails:
   input:
+    flows:
+      - activefence moderation
+  output:
     flows:
       - activefence moderation
 ```

--- a/examples/sample_config.yml
+++ b/examples/sample_config.yml
@@ -7,7 +7,7 @@ rails:
     flows:
       - self check input
       - check sensitive data
-      - activefence moderation
+      - activefence moderation on input
       - check toxicity
       - some other moderation thing
 
@@ -35,7 +35,7 @@ rails:
     flows:
       - self check facts
       - self check hallucination
-      - activefence moderation
+      - activefence moderation on output
       - check sensitive data
 
   # Execution rails are triggered before and after an action is invoked

--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -32,12 +32,15 @@ async def call_activefence_api(context: Optional[dict] = None):
     if api_key is None:
         raise ValueError("ACTIVEFENCE_API_KEY environment variable not set.")
 
-    user_message = context.get("user_message")
+    if context.get("triggered_input_rail"):
+        text = context.get("user_message")
+    else:
+        text = context.get("bot_message")
 
     url = "https://apis.activefence.com/sync/v3/content/text"
     headers = {"af-api-key": api_key, "af-source": "nemo-guardrails"}
     data = {
-        "text": user_message,
+        "text": text,
         "content_id": "ng-" + new_uuid(),
     }
 

--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -25,17 +25,12 @@ from nemoguardrails.utils import new_uuid
 log = logging.getLogger(__name__)
 
 
-@action(name="call activefence api", is_system_action=True)
-async def call_activefence_api(context: Optional[dict] = None):
+@action(is_system_action=True)
+async def call_activefence_api(text: Optional[str] = None):
     api_key = os.environ.get("ACTIVEFENCE_API_KEY")
 
     if api_key is None:
         raise ValueError("ACTIVEFENCE_API_KEY environment variable not set.")
-
-    if context.get("triggered_input_rail"):
-        text = context["user_message"]
-    else:
-        text = context["bot_message"]
 
     url = "https://apis.activefence.com/sync/v3/content/text"
     headers = {"af-api-key": api_key, "af-source": "nemo-guardrails"}

--- a/nemoguardrails/library/activefence/actions.py
+++ b/nemoguardrails/library/activefence/actions.py
@@ -33,9 +33,9 @@ async def call_activefence_api(context: Optional[dict] = None):
         raise ValueError("ACTIVEFENCE_API_KEY environment variable not set.")
 
     if context.get("triggered_input_rail"):
-        text = context.get("user_message")
+        text = context["user_message"]
     else:
-        text = context.get("bot_message")
+        text = context["bot_message"]
 
     url = "https://apis.activefence.com/sync/v3/content/text"
     headers = {"af-api-key": api_key, "af-source": "nemo-guardrails"}

--- a/nemoguardrails/library/activefence/flows.co
+++ b/nemoguardrails/library/activefence/flows.co
@@ -13,9 +13,9 @@ Adult Content	General
 Privacy Violation	PII
 """
 
-flow activefence moderation
+define flow activefence moderation on input
   """Guardrail based on the maximum risk score."""
-  $result = await  CallActivefenceApiAction()
+  $result = await  CallActivefenceApiAction(text=$input_text)
 
   if $result.max_risk_score > 0.7
     if $system.config.enable_rails_exceptions
@@ -24,9 +24,20 @@ flow activefence moderation
       bot refuse to respond
     abort
 
-flow activefence moderation detailed
+flow activefence moderation on output
+  """Guardrail based on the maximum risk score."""
+  $result = await  CallActivefenceApiAction(text=$input_text)
+
+  if $result.max_risk_score > 0.7
+    if $system.config.enable_rails_exceptions
+      send ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+    else
+      bot refuse to respond
+    abort
+
+flow activefence moderation on input detailed
   """Guardrail based on individual risk scores."""
-  $result = await  CallActivefenceApiAction()
+  $result = await  CallActivefenceApiAction(text=$input_text)
 
   if $result.violations.get("abusive_or_harmful.harassment_or_bullying", 0) > 0.8
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/activefence/flows.co
+++ b/nemoguardrails/library/activefence/flows.co
@@ -13,9 +13,9 @@ Adult Content	General
 Privacy Violation	PII
 """
 
-define flow activefence moderation on input
+flow activefence moderation on input
   """Guardrail based on the maximum risk score."""
-  $result = await  CallActivefenceApiAction(text=$input_text)
+  $result = await  CallActivefenceApiAction(text=$user_message)
 
   if $result.max_risk_score > 0.7
     if $system.config.enable_rails_exceptions
@@ -26,7 +26,7 @@ define flow activefence moderation on input
 
 flow activefence moderation on output
   """Guardrail based on the maximum risk score."""
-  $result = await  CallActivefenceApiAction(text=$input_text)
+  $result = await  CallActivefenceApiAction(text=$bot_message)
 
   if $result.max_risk_score > 0.7
     if $system.config.enable_rails_exceptions
@@ -37,7 +37,7 @@ flow activefence moderation on output
 
 flow activefence moderation on input detailed
   """Guardrail based on individual risk scores."""
-  $result = await  CallActivefenceApiAction(text=$input_text)
+  $result = await  CallActivefenceApiAction(text=$user_message)
 
   if $result.violations.get("abusive_or_harmful.harassment_or_bullying", 0) > 0.8
     if $system.config.enable_rails_exceptions

--- a/nemoguardrails/library/activefence/flows.v1.co
+++ b/nemoguardrails/library/activefence/flows.v1.co
@@ -13,9 +13,9 @@ Adult Content	General
 Privacy Violation	PII
 """
 
-define subflow activefence moderation
+define subflow activefence moderation on input
   """Guardrail based on the maximum risk score."""
-  $result = execute call activefence api
+  $result = execute call_activefence_api(text=$user_message)
 
   if $result.max_risk_score > 0.7
     if $config.enable_rails_exceptions
@@ -24,9 +24,21 @@ define subflow activefence moderation
       bot refuse to respond
     stop
 
-define subflow activefence moderation detailed
+ define subflow activefence moderation on output
+  """Guardrail based on the maximum risk score."""
+  $result = execute call_activefence_api(text=$bot_message)
+
+  if $result.max_risk_score > 0.7
+    if $config.enable_rails_exceptions
+      create event ActiveFenceModerationRailException(message="ActiveFence moderation triggered. The maximum risk score exceeded the threshold.")
+    else
+      bot refuse to respond
+    stop
+
+
+define subflow activefence moderation on input detailed
   """Guardrail based on individual risk scores."""
-  $result = execute call activefence api
+  $result = execute call_activefence_api(text=$user_message)
 
   if $result.violations.get("abusive_or_harmful.harassment_or_bullying", 0) > 0.8
     if $config.enable_rails_exceptions

--- a/tests/test_activefence_rail.py
+++ b/tests/test_activefence_rail.py
@@ -43,7 +43,7 @@ def test_input(monkeypatch):
             rails:
               input:
                 flows:
-                  - activefence moderation
+                  - activefence moderation on input
         """,
     )
     chat = TestChat(
@@ -103,7 +103,7 @@ def test_output(monkeypatch):
             rails:
               output:
                 flows:
-                  - activefence moderation
+                  - activefence moderation on output
         """,
     )
     chat = TestChat(


### PR DESCRIPTION
## Description
The current implementation of activefence action allows sending only user messages to activefence API.
This PR allows sending LLM output messages to Activefence API as part ofthe  output rail.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
