### PR TITLE
Fix bug with git to fetch models, use wget instead

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/Dockerfile
+++ b/nemoguardrails/library/jailbreak_detection/Dockerfile
@@ -1,8 +1,8 @@
 # Use python:3.10 as the base image
 FROM python:3.10-slim
 
-# Install git
-RUN apt-get update && apt-get install -y git gcc g++ python3-dev && apt-get clean
+# Install git and wget
+RUN apt-get update && apt-get install -y git gcc g++ python3-dev wget && apt-get clean
 
 # Set working directory
 WORKDIR /app
@@ -23,8 +23,8 @@ RUN python -c "from transformers import GPT2LMHeadModel, GPT2TokenizerFast; GPT2
 
 # Predownload embedding-based jailbreak detection models, set environment variable for path
 WORKDIR /models
-RUN git clone git@hf.co:/nvidia/NemoGuard-JailbreakDetect
-ENV EMBEDDING_CLASSIFIER_PATH=/models/NemoGuard-JailbreakDetect
+RUN wget https://huggingface.co/nvidia/NemoGuard-JailbreakDetect/resolve/main/snowflake.pkl
+ENV EMBEDDING_CLASSIFIER_PATH=/models
 
 # Expose a port for the server
 EXPOSE 1337

--- a/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
+++ b/nemoguardrails/library/jailbreak_detection/Dockerfile-GPU
@@ -1,8 +1,8 @@
 # Use nvidia/cuda:12.3.1-base-ubuntu20.04 as the base image
 FROM nvidia/cuda:12.3.1-base-ubuntu20.04
 
-# Install git
-RUN apt-get update && apt-get install -y git gcc g++ && apt-get clean
+# Install git and wget
+RUN apt-get update && apt-get install -y git gcc g++ wget && apt-get clean
 
 # Install python
 RUN apt-get install python3 python3-pip python3-dev -y
@@ -29,8 +29,8 @@ ENV JAILBREAK_CHECK_DEVICE=cuda:0
 
 # Predownload embedding-based jailbreak detection models, set environment variable for path
 WORKDIR /models
-RUN git clone git@hf.co:/nvidia/NemoGuard-JailbreakDetect
-ENV EMBEDDING_CLASSIFIER_PATH=/models/NemoGuard-JailbreakDetect
+RUN wget https://huggingface.co/nvidia/NemoGuard-JailbreakDetect/resolve/main/snowflake.pkl
+ENV EMBEDDING_CLASSIFIER_PATH=/models
 
 # To use nvidia/nv-embedqa-e5-v5 model, uncomment the line below and set your API key
 # ENV NVIDIA_API_KEY=<your_api_key>


### PR DESCRIPTION
## Description

Jailbreak container fails to build on most systems due to hf rejecting git clone.

## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ x ] I've updated the documentation if applicable.
- [ x ] I've added tests if applicable.
- [ x ] @mentions of the person or team responsible for reviewing proposed changes.
