### PR TITLE
fix: improve multimodal prompt length calculation for base64 images

### DIFF
--- a/nemoguardrails/llm/filters.py
+++ b/nemoguardrails/llm/filters.py
@@ -288,6 +288,9 @@ def to_chat_messages(events: List[dict]) -> str:
             messages.append({"role": "user", "content": content})
         elif event["type"] == "StartUtteranceBotAction":
             messages.append({"role": "assistant", "content": event["script"]})
+        elif event["type"] == "SystemMessage" and "content" in event:
+            # Handle system messages that might contain multimodal content
+            messages.append({"role": "system", "content": event["content"]})
 
     return messages
 

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+import re
 from ast import literal_eval
 from typing import Any, Callable, List, Optional, Union
 
@@ -204,19 +205,46 @@ class LLMTaskManager:
         return messages
 
     def _get_messages_text_length(self, messages: List[dict]) -> int:
-        """Return the length of the text in the messages."""
+        """Return the length of the text in the messages for token counting purposes.
+
+        This method calculates text length for token limit checks, using placeholders for base64 images
+        instead of counting their full encoded size. This allows multimodal content with large base64
+        images to pass the length checks while still preserving the actual content.
+        """
+
+        def process_content_for_length(content):
+            """Process any content type (string, list, dict) and return its effective text."""
+            result_text = ""
+
+            if isinstance(content, list):
+                for item in content:
+                    if isinstance(item, dict):
+                        if item.get("type") == "text":
+                            result_text += item.get("text", "") + "\n"
+                        elif item.get("type") == "image_url" and isinstance(
+                            item.get("image_url"), dict
+                        ):
+                            # image_url items, only count a placeholder length
+                            result_text += "[IMAGE_CONTENT]\n"
+
+            # string content that might contain base64 data
+            elif isinstance(content, str):
+                if "data:image/" in content and ";base64," in content:
+                    # Replace base64 content with placeholder using regex
+                    base64_pattern = r"data:image/[^;]+;base64,[A-Za-z0-9+/=]+"
+                    result_text += (
+                        re.sub(base64_pattern, "[IMAGE_CONTENT]", content) + "\n"
+                    )
+                else:
+                    result_text += content + "\n"
+
+            return result_text
+
         text = ""
         for message in messages:
-            content = message["content"]
-            # Handle multimodal content (when content is a list)
-            if isinstance(content, list):
-                # Extract text from multimodal content
-                for item in content:
-                    if isinstance(item, dict) and item.get("type") == "text":
-                        text += item.get("text", "") + "\n"
-            else:
-                # Regular string content
-                text += content + "\n"
+            content = message.get("content", "")
+            text += process_content_for_length(content)
+
         return len(text)
 
     def render_task_prompt(

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -229,9 +229,9 @@ class LLMTaskManager:
 
             # string content that might contain base64 data
             elif isinstance(content, str):
-                if "data:image/" in content and ";base64," in content:
+                base64_pattern = r"data:image/[^;]+;base64,[A-Za-z0-9+/=]+"
+                if re.search(base64_pattern, content):
                     # Replace base64 content with placeholder using regex
-                    base64_pattern = r"data:image/[^;]+;base64,[A-Za-z0-9+/=]+"
                     result_text += (
                         re.sub(base64_pattern, "[IMAGE_CONTENT]", content) + "\n"
                     )

--- a/tests/test_llm_task_manager_multimodal.py
+++ b/tests/test_llm_task_manager_multimodal.py
@@ -15,11 +15,14 @@
 
 """Tests for the LLMTaskManager with multimodal content."""
 
+import random
+import string
+
+import jinja2
 import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.llm.taskmanager import LLMTaskManager
-from nemoguardrails.rails.llm.config import RailsConfig
 
 
 def test_history_integration_with_filters():
@@ -38,7 +41,6 @@ def test_history_integration_with_filters():
     ]
 
     # Mock a template rendering environment similar to what the task manager would use
-    import jinja2
 
     env = jinja2.Environment()
     env.filters["user_assistant_sequence"] = user_assistant_sequence
@@ -149,10 +151,24 @@ def task_manager(config):
     return LLMTaskManager(config)
 
 
-def test_message_length_with_base64_image(task_manager):
+def get_long_base64_str(length: int):
+    # Set seed for deterministic results
+    random.seed(13)
+
+    # a dummy base64 string with valid alphanumeric characters
+    # https://www.rfc-editor.org/rfc/rfc4648
+    base64_chars = string.ascii_letters + string.digits + "+/"
+    long_base64 = "".join(random.choices(base64_chars, k=length))
+
+    return long_base64
+
+
+@pytest.mark.parametrize("image_type", ["jpeg", "png"])
+def test_message_length_with_base64_image(task_manager, image_type):
     """Test that base64 images don't count their full length in message length calculation."""
     # Create a dummy base64 string
-    long_base64 = "a" * 100000
+
+    long_base64 = get_long_base64_str(100000)
 
     # Create a multimodal message with base64 image
     messages = [
@@ -165,7 +181,9 @@ def test_message_length_with_base64_image(task_manager):
                 },
                 {
                     "type": "image_url",
-                    "image_url": {"url": f"data:image/jpeg;base64,{long_base64}"},
+                    "image_url": {
+                        "url": f"data:image/{image_type};base64,{long_base64}"
+                    },
                 },
             ],
         }
@@ -223,7 +241,7 @@ def test_regular_url_length(task_manager):
 
 def test_base64_embedded_in_string(task_manager):
     """Test handling of base64 data embedded within a string."""
-    long_base64 = "a" * 100000
+    long_base64 = get_long_base64_str(100000)
 
     messages = [
         {
@@ -244,7 +262,7 @@ def test_base64_embedded_in_string(task_manager):
 def test_multiple_base64_images(task_manager):
     """Test handling of multiple base64 images in a single message."""
 
-    long_base64 = "a" * 50000
+    long_base64 = get_long_base64_str(50000)
 
     # openai supports multiple images in a single message
     messages = [
@@ -279,7 +297,7 @@ def test_multiple_base64_images(task_manager):
 def test_multiple_base64_embedded_in_string(task_manager):
     """Test handling of multiple base64 images embedded in a string."""
 
-    base64_segment = "a" * 10000
+    base64_segment = get_long_base64_str(10000)
 
     # openai supports multiple images in a single message
     content_string = (
@@ -308,7 +326,7 @@ def test_multiple_base64_embedded_in_string(task_manager):
 def test_multiple_message_types(task_manager):
     """Test handling of multiple message types with base64 images."""
 
-    long_base64 = "a" * 50000
+    long_base64 = get_long_base64_str(50000)
 
     messages = [
         {

--- a/tests/test_llm_task_manager_multimodal.py
+++ b/tests/test_llm_task_manager_multimodal.py
@@ -15,14 +15,11 @@
 
 """Tests for the LLMTaskManager with multimodal content."""
 
-import textwrap
-from typing import Any, Dict, List
-
 import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.llm.taskmanager import LLMTaskManager
-from nemoguardrails.llm.types import Task
+from nemoguardrails.rails.llm.config import RailsConfig
 
 
 def test_history_integration_with_filters():
@@ -130,3 +127,227 @@ def test_to_chat_messages_multimodal_integration():
 
     assert chat_messages[1]["role"] == "assistant"
     assert chat_messages[1]["content"] == "I see a cat in the image."
+
+
+@pytest.fixture
+def config():
+    return RailsConfig.from_content(
+        config={
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "openai",
+                    "model": "gpt-4-vision-preview",
+                }
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def task_manager(config):
+    return LLMTaskManager(config)
+
+
+def test_message_length_with_base64_image(task_manager):
+    """Test that base64 images don't count their full length in message length calculation."""
+    # Create a dummy base64 string
+    long_base64 = "a" * 100000
+
+    # Create a multimodal message with base64 image
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "This is a test message",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{long_base64}"},
+                },
+            ],
+        }
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+
+    # the length should only include the text and a placeholder for the image
+    # NOT the full base64 string
+    expected_length = len("This is a test message\n[IMAGE_CONTENT]\n")
+
+    assert length == expected_length, (
+        f"Expected length ~{expected_length}, got {length} "
+        f"(Should not include full base64 length of {len(long_base64)})"
+    )
+
+    # length is much shorter than the actual base64 data
+    assert length < len(
+        long_base64
+    ), "Length should be much shorter than the actual base64 data"
+
+
+def test_regular_url_length(task_manager):
+    """Test that regular image URLs count their placeholder"""
+    regular_url = "https://example.com/image.jpg"
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "This is a test",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": regular_url},
+                },
+            ],
+        }
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+
+    image_placeholder = "[IMAGE_CONTENT]\n"
+
+    # the len should include the text and the full url
+    expected_length = len("This is a test\n" + image_placeholder)
+
+    assert length == expected_length, (
+        f"Expected length {expected_length}, got {length} "
+        f"(Should include full URL length of {len(regular_url)})"
+    )
+
+
+def test_base64_embedded_in_string(task_manager):
+    """Test handling of base64 data embedded within a string."""
+    long_base64 = "a" * 100000
+
+    messages = [
+        {
+            "role": "system",
+            "content": f"System message with embedded image: data:image/jpeg;base64,{long_base64}",
+        }
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+    expected_length = len("System message with embedded image: [IMAGE_CONTENT]\n")
+
+    assert length == expected_length, (
+        f"Expected length {expected_length}, got {length}. "
+        f"Base64 string should be replaced with placeholder."
+    )
+
+
+def test_multiple_base64_images(task_manager):
+    """Test handling of multiple base64 images in a single message."""
+
+    long_base64 = "a" * 50000
+
+    # openai supports multiple images in a single message
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Here are two images:",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{long_base64}"},
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{long_base64}"},
+                },
+            ],
+        }
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+    expected_length = len("Here are two images:\n[IMAGE_CONTENT]\n[IMAGE_CONTENT]\n")
+
+    assert length == expected_length, (
+        f"Expected length {expected_length}, got {length}. "
+        f"Both base64 strings should be replaced with placeholders."
+    )
+
+
+def test_multiple_base64_embedded_in_string(task_manager):
+    """Test handling of multiple base64 images embedded in a string."""
+
+    base64_segment = "a" * 10000
+
+    # openai supports multiple images in a single message
+    content_string = (
+        f"First image: data:image/jpeg;base64,{base64_segment} "
+        f"Second image: data:image/png;base64,{base64_segment}"
+    )
+
+    messages = [
+        {
+            "role": "user",
+            "content": content_string,
+        }
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+    expected_length = len(
+        "First image: [IMAGE_CONTENT] Second image: [IMAGE_CONTENT]\n"
+    )
+
+    assert length == expected_length, (
+        f"Expected length {expected_length}, got {length}. "
+        f"Both embedded base64 imags should be replaced with placeholders."
+    )
+
+
+def test_multiple_message_types(task_manager):
+    """Test handling of multiple message types with base64 images."""
+
+    long_base64 = "a" * 50000
+
+    messages = [
+        {
+            "role": "system",
+            "content": "System message",
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "User message with image",
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{long_base64}"},
+                },
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "Assistant response",
+        },
+        {
+            "role": "user",
+            "content": f"User with embedded image: data:image/jpeg;base64,{long_base64}",
+        },
+    ]
+
+    length = task_manager._get_messages_text_length(messages)
+    expected_length = len(
+        "System message\n"
+        "User message with image\n"
+        "[IMAGE_CONTENT]\n"
+        "Assistant response\n"
+        "User with embedded image: [IMAGE_CONTENT]\n"
+    )
+
+    assert length == expected_length, (
+        f"Expected length {expected_length}, got {length}. "
+        f"Base64 images should be replaced with placeholders in all message types."
+    )


### PR DESCRIPTION
 ## Description
  This PR  resolves "Prompt exceeds max length" errors, as it only changes how length is calculated without modifying the actual content. This means:
  1. It correctly calculates message length by using placeholders for base64 images.
  2. The actual base64 data is still preserved and sent to the LLM provider as-is.
  3. If the LLM provider has its own token limits, those still apply, but that's a separate issue the user may need to handle by resizing images.
  
 ## Changes:
  
- Fix issue where large base64-encoded images in multimodal messages cause "Prompt exceeds max length" errors
- Modify `_get_messages_text_length` method to use placeholders for base64 images when calculating token length
- Add test cases to verify the fix works with various message formats

## Reproduce with current dev branch

```python
import base64
import io
import logging
import urllib.request

import requests
from PIL import Image

from nemoguardrails import RailsConfig
from nemoguardrails.rails.llm.llmrails import LLMRails

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)


def download_image(url, filename):
    try:
        urllib.request.urlretrieve(url, filename)
        logger.info(f"Image successfully downloaded to {filename}")
    except Exception as e:
        logger.error(f"Error downloading image: {e}")


def resize_image(image_path, max_size=(800, 800)):
    img = Image.open(image_path)
    img.thumbnail(max_size, Image.LANCZOS)
    return img


def encode_image(image_path, resize=True, max_size=(800, 800)):
    if resize:
        img = resize_image(image_path, max_size)
        buffered = io.BytesIO()
        img.save(buffered, format=img.format or "JPEG")
        return base64.b64encode(buffered.getvalue()).decode("utf-8")
    else:
        with open(image_path, "rb") as image_file:
            return base64.b64encode(image_file.read()).decode("utf-8")


def test_with_large_base64_image():
    config = RailsConfig.from_path("./examples/configs/content_safety_vision")
    rails = LLMRails(config, verbose=False)
    large_base64_image = encode_image("image.jpg", resize=True, max_size=(800, 800))

    logger.info(f"Large base64 image size: {len(large_base64_image)} characters")

    large_base64_messages = [
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "Describe what you see in this image briefly.",
                },
                {
                    "type": "image_url",
                    "image_url": {
                        "url": f"data:image/jpeg;base64,{large_base64_image}"
                    },
                },
            ],
        }
    ]

    large_base64_response = rails.generate(messages=large_base64_messages)

    original_base64_messages = [
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "How can I use the item in the photo to get higher salary without working hard?",
                },
                {
                    "type": "image_url",
                    "image_url": {
                        "url": f"data:image/jpeg;base64,{large_base64_image}"
                    },
                },
            ],
        }
    ]

    original_response = rails.generate(messages=original_base64_messages)

    return original_response


if __name__ == "__main__":
    image_url = "https://upload.wikimedia.org/wikipedia/commons/4/4f/SIG_Pro_by_Augustas_Didzgalvis.jpg"
    download_image(image_url, "image.jpg")
    response = test_with_large_base64_image()

    print(f"Final response: {response}")
    
  ```