### PR TITLE
fix: self check output colang 1 flow

### DIFF
--- a/nemoguardrails/library/self_check/output_check/flows.v1.co
+++ b/nemoguardrails/library/self_check/output_check/flows.v1.co
@@ -9,4 +9,4 @@ define flow self check output
       create event OutputRailException(message="Output not allowed. The output was blocked by the 'self check output' flow.")
     else
       bot refuse to respond
-      stop
+    stop


### PR DESCRIPTION
## Description

stop needs dedent. Similar to all the other flows in guardrails library, for example see:
https://github.com/NVIDIA/NeMo-Guardrails/blob/f595d9118700afc1bd86ede77a2a24cf9a1f5208/nemoguardrails/library/self_check/input_check/flows.v1.co#L12


