### PR TITLE
feat: add support for system messages to RunnableRails

### DIFF
--- a/nemoguardrails/integrations/langchain/runnable_rails.py
+++ b/nemoguardrails/integrations/langchain/runnable_rails.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import Any, List, Optional
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.prompt_values import ChatPromptValue, StringPromptValue
 from langchain_core.runnables import Runnable
 from langchain_core.runnables.config import RunnableConfig
@@ -139,6 +139,8 @@ class RunnableRails(Runnable[Input, Output]):
                         messages.append({"role": "assistant", "content": msg.content})
                     elif isinstance(msg, HumanMessage):
                         messages.append({"role": "user", "content": msg.content})
+                    elif isinstance(msg, SystemMessage):
+                        messages.append({"role": "system", "content": msg.content})
             elif isinstance(_input, StringPromptValue):
                 messages.append({"role": "user", "content": _input.text})
             elif isinstance(_input, dict):


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

The current implementation does not support messages that have a System Message 

```python
guardrails_config = RailsConfig.from_path(<Path>)
guardrails = RunnableRails(guardrails_config)
client = ChatOpenAI(
                base_url=GEN_AI_ENDPOINT,
                api_key=GEN_AI_ENDPOINT_AUTHORIZATION,
                model= MODEL_NAME,
                temperature=0                
            )
messages = [
                (
                    "system", system
                )
                ,(
                    "human", prompt
                )
            ]
prompt = ChatPromptTemplate.from_messages(messages)

chain_with_guardrails =  prompt | (guardrails | client)
```

In this setup, `RunnableRails` does not handle messages containing system roles. Attempting to pass such a structure as a dictionary causes conflicts with the format expected by the `Runnable` interface from LangChain, which assumes a flat input structure and does not support multiple message types out of the box. This change addresses that limitation.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
