### PR TITLE
ci: add upgrade-deps option to test workflow

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -18,6 +18,11 @@ on:
         required: true
         default: "3.10"
         type: string
+      upgrade-deps:
+        description: "Whether to install all extras"
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -72,7 +77,13 @@ jobs:
         run: poetry check --lock
 
       - name: Install dependencies
-        run: poetry install --with dev
+        run: |
+          if [ "${{ inputs.upgrade-deps}}" = "true" ]; then
+            poetry update
+            poetry install --all-extras --with dev
+          else
+            poetry install --with dev
+          fi
 
       - name: Run pre-commit hooks
         run: poetry run make pre_commit

--- a/.github/workflows/latest-deps-tests.yml
+++ b/.github/workflows/latest-deps-tests.yml
@@ -1,0 +1,26 @@
+name: Test with Latest Dependencies
+
+on:
+  push:
+    paths-ignore:
+      - ".github/**"
+    tags:
+      - "v*"
+  schedule:
+    - cron: "0 22 * * *" # 10:00 PM UTC, daily
+jobs:
+  call-tests:
+    strategy:
+      matrix:
+        os: [Ubuntu]
+        python-version: ["3.9", "3.10", "3.11"]
+        include:
+          - os: Ubuntu
+            image: ubuntu-latest
+      fail-fast: false
+    uses: ./.github/workflows/_test.yml
+    with:
+      os: ${{ matrix.os }}
+      image: ${{ matrix.image }}
+      python-version: ${{ matrix.python-version }}
+      upgrade-deps: true


### PR DESCRIPTION
This workflow allows us to identify any issues caused by the latest dependencies.

- Update dependencies to the latest version
- Install extra (optional) dependencies
- Run tests


