### PR TITLE
chore(docs): Tolerate prompt in code blocks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
     "files.trimFinalNewlines": true,
     "prettier.tabWidth": 4,
     "isort.args": ["--profile", "black"],
+    "markdownlint.config": {
+        "commands-show-output": false
+    },
 
     // MARKDOWN
     "[markdown]": {
@@ -50,6 +53,7 @@
     ],
     "python.testing.unittestEnabled": false,
     //"python.envFile": "${workspaceFolder}/python_release.env",
+
 
     // MYPY
     "mypy-type-checker.args": [


### PR DESCRIPTION
## Description

I'd like to prevent markdownlint from preventing me to include the prompt in console code blocks.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
