### PR TITLE
chore: Add link to topic control config and prompts

### DIFF
--- a/docs/user-guides/advanced/nemoguard-topiccontrol-deployment.md
+++ b/docs/user-guides/advanced/nemoguard-topiccontrol-deployment.md
@@ -99,5 +99,5 @@ docker run -it --name=$MODEL_NAME \
 For more details on the TopicControl model, check out the other resources:
 
 - NeMo Guardrails library for [NVIDIA NemoGuard models](../guardrails-library.md#nvidia-models)
-- [TopicControl topic safety example config](../../../examples/configs/topic_safety/README.md)
+- TopicControl topic safety example [configuration and prompts](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/examples/configs/topic_safety)
 - [Paper at EMNLP 2024](https://arxiv.org/abs/2404.03820)


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/NeMo-Guardrails/issues/1096

## Description

Fix GH-only link to a works-everwhere HTTPS link to the sample config and prompt for topic control.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
