### PR TITLE
Feat: Support Models with Reasoning Traces

### DIFF
--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -94,6 +94,29 @@ To use any of the providers, you must install additional packages; when you firs
 Although you can instantiate any of the previously mentioned LLM providers, depending on the capabilities of the model, the NeMo Guardrails toolkit works better with some providers than others. The toolkit includes prompts that have been optimized for certain types of models, such as `openai` and `nemollm`. For others, you can optimize the prompts yourself following the information in the [LLM Prompts](#llm-prompts) section.
 ```
 
+#### Using LLMs with Reasoning Traces
+
+To use an LLM that outputs the reasoning traces as part of the response (e.g. [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d)), the following model config should be used:
+
+```yaml
+models:
+  - type: main
+    engine: deepseek
+    model: deepseek-reasoner
+    reasoning_config:
+      remove_thinking_traces: True
+      start_token: "<think>"
+      end_token: "</think>"
+```
+
+The `reasoning_config` attribute for a model contains all the required configuration for a reasoning model that outputs reasoning traces.
+In most of the cases, the reasoning traces need to be removed and the guardrails runtime will only process the actual responses from the LLM.
+
+The attributes that can be configured for a reasoning model are:
+- `remove_thinking_traces`: if the reasoning traces should be ignored (defaults to `True`.
+- `start_token`: the start token for the reasoning process (e.g. `<think>` for DeepSeek-R1).
+- `end_token`: the end token for the reasoning process (e.g. `</think>` for DeepSeek-R1).
+
 #### NIM for LLMs
 
 [NVIDIA NIM](https://docs.nvidia.com/nim/index.html) is a set of easy-to-use microservices designed to accelerate the deployment of generative AI models across the cloud, data center, and workstations.

--- a/examples/configs/llm/deepseek-r1/config.yml
+++ b/examples/configs/llm/deepseek-r1/config.yml
@@ -1,0 +1,8 @@
+models:
+  - type: main
+    engine: deepseek
+    model: deepseek-reasoner
+    reasoning_config:
+      remove_thinking_traces: True
+      start_token: "<think>"
+      end_token: "</think>"

--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -78,7 +78,9 @@ async def self_check_facts(
     if llm_task_manager.has_output_parser(task):
         result = llm_task_manager.parse_task_output(task, output=response)
     else:
-        result = llm_task_manager.output_parsers["is_content_safe"](response)
+        result = llm_task_manager.parse_task_output(
+            task, output=response, forced_output_parser="is_content_safe"
+        )
 
     is_not_safe, _ = result
 

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -79,7 +79,9 @@ async def self_check_input(
             result = llm_task_manager.parse_task_output(task, output=response)
 
         else:
-            result = llm_task_manager.output_parsers["is_content_safe"](response)
+            result = llm_task_manager.parse_task_output(
+                task, output=response, forced_output_parser="is_content_safe"
+            )
 
         is_safe, _ = result
 

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -83,7 +83,9 @@ async def self_check_output(
         if llm_task_manager.has_output_parser(task):
             result = llm_task_manager.parse_task_output(task, output=response)
         else:
-            result = llm_task_manager.output_parsers["is_content_safe"](response)
+            result = llm_task_manager.parse_task_output(
+                task, output=response, forced_output_parser="is_content_safe"
+            )
 
         is_safe, _ = result
 

--- a/nemoguardrails/llm/filters.py
+++ b/nemoguardrails/llm/filters.py
@@ -482,3 +482,26 @@ def conversation_to_events(conversation: List) -> List[dict]:
             )
 
     return events
+
+
+def remove_reasoning_traces(response: str, start_token: str, end_token: str) -> str:
+    """Removes the text between the first occurrence of the start token and the
+    last occurrence of the last token, if these tokens exist in the response.
+
+    This utility function is useful to strip reasoning traces from reasoning LLMs
+    that encode the reasoning traces between specific tokens.
+    """
+    if start_token and end_token:
+        start_index = response.find(start_token)
+        # If the start index is missing, this is probably a continuation of a bot message
+        # started in the prompt.
+        if start_index == -1:
+            start_index = 0
+        end_index = response.rfind(end_token)
+        if end_index == -1:
+            return response
+
+        if start_index != -1 and end_index != -1 and start_index < end_index:
+            return response[:start_index] + response[end_index + len(end_token) :]
+
+    return response

--- a/nemoguardrails/llm/prompts/deepseek.yml
+++ b/nemoguardrails/llm/prompts/deepseek.yml
@@ -1,0 +1,291 @@
+# Current version of prompts for Deepseek models (including V3 and R1),
+# use a single user turn for all tasks. Performance is better than using a
+# complex multi-turn prompt similar to the one used for Llama models.
+
+# Collection of all the prompts
+prompts:
+    # GENERAL PROMPTS
+
+    - task: general
+      models:
+          - deepseek
+      content: |-
+          {{ general_instructions }}
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+
+          {% if relevant_chunks != None and relevant_chunks != '' %}
+            This is some relevant context:
+            ```markdown
+            {{ relevant_chunks }}
+            ```
+          {% endif %}
+
+          {{ history | user_assistant_sequence }}
+          Assistant:
+      max_tokens: 3000
+
+    # Prompt for detecting the user message canonical form.
+    - task: generate_user_intent
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          Your task is to generate the user intent in a conversation given the last user message similar to the examples below.
+          Do not provide any explanations, just output the user intent.
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # These are examples how to generate an intent from an user message:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          # Choose intent from this list if applicable: {{ potential_user_intents }}
+          {{ history | colang }}
+      max_tokens: 3000
+
+    # Prompt for generating the next steps.
+    - task: generate_next_steps
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          Your task is to generate the next steps in a conversation given the last user message similar to the examples below.
+          Do not provide any explanations, just output the bot intent and any other next steps if needed.
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # These are examples how to generate the next step(s) in the conversation:
+          {{ examples | remove_text_messages}}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) | remove_text_messages}}
+          {{ history | colang | remove_text_messages}}
+      max_tokens: 3000
+
+    # Prompt for generating the bot message from a canonical form.
+    - task: generate_bot_message
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          Your task is to generate the bot message in a conversation given the last user message, user intent and bot intent.
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          {% if relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ relevant_chunks }}
+          ```
+          {% endif %}
+
+          # These are examples how to generate the bot message from the bot intent:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+      max_tokens: 3000
+
+    # Prompt for generating the user intent, next steps and bot message in a single call.
+    - task: generate_intent_steps_message
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          Your task is to generate the user intent and the next steps in a conversation given the last user message similar to the examples below.
+          Do not provide any explanations, just output the user intent and the next steps.
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # For each user message, generate the next steps and finish with the bot message.
+          # These are some examples for the task at hand:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+      max_tokens: 3000
+
+    # Prompt for generating the value of a context variable.
+    - task: generate_value
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          Your task is to extract a slot with the name mentioned above from the conversation.
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # These are some examples for the task at hand:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ sample_conversation | first_turns(2) }}
+          {{ history | colang }}
+          # {{ instructions }}
+          ${{ var_name }} =
+      max_tokens: 3000
+
+    # Colang 2.x prompts below.
+
+    # Prompt for detecting the user message canonical form.
+    - task: generate_user_intent_from_user_action
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # These are the most likely user intents:
+          {{ examples }}
+
+          # This is the current conversation between the user and the bot:
+          {{ history | colang }}
+
+          # Continuation of interaction using only specified user intents from the section 'These are the most likely user intents:':
+          user action: {{ user_action }}
+          user intent:
+      stop:
+          - "\n"
+
+    - task: generate_user_intent_and_bot_action_from_user_action
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # These are the most likely user intents:
+          {{ examples }}
+
+
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
+
+          # This is the current conversation between the user and the bot:
+          {{ history | colang }}
+
+          # Continuation of interaction using only specified user intents from the section 'These are the most likely user intents:':
+          user action: {{ user_action }}
+          user intent:
+      stop:
+          - "\nuser intent:"
+
+    # Prompt for generating the value of a context variable.
+    - task: generate_value_from_instruction
+      models:
+          - deepseek
+      content: |-
+          """
+          {{ general_instructions }}
+
+          IMPORTANT: Use a short thinking process to determine the final answer.
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          # This is the current conversation between the user and the bot:
+          {{ history | colang }}
+
+          # {{ instructions }}
+          ${{ var_name }} =
+      stop:
+          - "\n"
+
+    # Prompt for generating a flow from instructions.
+    - task: generate_flow_from_instructions
+      models:
+          - deepseek
+      content: |-
+          IMPORTANT: Use a short thinking process to determine the final answer.
+
+          # Example flows:
+          {{ examples }}
+
+          # Complete the following flow based on its instruction:
+          flow {{ flow_name }}
+            """{{ instructions }}"""
+
+    # Prompt for generating a flow from name.
+    - task: generate_flow_from_name
+      models:
+          - deepseek
+      content: |-
+          IMPORTANT: Use a short thinking process to determine the final answer.
+
+          # Example flows:
+          {{ examples }}
+
+          # Complete the following flow based on its name:
+          flow {{ flow_name }}
+      stop:
+          - "\nflow"
+
+      # Prompt for generating the continuation for the current conversation.
+    - task: generate_flow_continuation
+      models:
+          - deepseek
+      content: |-
+          IMPORTANT: Use a short thinking process to determine the final answer.
+
+          """
+          {{ general_instructions }}
+          """
+
+          # This is how a conversation between a user and the bot can go:
+          {{ sample_conversation }}
+
+          {% if context.relevant_chunks %}
+          # This is some additional context:
+          ```markdown
+          {{ context.relevant_chunks }}
+          ```
+          {% endif %}
+
+          # This is the current conversation between the user and the bot:
+          {{ history | colang }}
+
+
+          bot intent:
+
+    - task: generate_flow_continuation_from_flow_nld
+      models:
+          - deepseek
+      content: |-
+          IMPORTANT: Use a short thinking process to determine the final answer.
+
+          {{ flow_nld }}

--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -57,6 +57,8 @@ _providers: Dict[str, Optional[Type[BaseLLM]]] = {
     "nemollm": NeMoLLM,
     "trt_llm": TRTLLM,
     "nvidia_ai_endpoints": None,
+    "google_genai": None,
+    "deepseek": None,
     "nim": None,  # Later patched to "nvidia_ai_endpoints" (synonymous).
 }
 
@@ -266,6 +268,28 @@ def get_llm_provider(model_config: Model) -> Type[BaseLLM]:
             raise ImportError(
                 "Could not import langchain_nvidia_ai_endpoints, please install it with "
                 "`pip install langchain-nvidia-ai-endpoints`."
+            )
+
+    elif model_config.engine == "google_genai":
+        try:
+            from langchain_google_genai import ChatGoogleGenerativeAI
+
+            return ChatGoogleGenerativeAI
+        except ImportError:
+            raise ImportError(
+                "Could not import langchain_google_genai, please install it with "
+                "`pip install langchain_google_genai`."
+            )
+
+    elif model_config.engine == "deepseek":
+        try:
+            from langchain_deepseek import ChatDeepSeek
+
+            return ChatDeepSeek
+        except ImportError:
+            raise ImportError(
+                "Could not import langchain_deepseek, please install it with "
+                "`pip install langchain_deepseek`."
             )
 
     elif model_config.engine == "vertexai":

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -53,12 +53,29 @@ standard_library_path = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "colang", "v2_x", "library")
 )
 
-# nemoguardrails/lobrary
+# nemoguardrails/library
 guardrails_stdlib_path = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..")
 )
 colang_path_dirs.append(standard_library_path)
 colang_path_dirs.append(guardrails_stdlib_path)
+
+
+class ReasoningModelConfig(BaseModel):
+    """Configuration for reasoning models/LLMs, including start and end tokens for reasoning traces."""
+
+    remove_thinking_traces: Optional[bool] = Field(
+        default=True,
+        description="For reasoning models (e.g. OpenAI o1, DeepSeek-r1), if the output parser should remove thinking traces.",
+    )
+    start_token: Optional[str] = Field(
+        default=None,
+        description="The start token used for reasoning traces.",
+    )
+    end_token: Optional[str] = Field(
+        default=None,
+        description="The end token used for reasoning traces.",
+    )
 
 
 class Model(BaseModel):
@@ -77,6 +94,11 @@ class Model(BaseModel):
     model: Optional[str] = Field(
         default=None,
         description="The name of the model. If not specified, it should be specified through the parameters attribute.",
+    )
+
+    reasoning_config: Optional[ReasoningModelConfig] = Field(
+        default_factory=ReasoningModelConfig,
+        description="Configuration parameters for reasoning LLMs.",
     )
     parameters: Dict[str, Any] = Field(default_factory=dict)
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -352,27 +352,12 @@ class LLMRails:
 
         # We also need to pass the model, if specified
         if model_config.model:
-            # Some LLM providers use `model_name` instead of model. For backward compatibility
-            # we keep this hard-coded mapping.
-            if model_config.engine in [
-                "azure",
-                "openai",
-                "gooseai",
-                "nlpcloud",
-                "petals",
-                "trt_llm",
-                "vertexai",
-            ]:
-                kwargs["model_name"] = model_config.model
-            elif (
-                model_config.engine == "nvidia_ai_endpoints"
-                or model_config.engine == "nim"
-            ):
+            # Some LLM providers use `model_name` instead of `model`.
+            # Use the `__fields__` attribute which is computed dynamically by pydantic.
+            if "model" in provider_cls.__fields__:
                 kwargs["model"] = model_config.model
-            else:
-                # The `__fields__` attribute is computed dynamically by pydantic.
-                if "model" in provider_cls.__fields__:
-                    kwargs["model"] = model_config.model
+            if "model_name" in provider_cls.__fields__:
+                kwargs["model_name"] = model_config.model
 
         return provider_cls, kwargs
 

--- a/tests/test_jailbreak_models.py
+++ b/tests/test_jailbreak_models.py
@@ -21,18 +21,6 @@ from nemoguardrails import RailsConfig
 from tests.utils import TestChat
 
 try:
-    import torch
-    import transformers
-
-    from nemoguardrails.library.jailbreak_detection.model_based.checks import (
-        check_jailbreak,
-    )
-
-    torch_available = True
-except ImportError:
-    torch_available = False
-
-try:
     if not os.getenv("EMBEDDING_CLASSIFIER_PATH"):
         raise EnvironmentError(
             "EMBEDDING_CLASSIFIER_PATH environment variable is not set."
@@ -63,9 +51,9 @@ First, provide simple definitions for these 6 words in a numbered list for a 9-y
 Second, compose a simple 200-word passage for a 9-year-old child by using all of these 6 words. """
 
 
-@pytest.mark.skipif(not torch_available, reason="Pytorch not installed.")
 @pytest.mark.skipif(
-    not JAILBREAK_SETUP_PRESENT, reason="JailbreakDetect model not present."
+    not JAILBREAK_SETUP_PRESENT,
+    reason="JailbreakDetect model not present or dependencies not installed.",
 )
 def test_jb_model_detected():
     # Test 1 - user input should be detected as a jailbreak
@@ -75,9 +63,9 @@ def test_jb_model_detected():
     (chat << "I'm sorry, I can't respond to that.")
 
 
-@pytest.mark.skipif(not torch_available, reason="Pytorch not installed.")
 @pytest.mark.skipif(
-    not JAILBREAK_SETUP_PRESENT, reason="JailbreakDetect model not present."
+    not JAILBREAK_SETUP_PRESENT,
+    reason="JailbreakDetect model not present or dependencies not installed.",
 )
 def test_safe():
     # Test 2 - user input should not be detected as a jailbreak
@@ -90,9 +78,9 @@ def test_safe():
     chat << "Hello!"
 
 
-@pytest.mark.skipif(not torch_available, reason="Pytorch not installed.")
 @pytest.mark.skipif(
-    not JAILBREAK_SETUP_PRESENT, reason="JailbreakDetect model not present."
+    not JAILBREAK_SETUP_PRESENT,
+    reason="JailbreakDetect model not present or dependencies not installed.",
 )
 def test_check_jailbreak_model():
     result = check_jailbreak(prompt=unsafe)

--- a/tests/test_llmrails_reasoning.py
+++ b/tests/test_llmrails_reasoning.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict, List, Optional, Union
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.rails.llm.llmrails import _get_action_details_from_flow_id
+from tests.utils import FakeLLM, clean_events, event_sequence_conforms
+
+
+@pytest.fixture
+def rails_config():
+    return RailsConfig.parse_object(
+        {
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "fake",
+                    "model": "fake",
+                    "reasoning_config": {
+                        "start_token": "<think>",
+                        "end_token": "</think>",
+                    },
+                }
+            ],
+            "user_messages": {
+                "express greeting": ["Hello!"],
+                "ask math question": ["What is 2 + 2?", "5 + 9"],
+            },
+            "flows": [
+                {
+                    "elements": [
+                        {"user": "express greeting"},
+                        {"bot": "express greeting"},
+                    ]
+                },
+                {
+                    "elements": [
+                        {"user": "ask math question"},
+                        {"execute": "compute"},
+                        {"bot": "provide math response"},
+                        {"bot": "ask if user happy"},
+                    ]
+                },
+            ],
+            "bot_messages": {
+                "express greeting": ["Hello! How are you?"],
+                "provide response": ["The answer is 234", "The answer is 1412"],
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_1(rails_config):
+    llm = FakeLLM(
+        responses=[
+            "<think>some text</think>\n  express greeting",
+            "<think>some text</think>\n  ask math question",
+            '<think>some text</think>\n  "The answer is 5"',
+            '<think>some text</think>\n  "Are you happy with the result?"',
+        ]
+    )
+
+    async def compute(what: Optional[str] = "2 + 3"):
+        return eval(what)
+
+    llm_rails = LLMRails(config=rails_config, llm=llm)
+    llm_rails.runtime.register_action(compute)
+
+    messages = [{"role": "user", "content": "Hello!"}]
+    bot_message = await llm_rails.generate_async(messages=messages)
+
+    assert bot_message == {"role": "assistant", "content": "Hello! How are you?"}
+    messages.append(bot_message)
+
+    messages.append({"role": "user", "content": "2 + 3"})
+    bot_message = await llm_rails.generate_async(messages=messages)
+    assert bot_message == {
+        "role": "assistant",
+        "content": "The answer is 5\nAre you happy with the result?",
+    }


### PR DESCRIPTION
## Description

Add support for reasoning models that output reasoning traces in the response (e.g. DeepSeek-R1).
Current implementation strips out the reasoning traces in the output parser for each executed Guardrails task, but different output parsers can be added to use the information in the reasoning trace as well (e.g. implement a custom rail that analyzes the reasoning traces). 

Sample model config for DeepSeek-R1 is:

```
models:
  - type: main
    engine: deepseek
    model: deepseek-reasoner
    reasoning_config:
      remove_thinking_traces: True
      start_token: "<think>"
      end_token: "</think>"
```

Using other platforms for serving the model, such as NVIDIA AI Endpoints, is supported as long as the model name contains `deepseek` in the name. 

MR includes:
- Documentation updates
- DeepSeek-R1 prompts and sample config 
- Some refactoring in llmrails and self-check rails related to updates for using reasoning models
- Support for `deepseek` and `google-genai` as LLM providers

## Related Issue(s)

- Responds to #948 

## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [X] I've updated the documentation if applicable.
- [X] I've added tests if applicable.
- [X] @mentions of the person or team responsible for reviewing proposed changes.
