### PR TITLE
Use ref name as dir for push build

### DIFF
--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -74,7 +74,7 @@ jobs:
                   path: pr/
 
     store-html:
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.repository_owner == 'NVIDIA'
         needs: [build-docs]
         runs-on: ubuntu-latest
         steps:
@@ -89,6 +89,7 @@ jobs:
               uses: actions/download-artifact@v4
               with:
                   name: html-build-artifact
+                  path: ${{ github.ref_name }}
             - name: Copy HTML directories
               run: |
                   ls -asl


### PR DESCRIPTION
## Description

Add the HTML to `gh-pages` in a directory that matches the pushed ref, like `develop`.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
