### PR TITLE
feat: set default start and end reasoning tokens

### DIFF
--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -291,7 +291,7 @@ class LLMTaskManager:
         elif prompt.output_parser:
             output_parser = self.output_parsers.get(prompt.output_parser)
         if not output_parser:
-            logging.warning("No output parser found for %s", prompt.output_parser)
+            logging.info("No output parser found for %s", prompt.output_parser)
 
         model = get_task_model(self.config, task)
         if (

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -69,11 +69,11 @@ class ReasoningModelConfig(BaseModel):
         description="For reasoning models (e.g. OpenAI o1, DeepSeek-r1), if the output parser should remove thinking traces.",
     )
     start_token: Optional[str] = Field(
-        default=None,
+        default="<think>",
         description="The start token used for reasoning traces.",
     )
     end_token: Optional[str] = Field(
-        default=None,
+        default="</think>",
         description="The end token used for reasoning traces.",
     )
 

--- a/tests/test_reasoning_traces.py
+++ b/tests/test_reasoning_traces.py
@@ -153,6 +153,34 @@ class TestReasoningTraces:
             assert result == input_text
 
     @pytest.mark.asyncio
+    async def test_parse_task_output_with_default_reasoning_traces(self):
+        """Test that parse_task_output works without a reasoning config."""
+        config = MagicMock(spec=RailsConfig)
+
+        # a Model without reasoning_config
+        model_config = Model(type="main", engine="test", model="test-model")
+
+        # Mock the get_prompt and get_task_model functions
+        with (
+            patch("nemoguardrails.llm.taskmanager.get_prompt") as mock_get_prompt,
+            patch(
+                "nemoguardrails.llm.taskmanager.get_task_model"
+            ) as mock_get_task_model,
+        ):
+            mock_get_prompt.return_value = MagicMock(output_parser=None)
+            mock_get_task_model.return_value = model_config
+
+            llm_task_manager = LLMTaskManager(config)
+
+            # test parsing without a reasoning config
+            input_text = "This is a <think>Some reasoning here</think> final answer."
+            expected = "This is a  final answer."
+
+            # without a reasoning config, the default start_token and stop_token are used thus the text should change
+            result = llm_task_manager.parse_task_output(Task.GENERAL, input_text)
+            assert result == expected
+
+    @pytest.mark.asyncio
     async def test_parse_task_output_with_output_parser(self):
         """Test that parse_task_output correctly applies output parsers before returning."""
         config = MagicMock(spec=RailsConfig)


### PR DESCRIPTION
## Description

Two minor adjustments:

- set default reasoning tokens 
- change log level to info
- add test using default ReasoningModelConfig
