### PR TITLE
feat(llm): add support for langchain partner and community chat models

### DIFF
--- a/examples/configs/content_safety/config.yml
+++ b/examples/configs/content_safety/config.yml
@@ -1,7 +1,7 @@
 models:
   - type: main
     engine: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model: meta/llama-3.3-70b-instruct
 
   - type: content_safety
     engine: nim

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -23,10 +23,11 @@ import sys
 import threading
 from functools import lru_cache
 from time import time
-from typing import Callable, List, Optional, cast
+from typing import Callable, List, Optional, Union, cast
 
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
+from langchain_core.language_models import BaseChatModel
 from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions.actions import ActionResult, action
@@ -81,7 +82,7 @@ class LLMGenerationActions:
     def __init__(
         self,
         config: RailsConfig,
-        llm: BaseLLM,
+        llm: Union[BaseLLM, BaseChatModel],
         llm_task_manager: LLMTaskManager,
         get_embedding_search_provider_instance: Callable[
             [Optional[EmbeddingSearchProvider]], EmbeddingsIndex
@@ -417,7 +418,7 @@ class LLMGenerationActions:
                     )
                 # We add these in reverse order so the most relevant is towards the end.
                 for result in reversed(results):
-                    examples += f"user \"{result.text}\"\n  {result.meta['intent']}\n\n"
+                    examples += f'user "{result.text}"\n  {result.meta["intent"]}\n\n'
                     if result.meta["intent"] not in potential_user_intents:
                         potential_user_intents.append(result.meta["intent"])
 

--- a/nemoguardrails/llm/models/initializer.py
+++ b/nemoguardrails/llm/models/initializer.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for initializing LLM models with proper error handling and type checking."""
+
+from typing import Any, Dict, Literal, Optional, Union
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models.llms import BaseLLM
+
+from .langchain_initializer import ModelInitializationError, init_langchain_model
+
+
+# later we can easily conver it to a class
+def init_llm_model(
+    model_name: Optional[str],
+    provider_name: str,
+    mode: Literal["chat", "text"],
+    kwargs: Dict[str, Any],
+) -> Union[BaseChatModel, BaseLLM]:
+    """Initialize an LLM model with proper error handling.
+
+    Currently, this function only supports LangChain models.
+    In the future, it may support other model backends.
+
+    Args:
+        model_name: Name of the model to initialize
+        provider_name: Name of the provider to use
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized LLM model
+
+    Raises:
+        ModelInitializationError: If model initialization fails
+    """
+    # currently we only support LangChain models
+    return init_langchain_model(
+        model_name=model_name, provider_name=provider_name, mode=mode, kwargs=kwargs
+    )
+
+
+__all__ = ["init_llm_model", "ModelInitializationError"]

--- a/nemoguardrails/llm/models/langchain_initializer.py
+++ b/nemoguardrails/llm/models/langchain_initializer.py
@@ -117,7 +117,7 @@ def try_initialization_method(
 
 
 def init_langchain_model(
-    model_name: Optional[str],
+    model_name: str,
     provider_name: str,
     mode: Literal["chat", "text"],
     kwargs: Dict[str, Any],

--- a/nemoguardrails/llm/models/langchain_initializer.py
+++ b/nemoguardrails/llm/models/langchain_initializer.py
@@ -150,7 +150,8 @@ def init_langchain_model(
 
     # Track the last exception for better error reporting
     last_exception = None
-
+    # but also remember the first import‐error we see
+    first_import_error: Optional[ImportError] = None
     # Try each initializer in sequence
     for initializer in initializers:
         try:
@@ -163,14 +164,34 @@ def init_langchain_model(
             )
             if result is not None:
                 return result
-        except Exception as e:
-            # Keep track of the last exception
+        except ImportError as e:
+            # remember only the first import‐error we encounter
+            if first_import_error is None:
+                first_import_error = e
             last_exception = e
-            log.debug(f"Initialization failed with {initializer}: {str(e)}")
+            log.debug(f"Initialization import‐failure in {initializer}: {e}")
+        except Exception as e:
+            last_exception = e
+            log.debug(f"Initialization failed with {initializer}: {e}")
+    # build the final message, preferring that first ImportError if we saw one
+    base = (
+        f"Failed to initialize model {model_name!r} "
+        f"with provider {provider_name!r} in {mode!r} mode"
+    )
 
-    raise ModelInitializationError(
-        f"Failed to initialize model {model_name} with provider {provider_name} in {mode} mode"
-    ) from last_exception
+    # if we ever hit an ImportError, surface its message:
+    if first_import_error is not None:
+        base += f": {first_import_error}"
+        # chain from that importer
+        raise ModelInitializationError(base) from first_import_error
+
+    # otherwise fall back to the last exception we saw
+    if last_exception is not None:
+        base += f": {last_exception}"
+        raise ModelInitializationError(base) from last_exception
+
+    # (should never happen—no initializer claimed success, no exception thrown)
+    raise ModelInitializationError(base)
 
 
 def _init_chat_completion_model(

--- a/nemoguardrails/llm/models/langchain_initializer.py
+++ b/nemoguardrails/llm/models/langchain_initializer.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for initializing LangChain models with proper error handling."""
+
+import logging
+import warnings
+from importlib.metadata import version
+from typing import Any, Callable, Dict, Literal, Optional, Union
+
+from langchain.chat_models import init_chat_model
+from langchain_core._api.beta_decorator import LangChainBetaWarning
+from langchain_core._api.deprecation import LangChainDeprecationWarning
+from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models.llms import BaseLLM
+
+from nemoguardrails.llm.providers.providers import (
+    _get_chat_completion_provider,
+    _get_text_completion_provider,
+    _parse_version,
+)
+
+log = logging.getLogger(__name__)
+
+
+# Suppress specific LangChain warnings
+warnings.filterwarnings("ignore", category=LangChainDeprecationWarning)
+warnings.filterwarnings("ignore", category=LangChainBetaWarning)
+
+
+class ModelInitializationError(Exception):
+    """Raised when model initialization fails."""
+
+    pass
+
+
+ModelInitMethod = Callable[
+    [str, str, Dict[str, Any]], Optional[Union[BaseChatModel, BaseLLM]]
+]
+
+
+class ModelInitializer:
+    """A method for initializing a model with its supported modes."""
+
+    def __init__(
+        self,
+        init_method: ModelInitMethod,
+        supported_modes: list[Literal["chat", "text"]],
+    ):
+        self.init_method = init_method
+        self.supported_modes = supported_modes
+
+    def supports_mode(self, mode: Literal["chat", "text"]) -> bool:
+        """Check if this initializer supports the given mode."""
+        return mode in self.supported_modes
+
+    def execute(
+        self, model_name: str, provider_name: str, kwargs: Dict[str, Any]
+    ) -> Optional[Union[BaseChatModel, BaseLLM]]:
+        """Execute this initializer to initialize a model."""
+        return self.init_method(model_name, provider_name, kwargs)
+
+    def __str__(self) -> str:
+        return f"{self.init_method.__name__}(modes={self.supported_modes})"
+
+
+def try_initialization_method(
+    initializer: ModelInitializer,
+    model_name: str,
+    provider_name: str,
+    mode: Literal["chat", "text"],
+    kwargs: Dict[str, Any],
+):
+    """Wrap an initialization method execution with a try/except to capture errors.
+
+    1. Wraps the call to `try_initialization_method` in a try/except block
+    2. Catches any exceptions that might be thrown
+    3. Logs them and continues with the next initializer
+    4. Only fails at the end if all initializers have been tried
+    """
+    # skip initializers that don't support the requested mode
+    if not initializer.supports_mode(mode):
+        log.debug(
+            f"Skipping initializer: {initializer.init_method.__name__} for model: {model_name} "
+            f"and provider: {provider_name} as it doesn't support mode: {mode}"
+        )
+        return None
+
+    try:
+        log.debug(
+            f"Trying initializer: {initializer.init_method.__name__} for model: {model_name} and provider: {provider_name}"
+        )
+        result = initializer.execute(
+            model_name=model_name, provider_name=provider_name, kwargs=kwargs
+        )
+        log.debug(f"Initializer {initializer.init_method.__name__} returned: {result}")
+        if result is not None:
+            return result
+    except ValueError as e:
+        raise ValueError(
+            f"ValueError encountered in initializer {initializer} "
+            f"for model: {model_name} and provider: {provider_name}: {e}"
+        )
+    return None
+
+
+def init_langchain_model(
+    model_name: Optional[str],
+    provider_name: str,
+    mode: Literal["chat", "text"],
+    kwargs: Dict[str, Any],
+) -> Union[BaseChatModel, BaseLLM]:
+    """Initialize a LangChain model using a series of initialization methods.
+
+    This function tries multiple initialization methods in sequence until one succeeds.
+    Each method is attempted only if it supports the requested mode.
+    """
+
+    if mode not in ["chat", "text"]:
+        raise ValueError(f"Unsupported mode: {mode}")
+    if not model_name:
+        raise ModelInitializationError(
+            f"Model name is required for provider {provider_name}"
+        )
+
+    # Define initialization methods in order of preference
+    initializers: list[ModelInitializer] = [
+        # Try special case handlers first (handles both chat and text)
+        ModelInitializer(_handle_model_special_cases, ["chat", "text"]),
+        # For chat mode, first try the standard chat completion API
+        ModelInitializer(_init_chat_completion_model, ["chat"]),
+        # For chat mode, fall back to community chat models
+        ModelInitializer(_init_community_chat_models, ["chat"]),
+        # FIXME: is text and chat a good idea?
+        # For text mode, use text completion, we are using both text and chat as the last resort
+        ModelInitializer(_init_text_completion_model, ["text", "chat"]),
+    ]
+
+    # Track the last exception for better error reporting
+    last_exception = None
+
+    # Try each initializer in sequence
+    for initializer in initializers:
+        try:
+            result = try_initialization_method(
+                initializer=initializer,
+                model_name=model_name,
+                provider_name=provider_name,
+                mode=mode,
+                kwargs=kwargs,
+            )
+            if result is not None:
+                return result
+        except Exception as e:
+            # Keep track of the last exception
+            last_exception = e
+            log.debug(f"Initialization failed with {initializer}: {str(e)}")
+
+    raise ModelInitializationError(
+        f"Failed to initialize model {model_name} with provider {provider_name} in {mode} mode"
+    ) from last_exception
+
+
+def _init_chat_completion_model(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> BaseChatModel:  # noqa #type: ignore
+    """Initialize a chat completion model.
+
+    Args:
+        model_name: Name of the model to initialize
+        provider_name: Name of the provider to use
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized chat completion model
+
+    Raises:
+        ValueError: If the model cannot be initialized as a chat model
+    """
+
+    # just to document the expected behavior
+    # we don't support pre-0.2.7 versions of langchain-core it is in
+    # line wiht our pyproject.toml
+    package_version = version("langchain-core")
+
+    if _parse_version(package_version) < (0, 2, 7):
+        raise RuntimeError(
+            "this feature is supported from v0.2.7 of langchain-core."
+            " Please upgrade it with `pip install langchain-core --upgrade`."
+        )
+    try:
+        return init_chat_model(
+            model=model_name,
+            model_provider=provider_name,
+        )
+    except ValueError:
+        raise
+
+
+def _init_text_completion_model(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> BaseLLM:
+    """Initialize a text completion model.
+
+    Args:
+        model_name: Name of the model to initialize
+        provider_name: Name of the provider to use
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized text completion model
+
+    Raises:
+        RuntimeError: If the provider is not found
+    """
+    provider_cls = _get_text_completion_provider(provider_name)
+    if provider_cls is None:
+        raise ValueError()
+    kwargs = _update_model_kwargs(provider_cls, model_name, kwargs)
+
+    return provider_cls(**kwargs)
+
+
+def _init_community_chat_models(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> BaseChatModel:
+    """Initialize community chat models.
+
+    Args:
+        provider_name: Name of the provider to use
+        model_name: Name of the model to initialize
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized chat model
+
+    Raises:
+        ImportError: If langchain_community is not installed
+        ModelInitializationError: If model initialization fails
+    """
+    provider_cls = _get_chat_completion_provider(provider_name)
+    if provider_cls is None:
+        raise ValueError()
+    kwargs = _update_model_kwargs(provider_cls, model_name, kwargs)
+    return provider_cls(**kwargs)
+
+
+def _init_gpt35_turbo_instruct(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> BaseLLM:
+    """Initialize GPT-3.5 Turbo Instruct model.
+
+    Currently init_chat_model from langchain infers this as a chat model.
+    This is a bug in langchain, and we need to handle it here.
+
+    This model requires text completion initialization.
+
+    Args:
+        model_name: Name of the model to initialize
+        provider_name: Name of the provider to use
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized text completion model
+
+    Raises:
+        ModelInitializationError: If model initialization fails
+    """
+    try:
+        return _init_text_completion_model(
+            model_name=model_name,
+            provider_name=provider_name,
+            kwargs=kwargs,
+        )
+    except Exception as e:
+        raise ModelInitializationError(
+            f"Failed to initialize text completion model {model_name}: {str(e)}"
+        )
+
+
+def _init_nvidia_model(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> BaseChatModel:
+    """Initialize NVIDIA AI Endpoints model.
+
+    Args:
+        model_name: Name of the model to initialize
+        provider_name: Name of the provider to use
+        **kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized chat model
+
+    Raises:
+        ImportError: If langchain_nvidia_ai_endpoints is not installed
+        ModelInitializationError: If model initialization fails
+    """
+    try:
+        from nemoguardrails.llm.providers._langchain_nvidia_ai_endpoints_patch import (
+            ChatNVIDIA,
+        )
+
+        package_version = version("langchain_nvidia_ai_endpoints")
+
+        if _parse_version(package_version) < (0, 2, 0):
+            raise ValueError(
+                "langchain_nvidia_ai_endpoints version must be 0.2.0 or above."
+                " Please upgrade it with `pip install langchain-nvidia-ai-endpoints --upgrade`."
+            )
+
+        return ChatNVIDIA(model=model_name, **kwargs)
+    except ImportError as e:
+        raise ImportError(
+            "Could not import langchain_nvidia_ai_endpoints, please install it with "
+            "`pip install langchain-nvidia-ai-endpoints`."
+        )
+
+
+# special model handlers
+_SPECIAL_MODEL_INITIALIZERS = {
+    "gpt-3.5-turbo-instruct": _init_gpt35_turbo_instruct,
+}
+
+# provider-specific handlers
+_PROVIDER_INITIALIZERS = {
+    "nvidia_ai_endpoints": _init_nvidia_model,
+    "nim": _init_nvidia_model,
+}
+
+
+def _handle_model_special_cases(
+    model_name: str, provider_name: str, kwargs: Dict[str, Any]
+) -> Optional[Union[BaseChatModel, BaseLLM]]:
+    """Handle model initialization for special cases that need custom logic.
+
+    This function handles edge cases where standard initialization methods
+    don't work properly. It looks up initializers in the registry and dispatches
+    to the appropriate initialization function.
+
+    Args:
+        provider_name: Name of the provider to use
+        model_name: Name of the model to initialize
+        kwargs: Additional arguments to pass to the model initialization
+
+    Returns:
+        An initialized model for special cases, or None if no special initializer exists
+    """
+    initializer = None
+
+    for pattern, model_initializer in _SPECIAL_MODEL_INITIALIZERS.items():
+        if pattern in model_name:
+            initializer = model_initializer
+            break
+
+    if initializer is None and provider_name in _PROVIDER_INITIALIZERS:
+        initializer = _PROVIDER_INITIALIZERS[provider_name]
+
+    if initializer is None:
+        return None
+
+    result = initializer(model_name, provider_name, kwargs)
+    if not isinstance(result, (BaseChatModel, BaseLLM)):
+        raise TypeError("Initializer returned an invalid type")
+    return result
+
+
+def _update_model_kwargs(provider_cls: type, model_name: str, kwargs: dict) -> Dict:
+    """Update kwargs with the model name based on the provider's expected fields.
+
+    If provider_cls.model_fields contains 'model' or 'model_name',
+    sets the corresponding key in kwargs to model_name.
+    """
+    for key in ("model", "model_name"):
+        if key in getattr(provider_cls, "model_fields", {}):
+            kwargs[key] = model_name
+    return kwargs

--- a/nemoguardrails/llm/providers/__init__.py
+++ b/nemoguardrails/llm/providers/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 from .providers import (
-    HuggingFacePipelineCompatible,
-    get_llm_provider,
+    get_chat_provider_names,
     get_llm_provider_names,
+    register_chat_provider,
     register_llm_provider,
 )

--- a/nemoguardrails/llm/providers/__init__.py
+++ b/nemoguardrails/llm/providers/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from .providers import (
-    get_chat_provider_names,
+    get_community_chat_provider_names,
     get_llm_provider_names,
     register_chat_provider,
     register_llm_provider,

--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -154,7 +154,7 @@ def get_llm_provider_names() -> List[str]:
     return list(sorted(list(_llm_providers.keys())))
 
 
-def get_chat_provider_names() -> List[str]:
+def get_community_chat_provider_names() -> List[str]:
     """Returns the list of supported chat providers."""
     return list(sorted(list(_chat_providers.keys())))
 
@@ -181,7 +181,7 @@ __all__ = [
     "_llm_providers",
     "_parse_version",
     "get_llm_provider_names",
-    "get_chat_provider_names",
+    "get_community_chat_provider_names",
     "register_llm_provider",
     "register_chat_provider",
 ]

--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -22,21 +22,15 @@ Additional providers can be registered using the `register_llm_provider` functio
 """
 
 import asyncio
+import importlib
 import logging
 import warnings
-from importlib.metadata import version
-from typing import Any, Dict, List, Optional, Type
+from typing import Dict, List, Type
 
-from langchain.callbacks.manager import (
-    AsyncCallbackManagerForLLMRun,
-    CallbackManagerForLLMRun,
-)
-from langchain.schema.output import GenerationChunk
+from langchain.chat_models.base import BaseChatModel
 from langchain_community import llms
-from langchain_community.llms import HuggingFacePipeline
+from langchain_community.chat_models import _module_lookup
 from langchain_core.language_models.llms import BaseLLM
-
-from nemoguardrails.rails.llm.config import Model
 
 from .trtllm.llm import TRTLLM
 
@@ -48,126 +42,31 @@ warnings.filterwarnings(
     category=UserWarning,
     module=r"pydantic\._internal\._fields",
 )
+
 log = logging.getLogger(__name__)
-
-# Initialize the providers with the default ones
-# We set nvidia_ai_endpoints provider to None because it's only supported if `langchain_nvidia_ai_endpoints` is installed.
-_providers: Dict[str, Optional[Type[BaseLLM]]] = {
-    "trt_llm": TRTLLM,
-    "nvidia_ai_endpoints": None,
-    "google_genai": None,
-    "deepseek": None,
-    "nim": None,  # Later patched to "nvidia_ai_endpoints" (synonymous).
-}
-
-
-class HuggingFacePipelineCompatible(HuggingFacePipeline):
-    """
-    Hackish way to add backward-compatibility functions to the Langchain class.
-    TODO: Planning to add this fix directly to Langchain repo.
-    """
-
-    def _call(
-        self,
-        prompt: str,
-        stop: Optional[List[str]] = None,
-        run_manager: Optional[CallbackManagerForLLMRun] = None,
-        **kwargs: Any,
-    ) -> str:
-        """
-        Hackish way to perform a single llm call since Langchain dropped support
-        """
-        if not isinstance(prompt, str):
-            raise ValueError(
-                "Argument `prompt` is expected to be a string. Instead found "
-                f"{type(prompt)}. If you want to run the LLM on multiple prompts, use "
-                "`generate` instead."
-            )
-
-        # Streaming for NeMo Guardrails is not supported in sync calls.
-        if self.model_kwargs and self.model_kwargs.get("streaming"):
-            raise Exception(
-                "Streaming mode not supported for HuggingFacePipeline in NeMo Guardrails!"
-            )
-
-        llm_result = self._generate(
-            [prompt],
-            stop=stop,
-            run_manager=run_manager,
-            **kwargs,
-        )
-        return llm_result.generations[0][0].text
-
-    async def _acall(
-        self,
-        prompt: str,
-        stop: Optional[List[str]] = None,
-        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
-        **kwargs: Any,
-    ) -> str:
-        """
-        Hackish way to add async support
-        """
-        if not isinstance(prompt, str):
-            raise ValueError(
-                "Argument `prompt` is expected to be a string. Instead found "
-                f"{type(prompt)}. If you want to run the LLM on multiple prompts, use "
-                "`generate` instead."
-            )
-
-        # Handle streaming, if the flag is set
-        if self.model_kwargs and self.model_kwargs.get("streaming"):
-            # Retrieve the streamer object, needs to be set in model_kwargs
-            streamer = self.model_kwargs.get("streamer")
-            if not streamer:
-                raise Exception(
-                    "Cannot stream, please add HuggingFace streamer object to model_kwargs!"
-                )
-
-            loop = asyncio.get_running_loop()
-
-            # Pass the asyncio loop to the stream so that it can send back
-            # the chunks in the queue.
-            streamer.loop = loop
-
-            # Launch the generation in a separate task.
-            generation_kwargs = dict(
-                prompts=[prompt],
-                stop=stop,
-                run_manager=run_manager,
-                **kwargs,
-            )
-            loop.create_task(self._agenerate(**generation_kwargs))
-
-            # And start waiting for the chunks to come in.
-            completion = ""
-            async for item in streamer:
-                completion += item
-                chunk = GenerationChunk(text=item)
-                if run_manager:
-                    await run_manager.on_llm_new_token(item, chunk=chunk)
-
-            return completion
-
-        llm_result = await self._agenerate(
-            [prompt],
-            stop=stop,
-            run_manager=run_manager,
-            **kwargs,
-        )
-        return llm_result.generations[0][0].text
-
-
-async def _acall(self, *args, **kwargs):
-    """Hackish way to add async support to LLM providers that don't have it.
-
-    We just call the sync version of the function.
-    """
-    # TODO: run this in a thread pool!
-    return self._call(*args, **kwargs)
 
 
 def discover_langchain_providers():
+    """Automatically discover all LLM providers from LangChain.
+
+    This function is deprecated and will be removed in a future release.
+    Use `_discover_langchain_providers` directly instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "The `discover_langchain_providers` function is deprecated and will be removed in v0.15.0 release"
+        "Please use `get_model_provider` directly.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _discover_langchain_community_llm_providers()
+
+
+DEPRECATED_LLM_PROVIDERS = ["mlflow-chat", "databricks-chat"]
+
+
+def _discover_langchain_community_llm_providers():
     """Automatically discover all LLM providers from LangChain."""
     # To deal with deprecated stuff and avoid warnings, we compose the type_to_cls_dict here
     if hasattr(llms, "get_type_to_cls_dict"):
@@ -175,28 +74,45 @@ def discover_langchain_providers():
             k: v()
             for k, v in llms.get_type_to_cls_dict().items()
             # Exclude deprecated ones
-            if k not in ["mlflow-chat", "databricks-chat"]
+            if k not in DEPRECATED_LLM_PROVIDERS
         }
     else:
         type_to_cls_dict = llms.type_to_cls_dict
 
-    _providers.update(type_to_cls_dict)
+    return type_to_cls_dict
 
-    # We make sure we have OpenAI from the right package.
-    if "openai" in _providers:
-        try:
-            from langchain_openai import OpenAI
 
-            del _providers["openai"]
+def _discover_langchain_community_chat_providers():
+    """Creates a mapping from provider name to chat model class.
+    The provider name is defined as the last segment of the module path.
+    For example, for module path "langchain_community.chat_models.google_palm",
+    the provider name is "google_palm".
+    """
 
-            _providers["openai"] = OpenAI
-        except ImportError:
-            # If the `langchain_openai` package is not installed, the warning
-            # will come from langchain.
-            pass
+    mapping = {}
+    for class_name, module_path in _module_lookup.items():
+        # extract provider name (we assume it is the last segment after the dot)
+        provider_name = module_path.split(".")[-1]
 
-    # We also do some monkey patching to make sure that all LLM providers have async support
-    for provider_cls in _providers.values():
+        module = importlib.import_module(module_path)
+        class_ = getattr(module, class_name)
+        if provider_name in mapping:
+            log.debug(
+                f"Duplicate provider mapping for '{provider_name}': "
+                f"existing class {mapping[provider_name]} vs new class {class_}"
+            )
+        mapping[provider_name] = class_
+
+    return mapping
+
+
+async def _acall(self, *args, **kwargs):
+    """Adds asynchronous support to LLM providers that only have synchronous methods."""
+    return await asyncio.to_thread(self._call, *args, **kwargs)
+
+
+def _patch_acall_method_to(llm_providers: Dict[str, Type[BaseLLM]]):
+    for provider_cls in llm_providers.values():
         # If the "_acall" method is not defined, we add it.
         if (
             provider_cls
@@ -204,128 +120,68 @@ def discover_langchain_providers():
             and "_acall" not in provider_cls.__dict__
         ):
             log.debug("Adding async support to %s", provider_cls.__name__)
-            provider_cls._acall = _acall
+            setattr(provider_cls, "_acall", _acall)
 
 
-# Discover all the additional providers from LangChain
-discover_langchain_providers()
+# Initialize the providers with the default ones
+_llm_providers: Dict[str, Type[BaseLLM]] = {
+    "trt_llm": TRTLLM,
+}
+
+_chat_providers: Dict[str, Type[BaseChatModel]]
+
+_llm_providers.update(_discover_langchain_community_llm_providers())
+_patch_acall_method_to(_llm_providers)
+_chat_providers = _discover_langchain_community_chat_providers()
 
 
 def register_llm_provider(name: str, provider_cls: Type[BaseLLM]):
     """Register an additional LLM provider."""
-    _providers[name] = provider_cls
-
-
-def get_llm_provider(model_config: Model) -> Type[BaseLLM]:
-    if model_config.engine not in _providers:
-        raise RuntimeError(f"Could not find LLM provider '{model_config.engine}'")
-
-    # For OpenAI, we use a different provider depending on whether it's a chat model or not
-    if (
-        model_config.engine == "openai"
-        and ("gpt-3.5" in model_config.model or "gpt-4" in model_config.model)
-        and "instruct" not in model_config.model
-    ):
-        try:
-            from langchain_openai.chat_models import ChatOpenAI
-
-            return ChatOpenAI
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_openai, please install it with "
-                "`pip install langchain-openai`."
-            )
-
-    elif model_config.engine == "azure" and (
-        "gpt-3.5" in model_config.model or "gpt-4" in model_config.model
-    ):
-        try:
-            from langchain_openai.chat_models import AzureChatOpenAI
-
-            return AzureChatOpenAI
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_openai, please install it with "
-                "`pip install langchain-openai`."
-            )
-    elif model_config.engine == "nvidia_ai_endpoints" or model_config.engine == "nim":
-        try:
-            from ._langchain_nvidia_ai_endpoints_patch import ChatNVIDIA
-
-            # Check the version
-            package_version = version("langchain_nvidia_ai_endpoints")
-
-            if _parse_version(package_version) < (0, 2, 0):
-                raise ValueError(
-                    "langchain_nvidia_ai_endpoints version must be 0.2.0 or above."
-                    " Please upgrade it with `pip install langchain-nvidia-ai-endpoints --upgrade`."
-                )
-            return ChatNVIDIA
-
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_nvidia_ai_endpoints, please install it with "
-                "`pip install langchain-nvidia-ai-endpoints`."
-            )
-
-    elif model_config.engine == "google_genai":
-        try:
-            from langchain_google_genai import ChatGoogleGenerativeAI
-
-            return ChatGoogleGenerativeAI
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_google_genai, please install it with "
-                "`pip install langchain_google_genai`."
-            )
-
-    elif model_config.engine == "deepseek":
-        try:
-            from langchain_deepseek import ChatDeepSeek
-
-            return ChatDeepSeek
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_deepseek, please install it with "
-                "`pip install langchain_deepseek`."
-            )
-
-    elif model_config.engine == "vertexai":
-        # To avoid a LangChainDeprecationWarning with the default langchain_community.llms.vertexai.VertexAI which  is
-        # deprecated in langchain-community 0.0.12 and will be removed in 0.2.0.
-        try:
-            from langchain_google_vertexai import VertexAI
-
-            return VertexAI
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_google_vertexai, please install it with "
-                "`pip install langchain-google-vertexai`."
-            )
-    elif model_config.engine == "together":
-        try:
-            from langchain_together.chat_models import ChatTogether
-
-            return ChatTogether
-        except ImportError:
-            raise ImportError(
-                "Could not import langchain_together, please install it with "
-                "`pip install langchain-together`."
-            )
-
-    elif model_config.engine == "nemollm":
-        raise RuntimeError(
-            "'nemollm' engine is deprecated and has been removed in v0.14.0 release."
+    if not hasattr(provider_cls, "_acall"):
+        raise TypeError(
+            f"The provider class {provider_cls.__name__} must implement an '_acall' method."
         )
+    _llm_providers[name] = provider_cls
 
-    else:
-        return _providers[model_config.engine]
+
+def register_chat_provider(name: str, provider_cls: Type[BaseChatModel]):
+    """Register an additional chat provider."""
+    _chat_providers[name] = provider_cls
 
 
 def get_llm_provider_names() -> List[str]:
     """Returns the list of supported LLM providers."""
-    return list(sorted(list(_providers.keys())))
+    return list(sorted(list(_llm_providers.keys())))
+
+
+def get_chat_provider_names() -> List[str]:
+    """Returns the list of supported chat providers."""
+    return list(sorted(list(_chat_providers.keys())))
+
+
+def _get_text_completion_provider(provider_name: str) -> Type[BaseLLM]:
+    if provider_name not in _llm_providers:
+        raise RuntimeError(f"Could not find LLM provider '{provider_name}'")
+
+    return _llm_providers[provider_name]
+
+
+def _get_chat_completion_provider(provider_name: str) -> Type[BaseChatModel]:
+    if provider_name not in _chat_providers:
+        raise RuntimeError(f"Could not find chat provider '{provider_name}'")
+
+    return _chat_providers[provider_name]
 
 
 def _parse_version(version_str):
     return tuple(map(int, (version_str.split("."))))
+
+
+__all__ = [
+    "_llm_providers",
+    "_parse_version",
+    "get_llm_provider_names",
+    "get_chat_provider_names",
+    "register_llm_provider",
+    "register_chat_provider",
+]

--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -25,7 +25,7 @@ import asyncio
 import importlib
 import logging
 import warnings
-from typing import Dict, List, Type
+from typing import Dict, List, Set, Type
 
 from langchain.chat_models.base import BaseChatModel
 from langchain_community import llms
@@ -80,6 +80,16 @@ def _discover_langchain_community_llm_providers():
         type_to_cls_dict = llms.type_to_cls_dict
 
     return type_to_cls_dict
+
+
+# this is needed as we perform the mapping in langchain_initializer.py
+_CUSTOM_CHAT_PROVIDERS = {"nim"}
+
+
+def _discover_langchain_partner_chat_providers() -> Set[str]:
+    from langchain.chat_models.base import _SUPPORTED_PROVIDERS
+
+    return _SUPPORTED_PROVIDERS | _CUSTOM_CHAT_PROVIDERS
 
 
 def _discover_langchain_community_chat_providers():
@@ -157,6 +167,17 @@ def get_llm_provider_names() -> List[str]:
 def get_community_chat_provider_names() -> List[str]:
     """Returns the list of supported chat providers."""
     return list(sorted(list(_chat_providers.keys())))
+
+
+def _get_all_chat_provider_names() -> List[str]:
+    """Consolidates all chat provider names."""
+
+    return list(_chat_providers.keys() | _discover_langchain_partner_chat_providers())
+
+
+def get_chat_provider_names() -> List[str]:
+    """Returns the list of supported chat providers."""
+    return list(sorted(_get_all_chat_provider_names()))
 
 
 def _get_text_completion_provider(provider_name: str) -> Type[BaseLLM]:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -20,7 +20,7 @@ import os
 import re
 import warnings
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
 import yaml
 from pydantic import (
@@ -109,6 +109,11 @@ class Model(BaseModel):
     )
     parameters: Dict[str, Any] = Field(default_factory=dict)
 
+    mode: Literal["chat", "text"] = Field(
+        default="chat",
+        description="Whether the mode is 'text' completion or 'chat' completion. Allowed values are 'chat' or 'text'.",
+    )
+
     @model_validator(mode="before")
     @classmethod
     def set_and_validate_model(cls, data: Any) -> Any:
@@ -135,7 +140,7 @@ class Model(BaseModel):
             return data
 
     @model_validator(mode="after")
-    def model_must_be_non_empty(self) -> "Model":
+    def model_must_be_none_empty(self) -> "Model":
         """Validate that a model name is present either directly or in parameters."""
         if not self.model or not self.model.strip():
             raise ValueError(

--- a/tests/llm_providers/test_deprecated_providers.py
+++ b/tests/llm_providers/test_deprecated_providers.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from unittest.mock import patch
+
+import pytest
+
+from nemoguardrails.llm.providers.providers import (
+    _discover_langchain_community_llm_providers,
+    discover_langchain_providers,
+)
+
+
+class MockBaseLLM:
+    def _call(self, *args, **kwargs):
+        return "Mock response"
+
+
+@pytest.fixture
+def mock_discover_function():
+    with patch(
+        "nemoguardrails.llm.providers.providers._discover_langchain_community_llm_providers"
+    ) as mock_func:
+        mock_providers = {"mock_provider": MockBaseLLM}
+        mock_func.return_value = mock_providers
+        with patch(
+            "nemoguardrails.llm.providers.providers._patch_acall_method_to"
+        ) as mock_patch:
+            with patch(
+                "nemoguardrails.llm.providers.providers._llm_providers"
+            ) as mock_llm_providers:
+                mock_llm_providers.update(mock_providers)
+                yield mock_func
+
+
+def test_discover_langchain_providers_deprecation(mock_discover_function):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        discover_langchain_providers()
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+        assert "v0.15.0" in str(w[0].message)
+
+
+def test_discover_langchain_providers_functionality(mock_discover_function):
+    # ensure the function still works as expected
+    discover_langchain_providers()
+    # as the function is deprecated, we verify that it calls the underlying function
+    mock_discover_function.assert_called_once()

--- a/tests/llm_providers/test_langchain_initialization_methods.py
+++ b/tests/llm_providers/test_langchain_initialization_methods.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the initialization methods for different model types.
+
+This module contains tests for the initialization methods that are used to initialize
+different types of models (chat completion, community chat, text completion).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemoguardrails.llm.models.langchain_initializer import (
+    _init_chat_completion_model,
+    _init_community_chat_models,
+    _init_text_completion_model,
+    _update_model_kwargs,
+)
+
+
+class TestChatCompletionInitializer:
+    """Tests for the chat completion initializer."""
+
+    def test_init_chat_completion_model_success(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer.init_chat_model"
+        ) as mock_init:
+            mock_init.return_value = "chat_model"
+            with patch(
+                "nemoguardrails.llm.models.langchain_initializer.version"
+            ) as mock_version:
+                mock_version.return_value = "0.2.7"
+                result = _init_chat_completion_model("gpt-3.5-turbo", "openai", {})
+                assert result == "chat_model"
+                mock_init.assert_called_once_with(
+                    model="gpt-3.5-turbo",
+                    model_provider="openai",
+                )
+
+    def test_init_chat_completion_model_old_version(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer.version"
+        ) as mock_version:
+            mock_version.return_value = "0.2.6"
+            with pytest.raises(
+                RuntimeError,
+                match="this feature is supported from v0.2.7 of langchain-core",
+            ):
+                _init_chat_completion_model("gpt-3.5-turbo", "openai", {})
+
+    def test_init_chat_completion_model_error(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer.init_chat_model"
+        ) as mock_init:
+            mock_init.side_effect = ValueError("Chat model failed")
+            with patch(
+                "nemoguardrails.llm.models.langchain_initializer.version"
+            ) as mock_version:
+                mock_version.return_value = "0.2.7"
+                with pytest.raises(ValueError, match="Chat model failed"):
+                    _init_chat_completion_model("gpt-3.5-turbo", "openai", {})
+
+
+class TestCommunityChatInitializer:
+    """Tests for the community chat initializer."""
+
+    def test_init_community_chat_models_success(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._get_chat_completion_provider"
+        ) as mock_get_provider:
+            mock_provider_cls = MagicMock()
+            mock_provider_cls.model_fields = {"model": None}
+            mock_provider_cls.return_value = "community_model"
+            mock_get_provider.return_value = mock_provider_cls
+            result = _init_community_chat_models("community-model", "provider", {})
+            assert result == "community_model"
+            mock_get_provider.assert_called_once_with("provider")
+            mock_provider_cls.assert_called_once_with(model="community-model")
+
+    def test_init_community_chat_models_no_provider(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._get_chat_completion_provider"
+        ) as mock_get_provider:
+            mock_get_provider.return_value = None
+            with pytest.raises(ValueError):
+                _init_community_chat_models("community-model", "provider", {})
+
+
+class TestTextCompletionInitializer:
+    """Tests for the text completion initializer."""
+
+    def test_init_text_completion_model_success(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._get_text_completion_provider"
+        ) as mock_get_provider:
+            mock_provider_cls = MagicMock()
+            mock_provider_cls.model_fields = {"model": None}
+            mock_provider_cls.return_value = "text_model"
+            mock_get_provider.return_value = mock_provider_cls
+            result = _init_text_completion_model("text-model", "provider", {})
+            assert result == "text_model"
+            mock_get_provider.assert_called_once_with("provider")
+            mock_provider_cls.assert_called_once_with(model="text-model")
+
+    def test_init_text_completion_model_no_provider(self):
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._get_text_completion_provider"
+        ) as mock_get_provider:
+            mock_get_provider.return_value = None
+            with pytest.raises(ValueError):
+                _init_text_completion_model("text-model", "provider", {})
+
+
+class TestUpdateModelKwargs:
+    """Tests for the _update_model_kwargs function."""
+
+    def test_update_model_kwargs_with_model_field(self):
+        mock_provider_cls = MagicMock()
+        mock_provider_cls.model_fields = {"model": {}}
+        kwargs = {}
+        updated_kwargs = _update_model_kwargs(mock_provider_cls, "test-model", kwargs)
+        assert updated_kwargs == {"model": "test-model"}
+
+    def test_update_model_kwargs_with_model_name_field(self):
+        """Test that _update_model_kwargs updates kwargs with model name when provider has model_name field."""
+        mock_provider_cls = MagicMock()
+        mock_provider_cls.model_fields = {"model_name": {}}
+        kwargs = {}
+        updated_kwargs = _update_model_kwargs(mock_provider_cls, "test-model", kwargs)
+        assert updated_kwargs == {"model_name": "test-model"}
+
+    def test_update_model_kwargs_with_both_fields(self):
+        """Test _update_model_kwargs updates kwargs with model name when provider has both model and model_name fields."""
+
+        mock_provider_cls = MagicMock()
+        mock_provider_cls.model_fields = {"model": {}, "model_name": {}}
+        kwargs = {}
+        updated_kwargs = _update_model_kwargs(mock_provider_cls, "test-model", kwargs)
+        assert updated_kwargs == {"model": "test-model", "model_name": "test-model"}
+
+    def test_update_model_kwargs_with_existing_kwargs(self):
+        """Test _update_model_kwargs preserves existing kwargs."""
+
+        mock_provider_cls = MagicMock()
+        mock_provider_cls.model_fields = {"model": {}}
+        kwargs = {"temperature": 0.7}
+        updated_kwargs = _update_model_kwargs(mock_provider_cls, "test-model", kwargs)
+        assert updated_kwargs == {"model": "test-model", "temperature": 0.7}

--- a/tests/llm_providers/test_langchain_initializer.py
+++ b/tests/llm_providers/test_langchain_initializer.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemoguardrails.llm.models.langchain_initializer import (
+    ModelInitializationError,
+    _handle_model_special_cases,
+    _init_chat_completion_model,
+    _init_community_chat_models,
+    _init_text_completion_model,
+    init_langchain_model,
+)
+
+
+@pytest.fixture
+def mock_initializers():
+    """Mock all initialization methods for unit tests."""
+    with (
+        patch(
+            "nemoguardrails.llm.models.langchain_initializer._handle_model_special_cases"
+        ) as mock_special,
+        patch(
+            "nemoguardrails.llm.models.langchain_initializer._init_chat_completion_model"
+        ) as mock_chat,
+        patch(
+            "nemoguardrails.llm.models.langchain_initializer._init_community_chat_models"
+        ) as mock_community,
+        patch(
+            "nemoguardrails.llm.models.langchain_initializer._init_text_completion_model"
+        ) as mock_text,
+    ):
+        # Set __name__ attributes for the mocks
+        mock_special.__name__ = "_handle_model_special_cases"
+        mock_chat.__name__ = "_init_chat_completion_model"
+        mock_community.__name__ = "_init_community_chat_models"
+        mock_text.__name__ = "_init_text_completion_model"
+
+        yield {
+            "special": mock_special,
+            "chat": mock_chat,
+            "community": mock_community,
+            "text": mock_text,
+        }
+
+
+def test_special_case_called_first(mock_initializers):
+    mock_initializers["special"].return_value = "special_model"
+    result = init_langchain_model("gpt-3.5-turbo-instruct", "provider", "chat", {})
+    assert result == "special_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_not_called()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_chat_completion_called(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = "chat_model"
+    result = init_langchain_model("chat-model", "provider", "chat", {})
+    assert result == "chat_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_community_chat_called(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = "community_model"
+    result = init_langchain_model("community-chat", "provider", "chat", {})
+    assert result == "community_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_called_once()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_text_completion_called(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = None
+    mock_initializers["text"].return_value = "text_model"
+    result = init_langchain_model("text-model", "provider", "text", {})
+    assert result == "text_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_not_called()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_called_once()
+
+
+def test_all_initializers_fail(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = None
+    mock_initializers["text"].return_value = None
+    with pytest.raises(ModelInitializationError):
+        init_langchain_model("unknown-model", "provider", "chat", {})
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_called_once()
+    mock_initializers["text"].assert_called_once()
+
+
+def test_unsupported_mode(mock_initializers):
+    with pytest.raises(ValueError, match="Unsupported mode: invalid_mode"):
+        init_langchain_model("text-model", "provider", "invalid_mode", {})
+    mock_initializers["special"].assert_not_called()
+    mock_initializers["chat"].assert_not_called()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_missing_model_name(mock_initializers):
+    with pytest.raises(
+        ModelInitializationError, match="Model name is required for provider provider"
+    ):
+        init_langchain_model(None, "provider", "chat", {})
+    mock_initializers["special"].assert_not_called()
+    mock_initializers["chat"].assert_not_called()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_all_initializers_raise_exceptions(mock_initializers):
+    mock_initializers["special"].side_effect = RuntimeError("Special case failed")
+    mock_initializers["chat"].side_effect = ValueError("Chat model failed")
+    mock_initializers["community"].side_effect = ImportError("Community model failed")
+    mock_initializers["text"].side_effect = KeyError("Text model failed")
+    with pytest.raises(
+        ModelInitializationError, match="Failed to initialize model unknown-model"
+    ):
+        init_langchain_model("unknown-model", "provider", "chat", {})
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_called_once()
+    mock_initializers["text"].assert_called_once()
+
+
+def test_duplicate_modes_in_initializer(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = "chat_model"
+    result = init_langchain_model("chat-model", "provider", "chat", {})
+    assert result == "chat_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_chat_completion_called_when_special_returns_none(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = "chat_model"
+    result = init_langchain_model("chat-model", "provider", "chat", {})
+    assert result == "chat_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_community_chat_called_when_previous_fail(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = "community_model"
+    result = init_langchain_model("community-chat", "provider", "chat", {})
+    assert result == "community_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_called_once()
+    mock_initializers["text"].assert_not_called()
+
+
+def test_text_completion_called_when_previous_fail(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = None
+    mock_initializers["text"].return_value = "text_model"
+    result = init_langchain_model("text-model", "provider", "text", {})
+    assert result == "text_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_not_called()
+    mock_initializers["community"].assert_not_called()
+    mock_initializers["text"].assert_called_once()
+
+
+def test_text_completion_supports_chat_mode(mock_initializers):
+    mock_initializers["special"].return_value = None
+    mock_initializers["chat"].return_value = None
+    mock_initializers["community"].return_value = None
+    mock_initializers["text"].return_value = "text_model"
+    result = init_langchain_model("text-model", "provider", "chat", {})
+    assert result == "text_model"
+    mock_initializers["special"].assert_called_once()
+    mock_initializers["chat"].assert_called_once()
+    mock_initializers["community"].assert_called_once()
+    mock_initializers["text"].assert_called_once()

--- a/tests/llm_providers/test_langchain_initializer.py
+++ b/tests/llm_providers/test_langchain_initializer.py
@@ -143,7 +143,7 @@ def test_all_initializers_raise_exceptions(mock_initializers):
     mock_initializers["community"].side_effect = ImportError("Community model failed")
     mock_initializers["text"].side_effect = KeyError("Text model failed")
     with pytest.raises(
-        ModelInitializationError, match="Failed to initialize model unknown-model"
+        ModelInitializationError, match=r"Failed to initialize model 'unknown-model'"
     ):
         init_langchain_model("unknown-model", "provider", "chat", {})
     mock_initializers["special"].assert_called_once()

--- a/tests/llm_providers/test_langchain_integration.py
+++ b/tests/llm_providers/test_langchain_integration.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.chat_models.base import BaseChatModel
+from langchain_core.language_models import BaseLLM
+
+from nemoguardrails.llm.models.langchain_initializer import init_langchain_model
+from nemoguardrails.llm.providers.providers import (
+    _chat_providers,
+    _discover_langchain_community_chat_providers,
+    _discover_langchain_community_llm_providers,
+    _llm_providers,
+)
+
+
+class MockLangChainLLM:
+    def _call(self, *args, **kwargs):
+        return "Mock LangChain LLM response"
+
+
+class MockLangChainChatModel:
+    def _call(self, *args, **kwargs):
+        return "Mock LangChain Chat Model response"
+
+
+@pytest.fixture
+def mock_langchain_llms():
+    with patch("nemoguardrails.llm.providers.providers.llms") as mock_llms:
+        # mock  get_type_to_cls_dict method
+        mock_llms.get_type_to_cls_dict.return_value = {
+            "mock_provider": MockLangChainLLM
+        }
+        yield mock_llms
+
+
+@pytest.fixture
+def mock_langchain_chat_models():
+    with patch("nemoguardrails.llm.providers.providers._module_lookup") as mock_lookup:
+        # mock the items method to return a list of tuples
+        mock_lookup.items.return_value = [
+            (
+                "MockLangChainChatModel",
+                "langchain_community.chat_models.mock_provider",
+            )
+        ]
+        with patch(
+            "nemoguardrails.llm.providers.providers.importlib.import_module"
+        ) as mock_import:
+            # mock the import_module function
+            mock_module = MagicMock()
+            mock_module.MockLangChainChatModel = MockLangChainChatModel
+            mock_import.return_value = mock_module
+            yield mock_lookup
+
+
+def test_discover_mocked_langchain_community_llm_providers(mock_langchain_llms):
+    """Test that the function correctly discovers LangChain LLM providers."""
+    providers = _discover_langchain_community_llm_providers()
+    assert "mock_provider" in providers
+    # @FIXME:shouldn't it reutrn the class?
+    assert isinstance(providers["mock_provider"], MockLangChainLLM)
+
+
+def test_discover_mocked_langchain_community_chat_providers(mock_langchain_chat_models):
+    providers = _discover_langchain_community_chat_providers()
+    assert "mock_provider" in providers
+    assert providers["mock_provider"] == MockLangChainChatModel
+
+
+def test_langchain_providers_in_registry():
+    """Test that LangChain providers are included in the registry."""
+    # This test assumes that LangChain providers are already discovered and registered
+    # It checks that the registry contains at least one provider
+    assert len(_llm_providers) > 0, "No LLM providers found in the registry"
+    assert len(_chat_providers) > 0, "No chat providers found in the registry"
+
+
+def test_langchain_provider_has_acall():
+    """Test that LangChain providers have the _acall method."""
+    # this test assumes that LangChain providers are already discovered and registered
+    # it checks that at least one provider has the _acall method
+    has_acall_method = False
+    for provider_cls in _llm_providers.values():
+        if hasattr(provider_cls, "_acall") and callable(
+            getattr(provider_cls, "_acall")
+        ):
+            has_acall_method = True
+            break
+
+    if not has_acall_method:
+        warnings.warn(
+            "No LLM provider with _acall method found. "
+            "This might be due to a version mismatch with LangChain."
+        )
+
+
+def test_langchain_provider_imports():
+    """Test that LangChain providers can be imported without errors."""
+    # this test ensures that LangChain providers can be imported without errors
+    # it's useful for catching import errors early
+
+    # Get all provider names
+    llm_provider_names = list(_llm_providers.keys())
+    chat_provider_names = list(_chat_providers.keys())
+
+    # try to import each provider
+    for provider_name in llm_provider_names:
+        try:
+            provider_cls = _llm_providers[provider_name]
+            assert (
+                provider_cls is not None
+            ), f"Provider class for '{provider_name}' is None"
+        except Exception as e:
+            warnings.warn(f"Failed to import LLM provider '{provider_name}': {str(e)}")
+
+    for provider_name in chat_provider_names:
+        try:
+            provider_cls = _chat_providers[provider_name]
+            assert (
+                provider_cls is not None
+            ), f"Provider class for '{provider_name}' is None"
+        except Exception as e:
+            warnings.warn(f"Failed to import chat provider '{provider_name}': {str(e)}")
+
+
+def _is_langchain_installed():
+    """Check if LangChain is installed."""
+    try:
+        import langchain
+
+        return True
+    except ImportError:
+        return False
+
+
+def _is_langchain_community_installed():
+    """Check if LangChain Community is installed."""
+    try:
+        import langchain_community
+
+        return True
+    except ImportError:
+        return False
+
+
+def _has_openai():
+    """Check if OpenAI package is installed."""
+    try:
+        import langchain_openai
+
+        return True
+    except ImportError:
+        return False
+
+
+class TestLangChainIntegration:
+    """Integration tests for LangChain model initialization."""
+
+    @pytest.mark.skipif(
+        not _is_langchain_installed(), reason="LangChain is not installed"
+    )
+    def test_init_openai_chat_model(self):
+        """Test initializing an OpenAI chat model with real implementation."""
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+
+        model = init_langchain_model(
+            "gpt-3.5-turbo", "openai", "chat", {"temperature": 0.1}
+        )
+        assert model is not None
+        assert hasattr(model, "invoke")
+        assert isinstance(model, BaseChatModel)
+        assert not isinstance(model, BaseLLM)
+
+        # Test that the model can be used
+        from langchain_core.messages import HumanMessage
+
+        response = model.invoke([HumanMessage(content="Hello, world!")])
+        assert response is not None
+        assert hasattr(response, "content")
+
+    @pytest.mark.skipif(
+        not _has_openai(), reason="langchain_openai package is not installed"
+    )
+    def test_init_openai_text_model(self):
+        """Test initializing an OpenAI text model with real implementation."""
+        # skip if OpenAI API key is not set
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+
+        model = init_langchain_model(
+            "davinci-002", "openai", "text", {"temperature": 0.1}
+        )
+        assert model is not None
+        assert hasattr(model, "invoke")
+        assert isinstance(model, BaseLLM)
+        assert not isinstance(model, BaseChatModel)
+
+        response = model.invoke("Hello, world!")
+        assert response is not None
+
+    @pytest.mark.skipif(
+        not _is_langchain_installed(), reason="LangChain is not installed"
+    )
+    def test_init_gpt35_turbo_instruct(self):
+        """Test initializing a GPT-3.5 Turbo Instruct model with real implementation."""
+        # skip if OpenAI API key is not set
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+
+        model = init_langchain_model(
+            "gpt-3.5-turbo-instruct", "openai", "text", {"temperature": 0.1}
+        )
+        assert model is not None
+        # verify it's a text model
+        assert hasattr(model, "invoke")
+        assert isinstance(model, BaseLLM)
+
+        # test that the model can be used
+        response = model.invoke("Hello, world!")
+        assert response is not None
+
+    @pytest.mark.skipif(
+        not _is_langchain_installed(), reason="LangChain is not installed"
+    )
+    def test_init_with_different_modes(self):
+        """Test initializing the same model with different modes."""
+        # Skip if OpenAI API key is not set
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+
+        chat_model = init_langchain_model(
+            "gpt-3.5-turbo", "openai", "chat", {"temperature": 0.1}
+        )
+        assert chat_model is not None
+        assert hasattr(chat_model, "invoke")
+
+        # initialize as text model (should still work for some models)
+        text_model = init_langchain_model(
+            "gpt-3.5-turbo", "openai", "text", {"temperature": 0.1}
+        )
+        assert text_model is not None
+        assert hasattr(text_model, "invoke")
+
+    @pytest.mark.skipif(
+        not _is_langchain_installed() or not _has_openai(),
+        reason="LangChain is not installed",
+    )
+    def test_init_with_kwargs(self):
+        """Test initializing a model with additional kwargs."""
+
+        # skip if OpenAI API key is not set
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+
+        # Initialize with additional kwargs
+        model = init_langchain_model(
+            "gpt-4o",
+            "openai",
+            "chat",
+            {
+                "temperature": 0.1,
+                "max_tokens": 100,
+                "top_p": 0.9,
+            },
+        )
+        assert model is not None
+        assert hasattr(model, "invoke")
+
+        from langchain_core.messages import HumanMessage
+
+        response = model.invoke([HumanMessage(content="Hello, world!")])
+        assert response is not None
+        assert hasattr(response, "content")

--- a/tests/llm_providers/test_langchain_special_cases.py
+++ b/tests/llm_providers/test_langchain_special_cases.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the special case handlers in the LangChain model initializer.
+
+This module contains tests for the special case handlers that are used to initialize
+specific models or providers that require custom logic.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from langchain.chat_models.base import BaseChatModel
+from langchain_core.language_models import BaseLLM
+
+from nemoguardrails.llm.models.langchain_initializer import (
+    _PROVIDER_INITIALIZERS,
+    _SPECIAL_MODEL_INITIALIZERS,
+    ModelInitializationError,
+    _handle_model_special_cases,
+    _init_gpt35_turbo_instruct,
+    _init_nvidia_model,
+)
+
+
+def has_openai():
+    """Check if OpenAI package is installed."""
+    try:
+        import langchain_openai
+
+        return True
+    except ImportError:
+        return False
+
+
+def has_nvidia_ai_endpoints():
+    """Check if NVIDIA AI Endpoints package is installed."""
+    try:
+        import langchain_nvidia_ai_endpoints
+
+        return True
+    except ImportError:
+        return False
+
+
+class TestSpecialCaseHandlers:
+    """Tests for the special case handlers."""
+
+    def test_handle_model_special_cases_no_match(self):
+        """Test that _handle_model_special_cases returns None when no special case matche."""
+
+        result = _handle_model_special_cases("unknown-model", "unknown-provider", {})
+        assert result is None
+
+    @pytest.mark.skipif(
+        not has_openai(), reason="langchain-openai package not installed"
+    )
+    def test_handle_model_special_cases_model_match(self):
+        """Test that model-specific initializers are called correctly."""
+
+        # skip if OpenAI API key is not set
+        if not os.environ.get("OPENAI_API_KEY"):
+            pytest.skip("OpenAI API key not set")
+        model_name = "gpt-3.5-turbo-instruct"
+        provider_name = "openai"
+        kwargs = {"temperature": 0.7}
+
+        result = _handle_model_special_cases(model_name, provider_name, kwargs)
+
+        # ensure the result is a text completion model
+        assert result is not None
+        assert hasattr(result, "invoke")
+        assert hasattr(result, "generate")
+        assert isinstance(result, BaseLLM)
+
+    @pytest.mark.skipif(
+        not has_nvidia_ai_endpoints(),
+        reason="nvidia-ai-endpoints package not installed",
+    )
+    def test_handle_model_special_cases_provider_match(self):
+        """Test that provider-specific initializers are called correctly."""
+
+        model_name = "meta/llama-3.3-70b-instruct"
+        provider_name = "nim"
+        kwargs = {"temperature": 0.7}
+
+        result = _handle_model_special_cases(model_name, provider_name, kwargs)
+
+        # enure the result is a chat model
+        assert result is not None
+        assert isinstance(result, BaseChatModel)
+        assert hasattr(result, "invoke")
+        assert hasattr(result, "generate")
+
+    def test_special_model_initializers_registry(self):
+        """Test that the _SPECIAL_MODEL_INITIALIZERS registry contains the expected entries."""
+
+        assert "gpt-3.5-turbo-instruct" in _SPECIAL_MODEL_INITIALIZERS
+        assert (
+            _SPECIAL_MODEL_INITIALIZERS["gpt-3.5-turbo-instruct"]
+            == _init_gpt35_turbo_instruct
+        )
+
+    def test_provider_initializers_registry(self):
+        """Test that the _PROVIDER_INITIALIZERS registry contains the expected entries."""
+        assert "nvidia_ai_endpoints" in _PROVIDER_INITIALIZERS
+        assert "nim" in _PROVIDER_INITIALIZERS
+        assert _PROVIDER_INITIALIZERS["nvidia_ai_endpoints"] == _init_nvidia_model
+        assert _PROVIDER_INITIALIZERS["nim"] == _init_nvidia_model
+
+
+class TestGPT35TurboInstructInitializer:
+    """Tests for the GPT-3.5 Turbo Instruct initializer."""
+
+    def test_init_gpt35_turbo_instruct(self):
+        """Test that _init_gpt35_turbo_instruct calls _init_text_completion_model."""
+
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._init_text_completion_model"
+        ) as mock_init:
+            mock_init.return_value = "text_model"
+            result = _init_gpt35_turbo_instruct("gpt-3.5-turbo-instruct", "openai", {})
+            assert result == "text_model"
+            mock_init.assert_called_once_with(
+                model_name="gpt-3.5-turbo-instruct", provider_name="openai", kwargs={}
+            )
+
+    def test_init_gpt35_turbo_instruct_error(self):
+        """Test that _init_gpt35_turbo_instruct raises ModelInitializationError on failure."""
+        with patch(
+            "nemoguardrails.llm.models.langchain_initializer._init_text_completion_model"
+        ) as mock_init:
+            mock_init.side_effect = ValueError("Text model failed")
+            with pytest.raises(
+                ModelInitializationError,
+                match="Failed to initialize text completion model gpt-3.5-turbo-instruct",
+            ):
+                _init_gpt35_turbo_instruct("gpt-3.5-turbo-instruct", "openai", {})
+
+
+class TestNVIDIAModelInitializer:
+    """Tests for the NVIDIA model initializer."""
+
+    @pytest.mark.skipif(
+        not has_nvidia_ai_endpoints(),
+        reason="Requires  NVIDIA AI Endpoints package",
+    )
+    def test_init_nvidia_model_success(self):
+        """Test that _init_nvidia_model initializes a ChatNVIDIA model."""
+        result = _init_nvidia_model(
+            "meta/llama-3.3-70b-instruct",
+            "nim",
+            {
+                "api_key": "asdf"
+            },  # Note in future version of nvaie this might raise an error
+        )
+        assert result is not None
+        assert hasattr(result, "invoke")
+        assert hasattr(result, "generate")
+        assert hasattr(result, "agenerate")
+        assert isinstance(result, BaseChatModel)
+
+    @pytest.mark.skipif(
+        not has_nvidia_ai_endpoints(), reason="Requires NVIDIA AI Endpoints package"
+    )
+    def test_init_nvidia_model_old_version(self):
+        """Test that _init_nvidia_model raises ValueError for old versions."""
+
+        from importlib.metadata import version
+
+        from packaging.version import parse
+
+        current_version = version("langchain_nvidia_ai_endpoints")
+        if parse(current_version) < parse("0.2.0"):
+            with pytest.raises(
+                ValueError,
+                match="langchain_nvidia_ai_endpoints version must be 0.2.0 or above",
+            ):
+                _init_nvidia_model("some-model", "nvidia_ai_endpoints", {})
+        else:
+            pytest.skip("NVIDIA AI Endpoints version is >= 0.2.0")
+
+    def test_init_nvidia_model_import_error(self):
+        """Test that _init_nvidia_model raises ImportError when langchain_nvidia_ai_endpoints is not installed."""
+
+        if has_nvidia_ai_endpoints():
+            pytest.skip("NVIDIA AI Endpoints package is installed")
+        with pytest.raises(ImportError):
+            _init_nvidia_model("nvidia-model", "nvidia_ai_endpoints", {})

--- a/tests/llm_providers/test_providers.py
+++ b/tests/llm_providers/test_providers.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import warnings
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.chat_models.base import BaseChatModel
+from langchain_core.language_models.llms import BaseLLM
+
+from nemoguardrails.llm.providers.providers import (
+    _acall,
+    _chat_providers,
+    _get_chat_completion_provider,
+    _get_text_completion_provider,
+    _llm_providers,
+    _parse_version,
+    _patch_acall_method_to,
+    get_chat_provider_names,
+    get_llm_provider_names,
+    register_chat_provider,
+    register_llm_provider,
+)
+
+
+class MockLLM(BaseLLM):
+    def _call(self, *args, **kwargs):
+        return "Mock response"
+
+    def _generate(self, *args, **kwargs):
+        return "Mock generation"
+
+    def _llm_type(self):
+        return "mock_llm_type"
+
+
+class MockChatModel(BaseChatModel):
+    def _call(self, *args, **kwargs):
+        return "Mock chat response"
+
+
+@pytest.fixture
+def mock_langchain_llms():
+    with patch("nemoguardrails.llm.providers.providers.llms") as mock_llms:
+        mock_dict = {"mock_provider": MockLLM}
+        mock_llms.get_type_to_cls_dict.return_value = mock_dict
+        mock_llms.type_to_cls_dict = mock_dict
+        yield mock_llms
+
+
+@pytest.fixture
+def mock_langchain_chat_models():
+    with patch("nemoguardrails.llm.providers.providers._module_lookup") as mock_lookup:
+        mock_lookup.items.return_value = [
+            ("mock_provider", "langchain_community.chat_models.mock_provider")
+        ]
+        with patch(
+            "nemoguardrails.llm.providers.providers.importlib.import_module"
+        ) as mock_import:
+            mock_module = MagicMock()
+            mock_module.mock_provider = MockChatModel
+            mock_import.return_value = mock_module
+            yield mock_lookup
+
+
+def test_patch_acall_method_to():
+    # create a new class for testing to avoid affecting other tests
+    class TestLLM(MockLLM):
+        pass
+
+    providers = {"mock_provider": TestLLM}
+
+    # Mock asyncio.to_thread to return a future with the result
+    with patch("asyncio.to_thread") as mock_to_thread:
+        mock_to_thread.return_value = "Mock response"
+
+        # Patch the _acall method
+        _patch_acall_method_to(providers)
+
+        assert hasattr(TestLLM, "_acall")
+        assert callable(getattr(TestLLM, "_acall"))
+
+        # test that the patched _acall method works correctly
+        mock_llm = TestLLM()
+
+        # create an event loop to run the async function
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        try:
+            result = loop.run_until_complete(mock_llm._acall("test prompt"))
+            assert result == "Mock response"
+            mock_to_thread.assert_called_once()
+        finally:
+            loop.close()
+
+
+@pytest.mark.asyncio
+async def test_acall():
+    mock_llm = MockLLM()
+    result = await _acall(mock_llm, "test prompt")
+    assert result == "Mock response"
+
+
+@pytest.fixture
+def test_llm_provider_fixture():
+    _patch_acall_method_to({"test_llm_provider": MockLLM})
+    register_llm_provider("test_llm_provider", MockLLM)
+    yield
+
+    # unregister the provider after the test so that it doesn't affect other tests
+    _llm_providers.pop("test_llm_provider", None)
+
+
+def test_register_llm_provider(test_llm_provider_fixture):
+    assert "test_llm_provider" in _llm_providers
+    assert _llm_providers["test_llm_provider"] == MockLLM
+
+
+@pytest.fixture
+def test_chat_provider_fixture():
+    register_chat_provider("test_chat_provider", MockChatModel)
+    yield
+    # unregister the provider after the test so that it doesn't affect other tests
+    _chat_providers.pop("test_chat_provider", None)
+
+
+def test_register_chat_provider(test_chat_provider_fixture):
+    assert "test_chat_provider" in _chat_providers
+    assert _chat_providers["test_chat_provider"] == MockChatModel
+
+
+def test_get_llm_provider_names():
+    provider_names = get_llm_provider_names()
+    assert isinstance(provider_names, list)
+
+    # the default providers
+    assert (
+        "trt_llm" in provider_names
+    ), "Default provider 'trt_llm' is not in the list of providers"
+
+    common_providers = ["openai", "anthropic", "huggingface"]
+    for provider in common_providers:
+        if provider in provider_names:
+            # provider is available, this is good
+            pass
+        else:
+            # provider is not available, but we don't fail the test
+            # instead, we issue a warning
+            warnings.warn(
+                f"Common LLM provider '{provider}' is not available. "
+                "This might be due to a version mismatch with LangChain."
+            )
+
+
+def test_get_chat_provider_names():
+    provider_names = get_chat_provider_names()
+    assert isinstance(provider_names, list)
+
+    # check for common providers that should be available
+    common_providers = ["openai", "anthropic", "huggingface"]
+    for provider in common_providers:
+        if provider in provider_names:
+            pass
+        else:
+            warnings.warn(
+                f"Common chat provider '{provider}' is not available. "
+                "This might be due to a version mismatch with LangChain."
+            )
+
+
+def test_get_text_completion_provider():
+    # test with a registered provider
+    with patch(
+        "nemoguardrails.llm.providers.providers._llm_providers",
+        {"test_provider": MockLLM},
+    ):
+        provider = _get_text_completion_provider("test_provider")
+        assert provider == MockLLM
+
+    # test with a non-existent provider
+    with pytest.raises(RuntimeError):
+        _get_text_completion_provider("non_existent_provider")
+
+
+def test_get_chat_completion_provider():
+    # test with a registered provider
+    with patch(
+        "nemoguardrails.llm.providers.providers._chat_providers",
+        {"test_provider": MockChatModel},
+    ):
+        provider = _get_chat_completion_provider("test_provider")
+        assert provider == MockChatModel
+
+    # test with a non-existent provider
+    with pytest.raises(RuntimeError):
+        _get_chat_completion_provider("non_existent_provider")
+
+
+def test_parse_version():
+    assert _parse_version("1.2.3") == (1, 2, 3)
+    assert _parse_version("0.1.0") == (0, 1, 0)
+    assert _parse_version("10.20.30") == (10, 20, 30)

--- a/tests/llm_providers/test_providers.py
+++ b/tests/llm_providers/test_providers.py
@@ -29,7 +29,7 @@ from nemoguardrails.llm.providers.providers import (
     _llm_providers,
     _parse_version,
     _patch_acall_method_to,
-    get_chat_provider_names,
+    get_community_chat_provider_names,
     get_llm_provider_names,
     register_chat_provider,
     register_llm_provider,
@@ -167,7 +167,7 @@ def test_get_llm_provider_names():
 
 
 def test_get_chat_provider_names():
-    provider_names = get_chat_provider_names()
+    provider_names = get_community_chat_provider_names()
     assert isinstance(provider_names, list)
 
     # check for common providers that should be available

--- a/tests/llm_providers/test_trtllm_provider.py
+++ b/tests/llm_providers/test_trtllm_provider.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemoguardrails.llm.providers.providers import _llm_providers
+from nemoguardrails.llm.providers.trtllm.llm import TRTLLM
+
+
+def test_trtllm_provider_registered():
+    """Test that the TRTLLM provider is registered in the _llm_providers dictionary."""
+    assert "trt_llm" in _llm_providers
+    assert _llm_providers["trt_llm"] == TRTLLM
+
+
+@pytest.mark.asyncio
+async def test_trtllm_provider_has_acall():
+    """Test that the TRTLLM provider has the _acall method."""
+    assert hasattr(TRTLLM, "_acall")
+    assert callable(getattr(TRTLLM, "_acall"))
+
+
+@pytest.mark.asyncio
+async def test_trtllm_provider_acall_implementation():
+    """Test the implementation of the _acall method in the TRTLLM provider."""
+    # Create a mock instance of TRTLLM
+    with patch("nemoguardrails.llm.providers.trtllm.llm.TRTLLM") as mock_trtllm:
+        # Configure the mock to return a specific value from _call
+        mock_instance = MagicMock()
+        mock_instance._call.return_value = "Mock TRTLLM response"
+
+        # Add the _acall method to the mock instance
+        async def mock_acall(*args, **kwargs):
+            return await asyncio.to_thread(mock_instance._call, *args, **kwargs)
+
+        mock_instance._acall = mock_acall
+        mock_trtllm.return_value = mock_instance
+
+        # Create an instance and call _acall
+        trtllm_instance = mock_trtllm()
+        result = await trtllm_instance._acall("test prompt")
+
+        # Verify the result
+        assert result == "Mock TRTLLM response"
+        mock_instance._call.assert_called_once_with("test prompt")

--- a/tests/llm_providers/test_version_compatibility.py
+++ b/tests/llm_providers/test_version_compatibility.py
@@ -24,8 +24,9 @@ from nemoguardrails.llm.providers.providers import (
     _chat_providers,
     _discover_langchain_community_chat_providers,
     _discover_langchain_community_llm_providers,
+    _discover_langchain_partner_chat_providers,
     _llm_providers,
-    _parse_version,
+    get_chat_provider_names,
     get_community_chat_provider_names,
     get_llm_provider_names,
 )
@@ -133,7 +134,7 @@ _LLM_PROVIDERS_NAMES = [
     "yi",
     "you",
 ]
-_CHAT_PROVIDERS_NAMES = [
+_COMMUNITY_CHAT_PROVIDERS_NAMES = [
     "azure_openai",
     "bedrock",
     "anthropic",
@@ -195,6 +196,26 @@ _CHAT_PROVIDERS_NAMES = [
     "llamacpp",
     "yi",
 ]
+
+_PARTNER_CHAT_PROVIDERS_NAMES = {
+    "anthropic",
+    "azure_openai",
+    "bedrock",
+    "bedrock_converse",
+    "cohere",
+    "deepseek",
+    "fireworks",
+    "google_anthropic_vertex",
+    "google_genai",
+    "google_vertexai",
+    "groq",
+    "huggingface",
+    "mistralai",
+    "nim",
+    "ollama",
+    "openai",
+    "together",
+}
 # at some point we might care about certain providers
 CRITICAL_LLM_PROVIDERS = [
     "openai",
@@ -316,16 +337,38 @@ def test_provider_imports():
 
 
 def test_discover_langchain_community_chat_providers():
-    """Test that the function correctly discovers LangChain chat providers."""
+    """Test that the function correctly discovers LangChain community chat providers."""
+
     providers = _discover_langchain_community_chat_providers()
     chat_provider_names = get_community_chat_provider_names()
     assert set(chat_provider_names) == set(
         providers.keys()
     ), "it seems that we are registering a provider that is not in the LC community chat provider"
-    assert _CHAT_PROVIDERS_NAMES == list(providers.keys()), (
+    assert _COMMUNITY_CHAT_PROVIDERS_NAMES == list(providers.keys()), (
         "LangChain chat community providers may have changed. "
         "please investigate and update the test if necessary."
     )
+
+
+def test_dicsover_partner_chat_providers():
+    """Test that the function correctly discovers LangChain partner chat providers."""
+
+    partner_chat_providers = _discover_langchain_partner_chat_providers()
+    assert _PARTNER_CHAT_PROVIDERS_NAMES.issubset(partner_chat_providers), (
+        "LangChain partner chat providers may have changed. Update "
+        "_PARTNER_CHAT_PROVIDERS_NAMES to include all expected providers."
+    )
+    chat_providers = get_chat_provider_names()
+
+    assert partner_chat_providers.issubset(
+        chat_providers
+    ), "partner chat providers are not a subset of the list of chat providers"
+
+    if not partner_chat_providers == _PARTNER_CHAT_PROVIDERS_NAMES:
+        warnings.warn(
+            "LangChain partner chat providers may have changed. Update "
+            "_PARTNER_CHAT_PROVIDERS_NAMES to include all expected providers."
+        )
 
 
 def test_discover_langchain_community_llm_providers():

--- a/tests/llm_providers/test_version_compatibility.py
+++ b/tests/llm_providers/test_version_compatibility.py
@@ -1,0 +1,387 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import warnings
+from importlib.metadata import PackageNotFoundError, version
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemoguardrails.llm.providers.providers import (
+    _chat_providers,
+    _discover_langchain_community_chat_providers,
+    _discover_langchain_community_llm_providers,
+    _llm_providers,
+    _parse_version,
+    get_chat_provider_names,
+    get_llm_provider_names,
+)
+
+# valid for 0.3.13 till 0.3.21
+# previous 0.3 versions miss   -     'openllm_client',
+# 0.2 versions have more and less
+# name         : langchain-community
+# version      : 0.3.16
+# description  : Community contributed LangChain integrations.
+
+_LLM_PROVIDERS_NAMES = [
+    "ai21",
+    "aleph_alpha",
+    "amazon_api_gateway",
+    "amazon_bedrock",
+    "anthropic",
+    "anyscale",
+    "arcee",
+    "aviary",
+    "azure",
+    "azureml_endpoint",
+    "baichuan",
+    "bananadev",
+    "baseten",
+    "beam",
+    "cerebriumai",
+    "chat_glm",
+    "clarifai",
+    "cohere",
+    "ctransformers",
+    "ctranslate2",
+    "databricks",
+    "deepinfra",
+    "deepsparse",
+    "edenai",
+    "fake-list",
+    "forefrontai",
+    "friendli",
+    "giga-chat-model",
+    "google_palm",
+    "gooseai",
+    "gradient",
+    "gpt4all",
+    "huggingface_endpoint",
+    "huggingface_hub",
+    "huggingface_pipeline",
+    "huggingface_textgen_inference",
+    "human-input",
+    "koboldai",
+    "konko",
+    "llamacpp",
+    "llamafile",
+    "textgen",
+    "minimax",
+    "mlflow",
+    "mlflow-ai-gateway",
+    "mlx_pipeline",
+    "modal",
+    "mosaic",
+    "nebula",
+    "nibittensor",
+    "nlpcloud",
+    "oci_model_deployment_tgi_endpoint",
+    "oci_model_deployment_vllm_endpoint",
+    "oci_model_deployment_endpoint",
+    "oci_generative_ai",
+    "octoai_endpoint",
+    "ollama",
+    "openai",
+    "openlm",
+    "pai_eas_endpoint",
+    "petals",
+    "pipelineai",
+    "predibase",
+    "opaqueprompts",
+    "replicate",
+    "rwkv",
+    "sagemaker_endpoint",
+    "sambanovacloud",
+    "sambastudio",
+    "self_hosted",
+    "self_hosted_hugging_face",
+    "stochasticai",
+    "together",
+    "tongyi",
+    "titan_takeoff",
+    "titan_takeoff_pro",
+    "vertexai",
+    "vertexai_model_garden",
+    "openllm",
+    "outlines",
+    "vllm",
+    "vllm_openai",
+    "watsonxllm",
+    "weight_only_quantization",
+    "writer",
+    "xinference",
+    "javelin-ai-gateway",
+    "qianfan_endpoint",
+    "yandex_gpt",
+    "yuan2",
+    "VolcEngineMaasLLM",
+    "SparkLLM",
+    "yi",
+    "you",
+]
+_CHAT_PROVIDERS_NAMES = [
+    "azure_openai",
+    "bedrock",
+    "anthropic",
+    "anyscale",
+    "baichuan",
+    "naver",
+    "cohere",
+    "coze",
+    "databricks",
+    "deepinfra",
+    "everlyai",
+    "edenai",
+    "fireworks",
+    "friendli",
+    "google_palm",
+    "huggingface",
+    "hunyuan",
+    "javelin_ai_gateway",
+    "kinetica",
+    "konko",
+    "litellm",
+    "litellm_router",
+    "mlflow_ai_gateway",
+    "mlx",
+    "maritalk",
+    "mlflow",
+    "symblai_nebula",
+    "octoai",
+    "oci_generative_ai",
+    "oci_data_science",
+    "ollama",
+    "openai",
+    "outlines",
+    "reka",
+    "perplexity",
+    "sambanova",
+    "snowflake",
+    "sparkllm",
+    "tongyi",
+    "vertexai",
+    "yandex",
+    "yuan2",
+    "zhipuai",
+    "ernie",
+    "fake",
+    "gpt_router",
+    "gigachat",
+    "human",
+    "jinachat",
+    "llama_edge",
+    "minimax",
+    "moonshot",
+    "pai_eas_endpoint",
+    "promptlayer_openai",
+    "solar",
+    "baidu_qianfan_endpoint",
+    "volcengine_maas",
+    "premai",
+    "llamacpp",
+    "yi",
+]
+# at some point we might care about certain providers
+CRITICAL_LLM_PROVIDERS = [
+    "openai",
+    "anthropic",
+]
+
+# at some point we might care about certain providers
+CRITICAL_CHAT_PROVIDERS = [
+    "openai",
+    "anthropic",
+]
+
+# providers that have been renamed or moved in the past
+RENAMED_PROVIDERS = {
+    "mlflow-chat": "mlflow",
+    "databricks-chat": "databricks",
+}
+
+
+def get_langchain_version():
+    """Get the installed LangChain version."""
+    try:
+        return version("langchain")
+    except PackageNotFoundError:
+        try:
+            return version("langchain-community")
+        except PackageNotFoundError:
+            return "unknown"
+
+
+def test_critical_llm_providers_available():
+    """Test that critical LLM providers are available."""
+    provider_names = get_llm_provider_names()
+
+    # ensure we have critical providers
+    for provider in CRITICAL_LLM_PROVIDERS:
+        if provider not in provider_names:
+            warnings.warn(
+                f"Critical LLM provider '{provider}' is not available. "
+                f"This might cause compatibility issues with LangChain version {get_langchain_version()}."
+            )
+
+
+def test_critical_chat_providers_available():
+    """Test that critical chat providers are available."""
+    provider_names = get_chat_provider_names()
+
+    for provider in CRITICAL_CHAT_PROVIDERS:
+        if provider not in provider_names:
+            warnings.warn(
+                f"Critical chat provider '{provider}' is not available. "
+                f"This might cause compatibility issues with LangChain version {get_langchain_version()}."
+            )
+
+
+def test_renamed_providers():
+    """Test for providers that have been renamed or moved."""
+    llm_provider_names = get_llm_provider_names()
+    chat_provider_names = get_chat_provider_names()
+
+    for old_name, new_name in RENAMED_PROVIDERS.items():
+        if old_name in llm_provider_names or old_name in chat_provider_names:
+            warnings.warn(
+                f"Provider '{old_name}' has been renamed to '{new_name}' in newer versions of LangChain. "
+                f"Consider updating your code to use the new name."
+            )
+
+
+def test_provider_registry_stability():
+    """Test that the provider registry is stable and doesn't change unexpectedly."""
+    # Get the current providers
+    current_llm_providers = set(get_llm_provider_names())
+    current_chat_providers = set(get_chat_provider_names())
+
+    # This test will fail if the registry changes unexpectedly
+    # You can update this test when you intentionally change the registry
+    expected_llm_providers = set(_llm_providers.keys())
+    expected_chat_providers = set(_chat_providers.keys())
+
+    assert current_llm_providers == expected_llm_providers, (
+        f"LLM provider registry has changed unexpectedly. "
+        f"Expected: {expected_llm_providers}, Got: {current_llm_providers}"
+    )
+
+    assert current_chat_providers == expected_chat_providers, (
+        f"Chat provider registry has changed unexpectedly. "
+        f"Expected: {expected_chat_providers}, Got: {current_chat_providers}"
+    )
+
+
+def test_provider_imports():
+    """Test that all providers can be imported without errors."""
+    # This test ensures that all providers can be imported without errors
+    # It's useful for catching import errors early
+
+    # get all provider names
+    llm_provider_names = get_llm_provider_names()
+    chat_provider_names = get_chat_provider_names()
+
+    # try to import each provider
+    for provider_name in llm_provider_names:
+        try:
+            provider_cls = _llm_providers[provider_name]
+            assert (
+                provider_cls is not None
+            ), f"Provider class for '{provider_name}' is None"
+        except Exception as e:
+            pytest.fail(f"Failed to import LLM provider '{provider_name}': {str(e)}")
+
+    for provider_name in chat_provider_names:
+        try:
+            # This is a simplified example - you might need to adjust this
+            # based on how your providers are actually imported
+            provider_cls = _chat_providers[provider_name]
+            assert (
+                provider_cls is not None
+            ), f"Provider class for '{provider_name}' is None"
+        except Exception as e:
+            pytest.fail(f"Failed to import chat provider '{provider_name}': {str(e)}")
+
+
+def test_discover_langchain_community_chat_providers():
+    """Test that the function correctly discovers LangChain chat providers."""
+    providers = _discover_langchain_community_chat_providers()
+    chat_provider_names = get_chat_provider_names()
+    assert set(chat_provider_names) == set(
+        providers.keys()
+    ), "it seems that we are registering a provider that is not in the LC community chat provider"
+    assert _CHAT_PROVIDERS_NAMES == list(providers.keys()), (
+        "LangChain chat community providers may have changed. "
+        "please investigate and update the test if necessary."
+    )
+
+
+def test_discover_langchain_community_llm_providers():
+    providers = _discover_langchain_community_llm_providers()
+    llm_provider_names = get_llm_provider_names()
+
+    custom_registered_providers = {"trt_llm"}
+    assert set(llm_provider_names) - custom_registered_providers == set(
+        providers.keys()
+    ), "it seems that we are registering a provider that is not in the LC community llm provider"
+    assert _LLM_PROVIDERS_NAMES == list(providers.keys()), (
+        "LangChain LLM community providers may have changed. "
+        "Please investigate and update the test if necessary."
+    )
+
+
+def test_langchain_provider_compatibility():
+    """Test compatibility with different LangChain versions."""
+    # This test checks for compatibility with different LangChain versions
+    # It's useful for catching compatibility issues early
+
+    # check for common providers that should be available
+    common_llm_providers = ["openai", "anthropic"]
+    common_chat_providers = ["openai", "anthropic", "huggingface"]
+
+    # check for LLM providers
+    for provider in common_llm_providers:
+        if provider not in _llm_providers:
+            raise RuntimeError(
+                f"Common LLM provider '{provider}' is not available. "
+                "This might be due to a version mismatch with LangChain."
+            )
+
+    # check for chat providers
+    for provider in common_chat_providers:
+        if provider not in _chat_providers:
+            raise RuntimeError(
+                f"Common chat provider '{provider}' is not available. "
+                "This might be due to a version mismatch with LangChain."
+            )
+
+
+# TODO: we might need this
+# def test_provider_version_compatibility():
+#     """Test compatibility with different LangChain versions."""
+#     langchain_version = get_langchain_version()
+#
+#     if langchain_version != "unknown":
+#         version_tuple = _parse_version(langchain_version)
+#
+#         # we can check for version-specific compatibility issues
+#         if version_tuple >= (0, 1, 0):
+#             #  we can check for changes introduced in version 0.1.0 for example
+#             pass
+#
+#         if version_tuple >= (0, 2, 0):
+#             #  we can check for changes introduced in version 0.2.0 for example
+#             pass

--- a/tests/llm_providers/test_version_compatibility.py
+++ b/tests/llm_providers/test_version_compatibility.py
@@ -26,7 +26,7 @@ from nemoguardrails.llm.providers.providers import (
     _discover_langchain_community_llm_providers,
     _llm_providers,
     _parse_version,
-    get_chat_provider_names,
+    get_community_chat_provider_names,
     get_llm_provider_names,
 )
 
@@ -240,7 +240,7 @@ def test_critical_llm_providers_available():
 
 def test_critical_chat_providers_available():
     """Test that critical chat providers are available."""
-    provider_names = get_chat_provider_names()
+    provider_names = get_community_chat_provider_names()
 
     for provider in CRITICAL_CHAT_PROVIDERS:
         if provider not in provider_names:
@@ -253,7 +253,7 @@ def test_critical_chat_providers_available():
 def test_renamed_providers():
     """Test for providers that have been renamed or moved."""
     llm_provider_names = get_llm_provider_names()
-    chat_provider_names = get_chat_provider_names()
+    chat_provider_names = get_community_chat_provider_names()
 
     for old_name, new_name in RENAMED_PROVIDERS.items():
         if old_name in llm_provider_names or old_name in chat_provider_names:
@@ -267,10 +267,9 @@ def test_provider_registry_stability():
     """Test that the provider registry is stable and doesn't change unexpectedly."""
     # Get the current providers
     current_llm_providers = set(get_llm_provider_names())
-    current_chat_providers = set(get_chat_provider_names())
+    current_chat_providers = set(get_community_chat_provider_names())
 
     # This test will fail if the registry changes unexpectedly
-    # You can update this test when you intentionally change the registry
     expected_llm_providers = set(_llm_providers.keys())
     expected_chat_providers = set(_chat_providers.keys())
 
@@ -292,7 +291,7 @@ def test_provider_imports():
 
     # get all provider names
     llm_provider_names = get_llm_provider_names()
-    chat_provider_names = get_chat_provider_names()
+    chat_provider_names = get_community_chat_provider_names()
 
     # try to import each provider
     for provider_name in llm_provider_names:
@@ -319,7 +318,7 @@ def test_provider_imports():
 def test_discover_langchain_community_chat_providers():
     """Test that the function correctly discovers LangChain chat providers."""
     providers = _discover_langchain_community_chat_providers()
-    chat_provider_names = get_chat_provider_names()
+    chat_provider_names = get_community_chat_provider_names()
     assert set(chat_provider_names) == set(
         providers.keys()
     ), "it seems that we are registering a provider that is not in the LC community chat provider"

--- a/tests/test_configs/with_custom_chat_model/config.co
+++ b/tests/test_configs/with_custom_chat_model/config.co
@@ -1,0 +1,7 @@
+define user express greeting
+  "hi"
+  "hello"
+
+define flow
+  user express greeting
+  bot express greeting

--- a/tests/test_configs/with_custom_chat_model/config.py
+++ b/tests/test_configs/with_custom_chat_model/config.py
@@ -13,29 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
+from nemoguardrails.llm.providers import register_chat_provider
+from tests.test_configs.with_custom_chat_model.custom_chat_model import CustomChatModel
 
-from nemoguardrails.llm.models.initializer import init_llm_model
-from nemoguardrails.rails.llm.config import Model
-
-
-def initialize_llm(model_config: Model):
-    """Initializes the model from LLM provider."""
-
-    return init_llm_model(
-        model_name=model_config.model,
-        provider_name=model_config.engine,
-        kwargs=model_config.parameters,
-    )
-
-
-def load_dataset(dataset_path: str):
-    """Loads a dataset from a file."""
-
-    with open(dataset_path, "r") as f:
-        if dataset_path.endswith(".json"):
-            dataset = json.load(f)
-        else:
-            dataset = f.readlines()
-
-    return dataset
+register_chat_provider("custom_chat_model", CustomChatModel)

--- a/tests/test_configs/with_custom_chat_model/config.yml
+++ b/tests/test_configs/with_custom_chat_model/config.yml
@@ -1,0 +1,5 @@
+models:
+  - type: main
+    engine: custom_llm
+    parameters:
+      model: custom_model

--- a/tests/test_configs/with_custom_chat_model/custom_chat_model.py
+++ b/tests/test_configs/with_custom_chat_model/custom_chat_model.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+from langchain.callbacks.manager import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain.chat_models.base import BaseChatModel
+
+
+class CustomChatModel(BaseChatModel):
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+    ) -> str:
+        pass
+
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+    ) -> str:
+        pass
+
+    @property
+    def _llm_type(self) -> str:
+        return "custom_llm"

--- a/tests/test_custom_llm.py
+++ b/tests/test_custom_llm.py
@@ -17,7 +17,7 @@ import os
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.llm.providers import get_llm_provider_names
-from tests.utils import TestChat
+from nemoguardrails.llm.providers.providers import get_chat_provider_names
 
 CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
 
@@ -25,7 +25,16 @@ CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
 def test_custom_llm_registration():
     config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "with_custom_llm"))
 
-    app = LLMRails(config)
+    _ = LLMRails(config)
     supported_llms = get_llm_provider_names()
 
     assert "custom_llm" in supported_llms
+
+
+def test_custom_chat_model_registration():
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "with_custom_chat_model")
+    )
+    _ = LLMRails(config)
+
+    assert "custom_chat_model" in get_chat_provider_names()

--- a/tests/test_custom_llm.py
+++ b/tests/test_custom_llm.py
@@ -17,7 +17,7 @@ import os
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.llm.providers import get_llm_provider_names
-from nemoguardrails.llm.providers.providers import get_chat_provider_names
+from nemoguardrails.llm.providers.providers import get_community_chat_provider_names
 
 CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
 
@@ -37,4 +37,4 @@ def test_custom_chat_model_registration():
     )
     _ = LLMRails(config)
 
-    assert "custom_chat_model" in get_chat_provider_names()
+    assert "custom_chat_model" in get_community_chat_provider_names()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,29 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
+import pytest
 
-from nemoguardrails.llm.models.initializer import init_llm_model
-from nemoguardrails.rails.llm.config import Model
-
-
-def initialize_llm(model_config: Model):
-    """Initializes the model from LLM provider."""
-
-    return init_llm_model(
-        model_name=model_config.model,
-        provider_name=model_config.engine,
-        kwargs=model_config.parameters,
-    )
+from nemoguardrails.llm.providers.providers import _llm_providers
 
 
-def load_dataset(dataset_path: str):
-    """Loads a dataset from a file."""
-
-    with open(dataset_path, "r") as f:
-        if dataset_path.endswith(".json"):
-            dataset = json.load(f)
-        else:
-            dataset = f.readlines()
-
-    return dataset
+def test_acall_method_added():
+    for provider_name, provider_cls in _llm_providers.items():
+        assert hasattr(provider_cls, "_acall"), f"_acall not added to {provider_name}"
+        assert callable(
+            getattr(provider_cls, "_acall")
+        ), f"_acall is not callable in {provider_name}"


### PR DESCRIPTION
## Description

Introduces a new abstraction layer for initializing LLM models with:
- refactor providers module
- implement model initialization logic
- clear separation between text completion and chat models
- proper error handling with dedicated ModelInitializationError
- consistent provider name handling and discovery
- type safety improvements for LangChain models

Added tests, increase number of `providers` related tests from 2 to 69.


## Requires:
Following PRs must get merged first (those are cherry-picked to this PR)
#1084 
#1083

# Resolves
 #1055 
 #1044
 #1070
 #124
 #902
 #753 
 #520
 #865 
 might resolve #933 
 need to check #992
- [ ] which discussions?
- [ ] which issues? 

## TODO:

- [x] Add more tests (pending test restructuring PR)
- [x] Add `chat` and `completion` mode to `Model` class -> allows user to avoid our selection order
- [x] Figure out what to do with provider name inconsistencies -> mention in the docs in case of conflict we prefer `chat completions` over text and if the user wants to use the text completion `mode ' must be set to `text`
- [x] Add a fzf search to allow the user find the provider name (engine) easily #1088 
- [x] Add fzf search to CLI  #1088 