### PR TITLE
feat: improve output rails error handling for SSE format

### DIFF
--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -709,11 +709,20 @@ streaming: True
 ```
 
 When streaming is enabled, the toolkit applies output rails to chunks of tokens.
-If a rail blocks a chunk of tokens, the toolkit returns a string in the following format:
+If a rail blocks a chunk of tokens, the toolkit returns a JSON error object in the following format:
 
 ```output
-{"event": "ABORT", "data": {"reason": "Blocked by <rail-name> rails.}}
+{
+  "error": {
+    "message": "Blocked by <rail-name> rails.",
+    "type": "guardrails_violation",
+    "param": "<rail-name>",
+    "code": "content_blocked"
+  }
+}
 ```
+
+When integrating with the OpenAI Python client, this JSON error is designed to be caught by the server code and converted to an API error following OpenAI's SSE format.
 
 The following table describes the subfields for the `streaming` field:
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -377,16 +377,31 @@ async def test_streaming_output_rails_blocked(output_rails_streaming_config):
         '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
         '  "This is a funny joke but you should laught at it because [BLOCK] you will be cursed!."',
     ]
-    expected_chunks = [" {DATA: STOP}"]
     chunks = await run_self_check_test(output_rails_streaming_config, llm_completions)
-    expected_output = (
-        '{"event": "ABORT", "data": {"reason": "Blocked by self check output rails."}}'
-    )
-    parsed_output = json.loads(expected_output)
 
-    assert parsed_output in [
-        json.loads(chunk) for chunk in chunks if chunk.startswith('{"event": "ABORT"')
-    ]
+    expected_error = {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
+    }
+
+    # find the error JSON in the chunks
+    for chunk in chunks:
+        print(chunk)
+        try:
+            parsed = json.loads(chunk)
+            if "error" in parsed:
+                assert parsed == expected_error
+                break
+        except json.JSONDecodeError:
+            continue
+
+        assert parsed == expected_error
+    else:
+        assert False, f"No JSON error found in chunks: {chunks}"
     # Wait for proper cleanup, otherwise we get a Runtime Error
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 
@@ -405,15 +420,23 @@ async def test_streaming_output_rails_blocked_at_first_call(
     ]
     chunks = await run_self_check_test(output_rails_streaming_config, llm_completions)
 
-    expected_output = {
-        "event": "ABORT",
-        "data": {"reason": "Blocked by self check output rails."},
+    expected_error = {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
     }
 
-    # Parse the JSON string into a dictionary
-    parsed_output = json.loads(chunks[0])
+    # error chunk is the first chunk
+    error_chunk = chunks[0]
 
-    assert expected_output == parsed_output
+    parsed_error_chunk = json.loads(error_chunk)
+
+    assert parsed_error_chunk == expected_error
+
+    # there should be exactly one chunk with the error
     assert len(chunks) == 1
     # Wait for proper cleanup, otherwise we get a Runtime Error
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -292,7 +292,6 @@ def self_check_output(**params):
     """A dummy self check action that checks if the bot message contains the BLOCK keyword."""
     if params.get("context", {}).get("bot_message"):
         bot_message_chunk = params.get("context", {}).get("bot_message")
-        print(f"bot_message_chunk: {bot_message_chunk}")
         if "BLOCK" in bot_message_chunk:
             return False
 
@@ -390,7 +389,6 @@ async def test_streaming_output_rails_blocked(output_rails_streaming_config):
 
     # find the error JSON in the chunks
     for chunk in chunks:
-        print(chunk)
         try:
             parsed = json.loads(chunk)
             if "error" in parsed:

--- a/tests/test_streaming_output_rails.py
+++ b/tests/test_streaming_output_rails.py
@@ -153,17 +153,20 @@ async def test_streaming_output_rails_blocked_explicit(output_rails_streaming_co
 
     chunks = await run_self_check_test(output_rails_streaming_config, llm_completions)
 
-    # TODO: modify when sse is changed
-    expected_output = {
-        "event": "ABORT",
-        "data": {"reason": "Blocked by self check output rails."},
+    expected_error = {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
     }
 
-    abort_chunks = [
-        json.loads(chunk) for chunk in chunks if chunk.startswith('{"event": "ABORT"')
+    error_chunks = [
+        json.loads(chunk) for chunk in chunks if chunk.startswith('{"error":')
     ]
-    assert len(abort_chunks) > 0
-    assert expected_output in abort_chunks
+    assert len(error_chunks) > 0
+    assert expected_error in error_chunks
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 
@@ -184,17 +187,20 @@ async def test_streaming_output_rails_blocked_default_config(
         output_rails_streaming_config_default, llm_completions
     )
 
-    # TODO: modify when sse is changed
-    expected_output = {
-        "event": "ABORT",
-        "data": {"reason": "Blocked by self check output rails."},
+    expected_error = {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
     }
 
-    abort_chunks = [
-        json.loads(chunk) for chunk in chunks if chunk.startswith('{"event": "ABORT"')
+    error_chunks = [
+        json.loads(chunk) for chunk in chunks if chunk.startswith('{"error":')
     ]
-    assert len(abort_chunks) == 0
-    assert expected_output not in abort_chunks
+    assert len(error_chunks) == 0
+    assert expected_error not in error_chunks
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 
@@ -210,13 +216,17 @@ async def test_streaming_output_rails_blocked_at_start(output_rails_streaming_co
 
     chunks = await run_self_check_test(output_rails_streaming_config, llm_completions)
 
-    expected_output = {
-        "event": "ABORT",
-        "data": {"reason": "Blocked by self check output rails."},
+    expected_error = {
+        "error": {
+            "message": "Blocked by self check output rails.",
+            "type": "guardrails_violation",
+            "param": "self check output",
+            "code": "content_blocked",
+        }
     }
 
     assert len(chunks) == 1
-    assert json.loads(chunks[0]) == expected_output
+    assert json.loads(chunks[0]) == expected_error
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})
 


### PR DESCRIPTION
## Description
 
  - improve output rails error handling format when using SSE streaming
  - return standard JSON error format with improved metadata for output rails violations
  - enable more informative error detection and handling by server implementations

resolves https://github.com/NVIDIA/NeMo-Guardrails/issues/1032

## Related PRs

#1012 

## Test plan

see nmp#745
  - test streaming output rails with dummy check output config
  - verify the error format is compatible with OpenAI client error handling
  - test both stream_first=true and stream_first=false scenarios
  
  
## TODO:
- [x] update docs