### PR TITLE
chore: remove Ubuntu from full-tests workflow

### DIFF
--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -18,8 +18,6 @@ jobs:
         os: [Windows, macOS] # exclude Ubuntu as it is available in pr-tests
         python-version: ["3.9", "3.10", "3.11"]
         include:
-          - os: Ubuntu
-            image: ubuntu-latest
           - os: Windows
             image: windows-2022
           - os: macOS


### PR DESCRIPTION
## Description
It removes the dead code in full-tests workflow.

Recent Github Runner runs against out of scope test matrix.

The issue happened in #927 in full-tests job where it wrongly used Ubuntu as OS with Python 3.12.

