### PR TITLE
feat(streaming): add generation metadata to streaming chunks

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -940,9 +940,12 @@ class LLMRails:
         messages: Optional[List[dict]] = None,
         options: Optional[Union[dict, GenerationOptions]] = None,
         state: Optional[Union[dict, State]] = None,
+        include_generation_metadata: Optional[bool] = False,
     ) -> AsyncIterator[str]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
-        streaming_handler = StreamingHandler()
+        streaming_handler = StreamingHandler(
+            include_generation_metadata=include_generation_metadata
+        )
 
         # todo use a context var for buffer strategy and return it here?
         # then iterating over buffer strategy is nested loop?


### PR DESCRIPTION
## Description

Adds generation metadata per streamed token. This information can be used.

Example:

```python
from nemoguardrails import RailsConfig, LLMRails
config = RailsConfig.from_path("./examples/bots/hello_world")
# enable streaming
config.streaming = True

rails = LLMRails(config, verbose=False)

messages = [{"role": "user", "content": "are you sure?"}]

async for chunk in rails.stream_async(messages=messages, include_generation_metadata=True):
    print(f"CHUNK:{chunk}")

```

compare the output to the case when

```python
async for chunk in rails.stream_async(messages=messages, include_generation_metadata=False):
    print(f"CHUNK:{chunk}")
    
```

```
CHUNK:Yes
CHUNK:,
CHUNK: I
CHUNK: am
CHUNK: sure
CHUNK:.
CHUNK: Is there something specific
CHUNK: you
CHUNK: would
CHUNK: like
CHUNK: me
CHUNK: to
CHUNK: assist
CHUNK: you
CHUNK: with

```
by default include_generation_metadata is False, so following works as before

```python
async for chunk in rails.stream_async(messages=messages):
    print(f"CHUNK:{chunk}")
    
```

and let's see logprobs:

```python
from nemoguardrails import RailsConfig, LLMRails
config = RailsConfig.from_path("./examples/bots/hello_world")
# enable streaming
config.streaming = True
config.models[0].parameters["logprobs"] = True
rails = LLMRails(config, verbose=False)

messages = [{"role": "user", "content": "are you sure?"}]

async for chunk in rails.stream_async(messages=messages, include_generation_metadata=True):
    print(f"CHUNK:{chunk}")

```

```
CHUNK:{'text': 'Yes', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2766], 'token_logprobs': [-0.04808487], 'tokens': ['Yes'], 'top_logprobs': [{'Yes': -0.04808487}]}}}
CHUNK:{'text': ',', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2769], 'token_logprobs': [-0.00035643837], 'tokens': [','], 'top_logprobs': [{',': -0.00035643837}]}}}
CHUNK:{'text': ' I', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2770], 'token_logprobs': [-0.006206889], 'tokens': [' I'], 'top_logprobs': [{' I': -0.006206889}]}}}
CHUNK:{'text': ' am', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2772], 'token_logprobs': [-0.038049296], 'tokens': [' am'], 'top_logprobs': [{' am': -0.038049296}]}}}
CHUNK:{'text': ' sure', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2775], 'token_logprobs': [-0.18850017], 'tokens': [' sure'], 'top_logprobs': [{' sure': -0.18850017}]}}}
CHUNK:{'text': '.', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2780], 'token_logprobs': [-0.04797603], 'tokens': ['.'], 'top_logprobs': [{'.': -0.04797603}]}}}
CHUNK:{'text': ' Is there something specific', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2781, 2784, 2790, 2800], 'token_logprobs': [-0.19391938, -3.5954712e-05, -0.18670167, -0.03183038], 'tokens': [' Is', ' there', ' something', ' specific'], 'top_logprobs': [{' Is': -0.19391938}, {' there': -3.5954712e-05}, {' something': -0.18670167}, {' specific': -0.03183038}]}}}
CHUNK:{'text': ' you', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2809], 'token_logprobs': [-0.02350099], 'tokens': [' you'], 'top_logprobs': [{' you': -0.02350099}]}}}
CHUNK:{'text': ' would', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2813], 'token_logprobs': [-0.030586045], 'tokens': [' would'], 'top_logprobs': [{' would': -0.030586045}]}}}
CHUNK:{'text': ' like', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2819], 'token_logprobs': [-1.7835755e-05], 'tokens': [' like'], 'top_logprobs': [{' like': -1.7835755e-05}]}}}
CHUNK:{'text': ' me', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2824], 'token_logprobs': [-0.14419326], 'tokens': [' me'], 'top_logprobs': [{' me': -0.14419326}]}}}
CHUNK:{'text': ' to', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2827], 'token_logprobs': [-0.00010127832], 'tokens': [' to'], 'top_logprobs': [{' to': -0.00010127832}]}}}
CHUNK:{'text': ' assist', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2830], 'token_logprobs': [-0.3112674], 'tokens': [' assist'], 'top_logprobs': [{' assist': -0.3112674}]}}}
CHUNK:{'text': ' you', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2837], 'token_logprobs': [-0.06738678], 'tokens': [' you'], 'top_logprobs': [{' you': -0.06738678}]}}}
CHUNK:{'text': ' with', 'generation_info': {'finish_reason': None, 'logprobs': {'text_offset': [2841], 'token_lo
```
## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
