### PR TITLE
feat: implement validation to forbid dialog rails with reasoning traces

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1133,6 +1133,47 @@ class RailsConfig(BaseModel):
     )
 
     @root_validator(pre=True, allow_reuse=True)
+    def check_reasoning_traces_with_dialog_rails(cls, values):
+        """Check that reasoning traces are not enabled when dialog rails are present."""
+
+        models = values.get("models", [])
+        rails = values.get("rails", {})
+        dialog_rails = rails.get("dialog", {})
+
+        # check if any model has reasoning traces enabled
+        # TODO: we must check for models that are used in a specific dialog task
+        has_reasoning_traces = False
+        for model in models:
+            if isinstance(model, dict):
+                reasoning_config = model.get("reasoning_config", {})
+                if not reasoning_config.get("remove_thinking_traces", True):
+                    has_reasoning_traces = True
+                    break
+            elif hasattr(model, "reasoning_config"):
+                if not model.reasoning_config.remove_thinking_traces:
+                    has_reasoning_traces = True
+                    break
+
+        # check if dialog rails are present (explicitly or implicitly)
+        has_dialog_rails = bool(dialog_rails)
+
+        # check implicit dialog rails through user messages, bot messages, or flows
+        if not has_dialog_rails:
+            has_dialog_rails = (
+                bool(values.get("user_messages"))
+                or bool(values.get("bot_messages"))
+                or bool(values.get("flows"))
+            )
+
+        if has_reasoning_traces and has_dialog_rails:
+            raise ValueError(
+                "Reasoning traces cannot be enabled when dialog rails are present. "
+                "Please either disable reasoning traces or remove dialog rails."
+            )
+
+        return values
+
+    @root_validator(pre=True, allow_reuse=True)
     def check_prompt_exist_for_self_check_rails(cls, values):
         rails = values.get("rails", {})
 

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -36,6 +36,7 @@ from nemoguardrails import utils
 from nemoguardrails.colang import parse_colang_file, parse_flow_elements
 from nemoguardrails.colang.v2_x.lang.utils import format_colang_parsing_error_message
 from nemoguardrails.colang.v2_x.runtime.errors import ColangParsingError
+from nemoguardrails.llm.types import Task
 
 log = logging.getLogger(__name__)
 
@@ -1140,36 +1141,65 @@ class RailsConfig(BaseModel):
         rails = values.get("rails", {})
         dialog_rails = rails.get("dialog", {})
 
-        # check if any model has reasoning traces enabled
-        # TODO: we must check for models that are used in a specific dialog task
-        has_reasoning_traces = False
-        for model in models:
-            if isinstance(model, dict):
-                reasoning_config = model.get("reasoning_config", {})
-                if not reasoning_config.get("remove_thinking_traces", True):
-                    has_reasoning_traces = True
-                    break
-            elif hasattr(model, "reasoning_config"):
-                if not model.reasoning_config.remove_thinking_traces:
-                    has_reasoning_traces = True
-                    break
+        # dialog rail tasks that should not have reasoning traces
+        dialog_rail_tasks = [
+            Task.GENERATE_BOT_MESSAGE,
+            Task.GENERATE_USER_INTENT,
+            Task.GENERATE_NEXT_STEPS,
+            Task.GENERATE_INTENT_STEPS_MESSAGE,
+        ]
 
-        # check if dialog rails are present (explicitly or implicitly)
-        has_dialog_rails = bool(dialog_rails)
+        # dialog rails are activated (explicitly or implicitly)
+        has_dialog_rails = (
+            bool(dialog_rails)
+            or bool(values.get("user_messages"))
+            or bool(values.get("bot_messages"))
+            or bool(values.get("flows"))
+        )
 
-        # check implicit dialog rails through user messages, bot messages, or flows
-        if not has_dialog_rails:
-            has_dialog_rails = (
-                bool(values.get("user_messages"))
-                or bool(values.get("bot_messages"))
-                or bool(values.get("flows"))
+        if has_dialog_rails:
+            # Get the main model if it exists
+            main_model = next(
+                (model for model in models if model.get("type") == "main"), None
             )
 
-        if has_reasoning_traces and has_dialog_rails:
-            raise ValueError(
-                "Reasoning traces cannot be enabled when dialog rails are present. "
-                "Please either disable reasoning traces or remove dialog rails."
-            )
+            violations = []
+
+            for task in dialog_rail_tasks:
+                # Check if there's a dedicated model for this task
+                task_model = next(
+                    (model for model in models if model.get("type") == task.value), None
+                )
+
+                if task_model:
+                    # Handle both dictionary and Model object cases
+                    reasoning_config = (
+                        task_model.reasoning_config
+                        if hasattr(task_model, "reasoning_config")
+                        else task_model.get("reasoning_config", {})
+                    )
+                    if not reasoning_config.get("remove_thinking_traces", True):
+                        violations.append(
+                            f"Model '{task_model.get('type')}' has reasoning traces enabled in config.yml. "
+                            f"Reasoning traces must be disabled for dialog rail tasks. "
+                            f"Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config for this model."
+                        )
+                elif main_model:
+                    # Handle both dictionary and Model object cases
+                    reasoning_config = (
+                        main_model.reasoning_config
+                        if hasattr(main_model, "reasoning_config")
+                        else main_model.get("reasoning_config", {})
+                    )
+                    if not reasoning_config.get("remove_thinking_traces", True):
+                        violations.append(
+                            f"Main model has reasoning traces enabled in config.yml and is being used for dialog rail task '{task.value}'. "
+                            f"Reasoning traces must be disabled when dialog rails are present. "
+                            f"Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config for the main model."
+                        )
+
+            if violations:
+                raise ValueError("\n".join(violations))
 
         return values
 

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1143,7 +1143,7 @@ class RailsConfig(BaseModel):
 
         # dialog rail tasks that should not have reasoning traces
         dialog_rail_tasks = [
-            Task.GENERATE_BOT_MESSAGE,
+            # Task.GENERATE_BOT_MESSAGE,
             Task.GENERATE_USER_INTENT,
             Task.GENERATE_NEXT_STEPS,
             Task.GENERATE_INTENT_STEPS_MESSAGE,
@@ -1158,7 +1158,6 @@ class RailsConfig(BaseModel):
         )
 
         if has_dialog_rails:
-            # Get the main model if it exists
             main_model = next(
                 (model for model in models if model.get("type") == "main"), None
             )
@@ -1166,13 +1165,11 @@ class RailsConfig(BaseModel):
             violations = []
 
             for task in dialog_rail_tasks:
-                # Check if there's a dedicated model for this task
                 task_model = next(
                     (model for model in models if model.get("type") == task.value), None
                 )
 
                 if task_model:
-                    # Handle both dictionary and Model object cases
                     reasoning_config = (
                         task_model.reasoning_config
                         if hasattr(task_model, "reasoning_config")
@@ -1185,7 +1182,6 @@ class RailsConfig(BaseModel):
                             f"Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config for this model."
                         )
                 elif main_model:
-                    # Handle both dictionary and Model object cases
                     reasoning_config = (
                         main_model.reasoning_config
                         if hasattr(main_model, "reasoning_config")

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -72,7 +72,7 @@ class ReasoningModelConfig(BaseModel):
 
     remove_thinking_traces: Optional[bool] = Field(
         default=True,
-        description="For reasoning models (e.g. OpenAI o1, DeepSeek-r1), if the output parser should remove thinking traces.",
+        description="For reasoning models (e.g. DeepSeek-r1), if the output parser should remove thinking traces.",
     )
     start_token: Optional[str] = Field(
         default="<think>",

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -143,8 +143,15 @@ def test_reasoning_traces_with_explicit_dialog_rails():
             """,
         )
 
-    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+    assert "Main model has reasoning traces enabled in config.yml" in str(
         exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
     )
 
 
@@ -180,6 +187,58 @@ def test_dialog_rails_without_reasoning_traces():
     )
 
 
+def test_input_rails_only_no_dialog_rails():
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+            reasoning_config:
+                remove_thinking_traces: false
+        rails:
+          input:
+            flows:
+              - self check input
+        prompts:
+          - task: self_check_input
+            content: "Check if input is safe"
+        """,
+    )
+
+    assert not config.user_messages
+    assert not config.bot_messages
+    assert not config.flows
+    assert not config.rails.dialog.single_call.enabled
+
+
+def test_no_dialog_tasks_with_only_output_rails():
+    """Test that dialog tasks are not used when only output rails are present."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+            reasoning_config:
+                remove_thinking_traces: false
+        rails:
+          output:
+            flows:
+              - self check output
+        prompts:
+          - task: self_check_output
+            content: "Check if output is safe"
+        """,
+    )
+
+    assert not config.user_messages
+    assert not config.bot_messages
+    assert not config.flows
+    assert not config.rails.dialog.single_call.enabled
+
+
 def test_reasoning_traces_with_implicit_dialog_rails_user_bot_messages():
     """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru user/bot messages."""
 
@@ -207,8 +266,15 @@ def test_reasoning_traces_with_implicit_dialog_rails_user_bot_messages():
             """,
         )
 
-    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+    assert "Main model has reasoning traces enabled in config.yml" in str(
         exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
     )
 
 
@@ -232,8 +298,15 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
             """,
         )
 
-    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+    assert "Main model has reasoning traces enabled in config.yml" in str(
         exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
     )
 
 
@@ -257,8 +330,15 @@ def test_reasoning_traces_with_implicit_dialog_rails_user_messages_only():
             """,
         )
 
-    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+    assert "Main model has reasoning traces enabled in config.yml" in str(
         exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
     )
 
 
@@ -281,6 +361,242 @@ def test_reasoning_traces_with_implicit_dialog_rails_bot_messages_only():
             """,
         )
 
-    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+    assert "Main model has reasoning traces enabled in config.yml" in str(
         exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
+    )
+
+
+def test_reasoning_traces_with_dedicated_task_models():
+    """Test that reasoning traces cannot be enabled for dedicated task models when dialog rails are present."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+              - type: generate_bot_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+              - type: generate_user_intent
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            rails:
+              dialog:
+                single_call:
+                  enabled: true
+            """,
+        )
+
+    assert (
+        "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
+        in str(exc_info.value)
+    )
+    assert "Reasoning traces must be disabled for dialog rail tasks" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
+    )
+
+
+def test_reasoning_traces_with_mixed_task_models():
+    """Test that reasoning traces cannot be enabled for any task model when dialog rails are present."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+              - type: generate_bot_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+              - type: generate_user_intent
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            rails:
+              dialog:
+                single_call:
+                  enabled: true
+            """,
+        )
+
+    assert (
+        "Model 'generate_user_intent' has reasoning traces enabled in config.yml"
+        in str(exc_info.value)
+    )
+    assert "Reasoning traces must be disabled for dialog rail tasks" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
+    )
+
+
+def test_reasoning_traces_with_all_dialog_tasks():
+    """Test that reasoning traces cannot be enabled for any dialog rail task."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+              - type: generate_bot_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+              - type: generate_user_intent
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+              - type: generate_next_steps
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+              - type: generate_intent_steps_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+            rails:
+              dialog:
+                single_call:
+                  enabled: true
+            """,
+        )
+
+    error_message = str(exc_info.value)
+    assert (
+        "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
+        in error_message
+    )
+    assert (
+        "Model 'generate_next_steps' has reasoning traces enabled in config.yml"
+        in error_message
+    )
+    assert "Reasoning traces must be disabled for dialog rail tasks" in error_message
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in error_message
+    )
+
+
+def test_reasoning_traces_with_dedicated_models_no_dialog_rails():
+    """Test that reasoning traces can be enabled for dedicated models when no dialog rails are present."""
+
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+          - type: generate_bot_message
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+            reasoning_config:
+              remove_thinking_traces: false
+          - type: generate_user_intent
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+            reasoning_config:
+              remove_thinking_traces: false
+        """,
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_and_dedicated_models():
+    """Test that reasoning traces cannot be enabled for dedicated models when dialog rails are implicitly enabled."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+              - type: generate_bot_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
+            define user express greeting
+              "hello"
+              "hi"
+
+            define bot express greeting
+              "Hello there!"
+
+            define flow
+              user express greeting
+              bot express greeting
+            """,
+        )
+
+    assert (
+        "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
+        in str(exc_info.value)
+    )
+    assert "Reasoning traces must be disabled for dialog rail tasks" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
+    )
+
+
+def test_reasoning_traces_with_partial_dedicated_models():
+    """Test that reasoning traces cannot be enabled for any model when some tasks use dedicated models and others fall back to main."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+              - type: generate_bot_message
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+            rails:
+              dialog:
+                single_call:
+                  enabled: true
+            """,
+        )
+
+    assert "Main model has reasoning traces enabled in config.yml" in str(
+        exc_info.value
+    )
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
+    )
+    assert (
+        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        in str(exc_info.value)
     )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -122,3 +122,165 @@ def test_passthrough_and_single_call_incompatibility():
 #         LLMRails(config=config)
 #
 #     assert "You must provide a `self_check_facts` prompt" in str(exc_info.value)
+
+
+def test_reasoning_traces_with_explicit_dialog_rails():
+    """Test that reasoning traces cannot be enabled when dialog rails are explicitly configured."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            rails:
+              dialog:
+                single_call:
+                  enabled: true
+            """,
+        )
+
+    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+        exc_info.value
+    )
+
+
+def test_reasoning_traces_without_dialog_rails():
+    """Test that reasoning traces can be enabled when no dialog rails are present."""
+
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+            reasoning_config:
+              remove_thinking_traces: false
+        """,
+    )
+
+
+def test_dialog_rails_without_reasoning_traces():
+    """Test that dialog rails can be enabled when reasoning traces are not enabled."""
+
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        rails:
+          dialog:
+            single_call:
+              enabled: true
+        """,
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_user_bot_messages():
+    """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru user/bot messages."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
+            define user express greeting
+              "hello"
+              "hi"
+
+            define bot express greeting
+              "Hello there!"
+
+            define flow
+              user express greeting
+              bot express greeting
+            """,
+        )
+
+    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+        exc_info.value
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
+    """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru flows only."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
+            define flow
+              user express greeting
+              bot express greeting
+            """,
+        )
+
+    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+        exc_info.value
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_user_messages_only():
+    """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru user messages only."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
+            define user express greeting
+              "hello"
+              "hi"
+            """,
+        )
+
+    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+        exc_info.value
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_bot_messages_only():
+    """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru bot messages only."""
+
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
+            define bot express greeting
+              "Hello there!"
+            """,
+        )
+
+    assert "Reasoning traces cannot be enabled when dialog rails are present" in str(
+        exc_info.value
+    )

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -401,7 +401,7 @@ def test_reasoning_traces_with_dedicated_task_models():
         )
 
     assert (
-        "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
+        "Model 'generate_user_intent' has reasoning traces enabled in config.yml"
         in str(exc_info.value)
     )
     assert "Reasoning traces must be disabled for dialog rail tasks" in str(
@@ -489,7 +489,7 @@ def test_reasoning_traces_with_all_dialog_tasks():
     error_message = str(exc_info.value)
     assert (
         "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
-        in error_message
+        not in error_message
     )
     assert (
         "Model 'generate_next_steps' has reasoning traces enabled in config.yml"
@@ -535,7 +535,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_and_dedicated_models():
               - type: main
                 engine: openai
                 model: gpt-3.5-turbo-instruct
-              - type: generate_bot_message
+              - type: generate_user_intent
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
@@ -556,7 +556,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_and_dedicated_models():
         )
 
     assert (
-        "Model 'generate_bot_message' has reasoning traces enabled in config.yml"
+        "Model 'generate_user_intent' has reasoning traces enabled in config.yml"
         in str(exc_info.value)
     )
     assert "Reasoning traces must be disabled for dialog rail tasks" in str(

--- a/tests/test_dialog_tasks.py
+++ b/tests/test_dialog_tasks.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.llm.types import Task
+
+try:
+    import langchain_openai
+
+    has_langchain_openai = True
+except ImportError:
+    has_langchain_openai = False
+
+has_openai_key = bool(os.getenv("OPENAI_API_KEY"))
+
+skip_if_no_openai = pytest.mark.skipif(
+    not (has_langchain_openai and has_openai_key),
+    reason="Requires langchain_openai and OPENAI_API_KEY environment variable",
+)
+
+
+@skip_if_no_openai
+def test_dialog_tasks_with_only_input_rails():
+    """Test that dialog tasks are not used when only input rails are present."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        rails:
+          input:
+            flows:
+              - self check input
+        prompts:
+          - task: self_check_input
+            content: "Check if input is safe"
+        """,
+    )
+
+    assert not config.user_messages
+    assert not config.bot_messages
+    assert not config.flows
+    assert not config.rails.dialog.single_call.enabled
+
+    rails = LLMRails(config=config)
+
+    assert not rails.config.rails.dialog.single_call.enabled
+    # with just input rails, some basic flows and messages are created
+    # but they are not for actual dialog processing
+    assert rails.config.bot_messages
+    assert rails.config.flows
+    # even there should be no user messages defined
+    assert not rails.config.user_messages
+
+
+@skip_if_no_openai
+def test_dialog_tasks_with_only_output_rails():
+    """Test that dialog tasks are not used when only output rails are present."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        rails:
+          output:
+            flows:
+              - self check output
+        prompts:
+          - task: self_check_output
+            content: "Check if output is safe"
+        """,
+    )
+
+    assert not config.user_messages
+    assert not config.bot_messages
+    assert not config.flows
+    assert not config.rails.dialog.single_call.enabled
+
+    rails = LLMRails(config=config)
+
+    assert not rails.config.rails.dialog.single_call.enabled
+    assert rails.config.bot_messages
+    assert rails.config.flows
+    assert not rails.config.user_messages
+
+
+@skip_if_no_openai
+def test_dialog_tasks_with_dialog_rails():
+    """Test that dialog tasks are used when dialog rails are present."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        rails:
+          dialog:
+            single_call:
+              enabled: true
+        """,
+        colang_content="""
+        define user express greeting
+          "hello"
+          "hi"
+
+        define bot express greeting
+          "Hello there!"
+
+        define flow
+          user express greeting
+          bot express greeting
+        """,
+    )
+
+    assert config.user_messages
+    assert config.bot_messages
+    assert config.flows
+    assert config.rails.dialog.single_call.enabled
+
+    rails = LLMRails(config=config)
+
+    assert rails.config.rails.dialog.single_call.enabled
+    assert rails.config.user_messages
+    assert rails.config.bot_messages
+    assert rails.config.flows
+
+
+@skip_if_no_openai
+def test_dialog_tasks_with_implicit_dialog_rails():
+    """Test that dialog tasks are used when dialog rails are implicitly present through user/bot messages."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        """,
+        colang_content="""
+        define user express greeting
+          "hello"
+          "hi"
+
+        define bot express greeting
+          "Hello there!"
+
+        define flow
+          user express greeting
+          bot express greeting
+        """,
+    )
+
+    assert config.user_messages
+    assert config.bot_messages
+    assert config.flows
+
+    assert config.user_messages == {"express greeting": ["hello", "hi"]}
+    assert config.bot_messages == {"express greeting": ["Hello there!"]}
+    assert len(config.bot_messages) == 1
+    assert len(config.flows) == 1
+
+    assert not config.rails.dialog.single_call.enabled
+
+    rails = LLMRails(config=config)
+
+    assert rails.config.user_messages
+    assert len(rails.config.user_messages) == 1
+    assert rails.config.bot_messages
+    assert len(rails.config.bot_messages) > 1
+    assert rails.config.flows
+
+
+@skip_if_no_openai
+def test_dialog_tasks_with_mixed_rails():
+    """Test that dialog tasks are used when dialog rails are present along with other rails."""
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        models:
+          - type: main
+            engine: openai
+            model: gpt-3.5-turbo-instruct
+        rails:
+          input:
+            flows:
+              - self check input
+          output:
+            flows:
+              - self check output
+          dialog:
+            single_call:
+              enabled: true
+        prompts:
+          - task: self_check_input
+            content: "Check if input is safe"
+          - task: self_check_output
+            content: "Check if output is safe"
+        """,
+        colang_content="""
+        define user express greeting
+          "hello"
+          "hi"
+
+        define bot express greeting
+          "Hello there!"
+
+        define flow
+          user express greeting
+          bot express greeting
+        """,
+    )
+    assert config.rails.dialog.single_call.enabled
+    assert config.user_messages
+    assert config.bot_messages
+    assert config.flows
+    assert config.rails.input.flows
+    assert config.rails.output.flows
+
+    rails = LLMRails(config=config)
+
+    assert rails.config.rails.dialog.single_call.enabled
+    assert rails.config.user_messages
+    assert rails.config.bot_messages
+    assert rails.config.flows
+    assert rails.config.rails.input.flows
+    assert rails.config.rails.output.flows


### PR DESCRIPTION
## Description

This PR implements a validator to ensure that reasoning traces cannot be enabled when dialog rails are present. The validator checks for both explicit dialog rails configuration and implicit dialog rails enabled through user messages, bot messages, and flows.

## Impact

This change ensures that:

1. Users cannot enable reasoning traces when dialog rails are present
2. The validation covers all ways dialog rails can be enabled
3. Clear error messages guide users to resolve configuration conflicts

## Changes

1. Added `check_reasoning_traces_with_dialog_rails` validator to `RailsConfig` class that:
   - Checks if any model has reasoning traces enabled
   - Verifies presence of dialog rails through:
     - Explicit configuration in `rails.dialog`
     - Implicit configuration through `user_messages`
     - Implicit configuration through `bot_messages`
     - Implicit configuration through `flows`
   - Raises a `ValueError` if reasoning traces are enabled while dialog rails are present

2. Added test cases in `test_config_validation.py` to verify:
   - Error is raised when both reasoning traces and dialog rails are enabled
   - No error when only reasoning traces are present
   - No error when only dialog rails are present
   - Error is raised when reasoning traces are enabled with implicit dialog rails


## Testing

Added comprehensive test coverage:


## Technical Details

The validator is implemented as a root validator in the `RailsConfig` class that (must migrated as part of #967:

- Takes pre-validated values as input
- Checks model configurations for reasoning traces
- Verifies dialog rails presence through multiple sources
- Returns the values if validation passes
- Raises an error if validation fails

## Breaking Changes

None. This is a new validation that prevents invalid configurations while it maintains backward compatibility


## TODO:

- [x] check for reasoning traces per dialog task