### PR TITLE
Fix TypeError from attempting to unpack already-unpacked dictionary.

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -118,4 +118,4 @@ async def jailbreak_detection_model(
         # If no result, assume not a jailbreak
         return False
     else:
-        return jailbreak["jailbreak"]
+        return jailbreak


### PR DESCRIPTION
## Description

`actions.py` for jailbreak models throws a `TypeError` since the `jailbreak` dictionary is already unpacked by the server.

## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ x ] I've updated the documentation if applicable.
- [ x ] I've added tests if applicable.
- [ x ] @mentions of the person or team responsible for reviewing proposed changes.
