### PR TITLE
Typos with oauthtoken

### DIFF
--- a/docs/user-guides/advanced/nemoguard-contentsafety-deployment.md
+++ b/docs/user-guides/advanced/nemoguard-contentsafety-deployment.md
@@ -13,7 +13,7 @@ Once you have the NGC API key with the necessary permissions, set the following 
 
 ```bash
 export NGC_API_KEY=<your NGC API key>
-docker login nvcr.io -u "$oauthtoken" -p <<< <your NGC API key>
+docker login nvcr.io -u '$oauthtoken' -p <<< <your NGC API key>
 ```
 
 Test that you are able to use the NVIDIA NIM assets through by pulling the latest NemoGuard container.

--- a/docs/user-guides/advanced/nemoguard-topiccontrol-deployment.md
+++ b/docs/user-guides/advanced/nemoguard-topiccontrol-deployment.md
@@ -13,7 +13,7 @@ Once you have the NGC API key with the necessary permissions, set the following 
 
 ```bash
 export NGC_API_KEY=<your NGC API key>
-docker login nvcr.io -u "$oauthtoken" -p <<< <your NGC API key>
+docker login nvcr.io -u '$oauthtoken' -p <<< <your NGC API key>
 ```
 
 Test that you are able to use the NVIDIA NIM assets through by pulling the latest TopicControl container.


### PR DESCRIPTION
## Description

Fix use of '$oauthtoken' in sample command.

Review HTML:
* https://nvidia.github.io/NeMo-Guardrails/review/pr-957/user-guides/advanced/nemoguard-contentsafety-deployment.html#access
* https://nvidia.github.io/NeMo-Guardrails/review/pr-957/user-guides/advanced/nemoguard-topiccontrol-deployment.html#access

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
