### PR TITLE
Add option to configure SHA256 hash algorithm instead of MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The changes related to the Colang language and runtime have moved to [CHANGELOG-
 
 ### Added
 
+- **Hashing Configuration**: Added SHA-256 hashing algorithm and an option to configure it ([#910](https://github.com/NVIDIA/NeMo-Guardrails/pull/910)) by @mdambski
 - **Observability**: Add observability support with support for different backends ([#844](https://github.com/NVIDIA/NeMo-Guardrails/pull/844)) by @Pouyanpi
 - **Private AI Integration**: Add Private AI Integration ([#815](https://github.com/NVIDIA/NeMo-Guardrails/pull/815)) by @letmerecall
 - **Patronus Evaluate API Integration**: Patronus Evaluate API Integration ([#834](https://github.com/NVIDIA/NeMo-Guardrails/pull/834)) by @varjoshi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The changes related to the Colang language and runtime have moved to [CHANGELOG-
 
 ### Added
 
-- **Hashing Configuration**: Added SHA-256 hashing algorithm and an option to configure it ([#910](https://github.com/NVIDIA/NeMo-Guardrails/pull/910)) by @mdambski
+- **Hashing Configuration**: Added SHA-256 hashing algorithm and made it configurable ([#910](https://github.com/NVIDIA/NeMo-Guardrails/pull/910)) by @mdambski
 - **Observability**: Add observability support with support for different backends ([#844](https://github.com/NVIDIA/NeMo-Guardrails/pull/844)) by @Pouyanpi
 - **Private AI Integration**: Add Private AI Integration ([#815](https://github.com/NVIDIA/NeMo-Guardrails/pull/815)) by @letmerecall
 - **Patronus Evaluate API Integration**: Patronus Evaluate API Integration ([#834](https://github.com/NVIDIA/NeMo-Guardrails/pull/834)) by @varjoshi

--- a/docs/user-guides/advanced/embedding-search-providers.md
+++ b/docs/user-guides/advanced/embedding-search-providers.md
@@ -71,7 +71,7 @@ knowledge_base:
 The default implementation is also designed to support asynchronous execution of the embedding computation process, thereby enhancing the efficiency of the search functionality.
 
 The `cache` configuration is optional. If enabled, it uses the specified `key_generator` and `store` to cache the embeddings. The `store_config` can be used to provide additional configuration options required for the store.
-The default `cache` configuration uses the `md5` key generator and the `filesystem` store. The cache is disabled by default.
+The default `cache` configuration uses the `md5` key generator and the `filesystem` store. Alternatively, `sha256` or `hash` key generators can be selected. The cache is disabled by default.
 
 ## Batch Implementation
 

--- a/nemoguardrails/embeddings/cache.py
+++ b/nemoguardrails/embeddings/cache.py
@@ -64,6 +64,15 @@ class MD5KeyGenerator(KeyGenerator):
         return hashlib.md5(text.encode("utf-8")).hexdigest()
 
 
+class SHA256KeyGenerator(KeyGenerator):
+    """SHA256-based key generator."""
+
+    name = "sha256"
+
+    def generate_key(self, text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
 class CacheStore(ABC):
     """Abstract class for cache stores."""
 

--- a/nemoguardrails/kb/kb.py
+++ b/nemoguardrails/kb/kb.py
@@ -99,6 +99,12 @@ class KnowledgeBase:
             chunks = split_markdown_in_topic_chunks(doc)
             self.chunks.extend(chunks)
 
+    def compute_hash(self, value):
+        """Compute the hash of a given value."""
+        hash_map = {"md5": hashlib.md5, "sha256": hashlib.sha256}
+        func = hash_map[self.config.hash_algorithm]
+        return func(value.encode("utf-8")).hexdigest()
+
     async def build(self):
         """Builds the knowledge base index."""
         t0 = time()
@@ -114,18 +120,16 @@ class KnowledgeBase:
         if not index_items:
             return
 
-        # We compute the md5
+        # We compute the hash
         # As part of the hash, we also include the embedding engine and the model
         # to prevent the cache being used incorrectly when the embedding model changes.
         hash_prefix = self.config.embedding_search_provider.parameters.get(
             "embedding_engine", ""
         ) + self.config.embedding_search_provider.parameters.get("embedding_model", "")
 
-        md5_hash = hashlib.md5(
-            (hash_prefix + "".join(all_text_items)).encode("utf-8")
-        ).hexdigest()
-        cache_file = os.path.join(CACHE_FOLDER, f"{md5_hash}.ann")
-        embedding_size_file = os.path.join(CACHE_FOLDER, f"{md5_hash}.esize")
+        hash_value = self.compute_hash(hash_prefix + "".join(all_text_items))
+        cache_file = os.path.join(CACHE_FOLDER, f"{hash_value}.ann")
+        embedding_size_file = os.path.join(CACHE_FOLDER, f"{hash_value}.esize")
 
         # If we have already computed this before, we use it
         if (

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -279,6 +279,10 @@ class KnowledgeBaseConfig(BaseModel):
         default_factory=EmbeddingSearchProvider,
         description="The search provider used to search the knowledge base.",
     )
+    hash_algorithm: str = Field(
+        default="md5",
+        description="The algorithm to use for computing hashes.",
+    )
 
 
 class CoreConfig(BaseModel):

--- a/tests/test_cache_embeddings.py
+++ b/tests/test_cache_embeddings.py
@@ -30,6 +30,7 @@ from nemoguardrails.embeddings.cache import (
     KeyGenerator,
     MD5KeyGenerator,
     RedisCacheStore,
+    SHA256KeyGenerator,
     cache_embeddings,
 )
 from nemoguardrails.rails.llm.config import EmbeddingsCacheConfig
@@ -56,6 +57,22 @@ def test_md5_key_generator():
     key = key_gen.generate_key("test")
     assert isinstance(key, str)
     assert len(key) == 32  # MD5 hash is 32 characters long
+
+
+def test_sha256_key_generator():
+    key_gen = SHA256KeyGenerator()
+    key = key_gen.generate_key("test")
+    assert isinstance(key, str)
+    assert len(key) == 64  # SHA256 hash is 64 characters long
+
+
+@pytest.mark.parametrize("name, expected_class", [
+    ("hash", HashKeyGenerator),
+    ("md5", MD5KeyGenerator),
+    ("sha256", SHA256KeyGenerator),
+])
+def test_key_generator_class(name, expected_class):
+    assert KeyGenerator.from_name(name) == expected_class
 
 
 def test_in_memory_cache_store():
@@ -89,6 +106,7 @@ def test_redis_cache_store():
 
 
 class TestEmbeddingsCache(unittest.TestCase):
+
     def setUp(self):
         self.cache_embeddings = EmbeddingsCache(
             key_generator=MD5KeyGenerator(), cache_store=FilesystemCacheStore()

--- a/tests/test_cache_embeddings.py
+++ b/tests/test_cache_embeddings.py
@@ -66,11 +66,14 @@ def test_sha256_key_generator():
     assert len(key) == 64  # SHA256 hash is 64 characters long
 
 
-@pytest.mark.parametrize("name, expected_class", [
-    ("hash", HashKeyGenerator),
-    ("md5", MD5KeyGenerator),
-    ("sha256", SHA256KeyGenerator),
-])
+@pytest.mark.parametrize(
+    "name, expected_class",
+    [
+        ("hash", HashKeyGenerator),
+        ("md5", MD5KeyGenerator),
+        ("sha256", SHA256KeyGenerator),
+    ],
+)
 def test_key_generator_class(name, expected_class):
     assert KeyGenerator.from_name(name) == expected_class
 
@@ -106,7 +109,6 @@ def test_redis_cache_store():
 
 
 class TestEmbeddingsCache(unittest.TestCase):
-
     def setUp(self):
         self.cache_embeddings = EmbeddingsCache(
             key_generator=MD5KeyGenerator(), cache_store=FilesystemCacheStore()

--- a/tests/test_configs/with_openai_embeddings_and_sha256/config.co
+++ b/tests/test_configs/with_openai_embeddings_and_sha256/config.co
@@ -1,0 +1,12 @@
+define user ask capabilities
+  "What can you do?"
+  "What can you help me with?"
+  "tell me what you can do"
+  "tell me about you"
+
+define bot inform capabilities
+  "I am an AI assistant that helps answer questions."
+
+define flow
+  user ask capabilities
+  bot inform capabilities

--- a/tests/test_configs/with_openai_embeddings_and_sha256/config.yml
+++ b/tests/test_configs/with_openai_embeddings_and_sha256/config.yml
@@ -1,0 +1,26 @@
+# Config where SHA256 is used for both KB hashing and cache key generation
+models:
+  - type: main
+    engine: openai
+    model: gpt-3.5-turbo-instruct
+
+core:
+  embedding_search_provider:
+    name: default
+    parameters:
+      embedding_engine: openai
+      embedding_model: text-embedding-ada-002
+    cache:
+      enabled: True
+      key_generator: sha256
+
+knowledge_base:
+  hash_algorithm: sha256
+  embedding_search_provider:
+    name: default
+    parameters:
+      embedding_engine: openai
+      embedding_model: text-embedding-ada-002
+    cache:
+      enabled: True
+      key_generator: sha256

--- a/tests/test_configs/with_openai_embeddings_and_sha256/kb/kb.md
+++ b/tests/test_configs/with_openai_embeddings_and_sha256/kb/kb.md
@@ -1,0 +1,7 @@
+# A Sample Knowledge Base
+
+## NeMo Guardrails
+
+NeMo Guardrails is an open-source toolkit for easily adding programmable guardrails to LLM-based conversational systems. Guardrails (or "rails" for short) are specific ways of controlling the output of a large language model, such as not talking about politics, responding in a particular way to specific user requests, following a predefined dialog path, using a particular language style, extracting structured data, and more.
+
+This toolkit is currently in its early alpha stages, and we invite the community to contribute towards making the power of trustworthy, safe, and secure LLMs accessible to everyone. The examples provided within the documentation are for educational purposes to get started with NeMo Guardrails, and are not meant for use in production applications.


### PR DESCRIPTION
## Description
At the moment, the library by default uses MD5 hashing and does not allow the option to choose an alternative algorithm from the approved list under [FIPS](https://csrc.nist.gov/pubs/fips/140-2/upd2/final) regulation. Some versions of Python, which are FIPS compliant, will raise an error when trying to use the MD5 hashing algorithm (more information on FIPS specific behaviour in [python docs](https://docs.python.org/3/library/hashlib.html#hash-algorithms)).

This change-set preserves the current default (MD5) but allows choosing SHA-256 as an alternative.

## Related Issue(s)

  - Fixes #909 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
