### PR TITLE
Fix/community integrations colang2

### DIFF
--- a/nemoguardrails/library/privateai/actions.py
+++ b/nemoguardrails/library/privateai/actions.py
@@ -37,7 +37,7 @@ def detect_pii_mapping(result: bool) -> bool:
     return result
 
 
-@action(is_system_action=True, output_mapping=detect_pii_mapping)
+@action(is_system_action=False, output_mapping=detect_pii_mapping)
 async def detect_pii(
     source: str,
     text: str,
@@ -89,7 +89,7 @@ async def detect_pii(
     return entity_detected
 
 
-@action(is_system_action=True)
+@action(is_system_action=False)
 async def mask_pii(source: str, text: str, config: RailsConfig):
     """Masks any detected PII in the provided text.
 

--- a/nemoguardrails/library/privateai/flows.co
+++ b/nemoguardrails/library/privateai/flows.co
@@ -2,7 +2,6 @@
 
 # INPUT RAILS
 
-@active
 flow detect pii on input
   """Check if the user input has PII."""
   $has_pii = await DetectPiiAction(source="input", text=$user_message)
@@ -14,7 +13,6 @@ flow detect pii on input
 
 # INPUT RAILS
 
-@active
 flow detect pii on output
   """Check if the bot output has PII."""
   $has_pii = await DetectPiiAction(source="output", text=$bot_message)
@@ -26,7 +24,6 @@ flow detect pii on output
 
 # RETRIVAL RAILS
 
-@active
 flow detect pii on retrieval
   """Check if the relevant chunks from the knowledge base have any PII."""
   $has_pii = await DetectPiiAction(source="retrieval", text=$relevant_chunks)
@@ -43,7 +40,6 @@ flow detect pii on retrieval
 
 # INPUT RAILS
 
-@active
 flow mask pii on input
   """Mask any detected PII in the user input."""
   $masked_input = await MaskPiiAction(source="input", text=$user_message)
@@ -54,7 +50,6 @@ flow mask pii on input
 
 # OUTPUT RAILS
 
-@active
 flow mask pii on output
   """Mask any detected PII in the bot output."""
   $bot_message = await MaskPiiAction(source="output", text=$bot_message)
@@ -62,7 +57,6 @@ flow mask pii on output
 
 # RETRIVAL RAILS
 
-@active
 flow mask pii on retrieval
   """Mask any detected PII in the relevant chunks from the knowledge base."""
   $relevant_chunks = await MaskPiiAction(source="retrieval", text=$relevant_chunks)

--- a/nemoguardrails/library/prompt_security/flows.co
+++ b/nemoguardrails/library/prompt_security/flows.co
@@ -1,24 +1,22 @@
 # INPUT RAILS
 
-@active
 flow protect prompt
   """Check if the prompt is valid according to Prompt Security."""
-  $result = await protect_text(user_prompt=$user_message)
+  $result = await ProtectTextAction(user_prompt=$user_message)
   if $result["is_blocked"]
     bot inform answer unknown
-    stop
+    abort
   else if $result["is_modified"]
     $user_message = $result["modified_text"]
 
 
 # OUTPUT RAILS
 
-@active
-flow protect response
+flow protect response $
   """Check if the response is valid according to Prompt Security."""
-  $result = await protect_text(bot_response=$bot_message)
+  $result = await ProtectTextAction(bot_response=$bot_message)
   if $result["is_blocked"]
     bot inform answer unknown
-    stop
+    abort
   else if $result["is_modified"]
     $bot_message = $result["modified_text"]

--- a/nemoguardrails/library/prompt_security/flows.co
+++ b/nemoguardrails/library/prompt_security/flows.co
@@ -4,7 +4,10 @@ flow protect prompt
   """Check if the prompt is valid according to Prompt Security."""
   $result = await ProtectTextAction(user_prompt=$user_message)
   if $result["is_blocked"]
-    bot inform answer unknown
+    if $system.config.enable_rails_exceptions
+      send PromptSecurityRailException(message="Prompt not allowed. The prompt was blocked by the 'protect prompt' flow.")
+    else
+      bot inform answer unknown
     abort
   else if $result["is_modified"]
     $user_message = $result["modified_text"]
@@ -12,11 +15,14 @@ flow protect prompt
 
 # OUTPUT RAILS
 
-flow protect response $
+flow protect response
   """Check if the response is valid according to Prompt Security."""
   $result = await ProtectTextAction(bot_response=$bot_message)
   if $result["is_blocked"]
-    bot inform answer unknown
+    if $system.config.enable_rails_exceptions
+      send PromptSecurityRailException(message="Response not allowed. The response was blocked by the 'protect response' flow.")
+    else
+      bot inform answer unknown
     abort
   else if $result["is_modified"]
     $bot_message = $result["modified_text"]

--- a/nemoguardrails/library/prompt_security/flows.v1.co
+++ b/nemoguardrails/library/prompt_security/flows.v1.co
@@ -4,7 +4,10 @@ define subflow protect prompt
   """Check if the prompt is valid according to Prompt Security."""
   $result = execute protect_text(user_prompt=$user_message)
   if $result["is_blocked"]
-    bot inform answer unknown
+    if $config.enable_rails_exceptions
+      create event PromptSecurityRailRailException(message="Prompt not allowed. The prompt was blocked by the 'protect prompt' flow.")
+    else
+      bot inform answer unknown
     stop
   else if $result["is_modified"]
     $user_message = $result["modified_text"]
@@ -16,7 +19,10 @@ define subflow protect response
   """Check if the response is valid according to Prompt Security."""
   $result = execute protect_text(bot_response=$bot_message)
   if $result["is_blocked"]
-    bot inform answer unknown
+    if $config.enable_rails_exceptions
+      create event PromptSecurityRailException(message="Response not allowed. The response was blocked by the 'protect response' flow.")
+    else
+      bot inform answer unknown
     stop
   else if $result["is_modified"]
     $bot_message = $result["modified_text"]


### PR DESCRIPTION
## Description

This pull request includes fixes to the PII detection and masking flows of PrivateAI, as well as fixes to the prompt security colang 2 flows. 

### PII Detection and Masking Updates:
* Changed the `is_system_action` parameter for `detect_pii` and `mask_pii` actions to `False`, making them non-system actions. (`nemoguardrails/library/privateai/actions.py`, [[1]](diffhunk://#diff-6b815a027bbd9691b95dbb3ee4f46b24e6eca0f70ec391f52d17788de61fe31bL40-R40) [[2]](diffhunk://#diff-6b815a027bbd9691b95dbb3ee4f46b24e6eca0f70ec391f52d17788de61fe31bL92-R92)
* Removed the `@active` directive from all PII-related flows, including detection and masking for input, output, and retrieval contexts. (`nemoguardrails/library/privateai/flows.co`, [[1]](diffhunk://#diff-cfb09d97eed3f5837dc4bd7dbd651ded83eb176eb6fdaa5656c5a889ddd54215L5) [[2]](diffhunk://#diff-cfb09d97eed3f5837dc4bd7dbd651ded83eb176eb6fdaa5656c5a889ddd54215L17) [[3]](diffhunk://#diff-cfb09d97eed3f5837dc4bd7dbd651ded83eb176eb6fdaa5656c5a889ddd54215L29) [[4]](diffhunk://#diff-cfb09d97eed3f5837dc4bd7dbd651ded83eb176eb6fdaa5656c5a889ddd54215L46) [[5]](diffhunk://#diff-cfb09d97eed3f5837dc4bd7dbd651ded83eb176eb6fdaa5656c5a889ddd54215L57-L65)

### Prompt Security Fixes:
* Replaced `protect_text` calls with `ProtectTextAction` in the `protect prompt` and `protect response` flows, and added support for configurable exceptions using `enable_rails_exceptions`. If enabled, exceptions are raised when prompts or responses are blocked; otherwise, the flow aborts with a generic message. (`nemoguardrails/library/prompt_security/flows.co`, [nemoguardrails/library/prompt_security/flows.coL3-R26](diffhunk://#diff-1ab55e94a7d439f1e079e8a6cfc916be4f4390bc7bad3f9153f58333638a029cL3-R26))
* Updated subflows in `flows.v1.co` to include exception handling for blocked prompts and responses, aligning with the new configurable behavior. (`nemoguardrails/library/prompt_security/flows.v1.co`, [[1]](diffhunk://#diff-216dbea5b75134ca169c51c7ddbc9ac47f99f615414963cb82f6bc8f9b7c3032R7-R9) [[2]](diffhunk://#diff-216dbea5b75134ca169c51c7ddbc9ac47f99f615414963cb82f6bc8f9b7c3032R22-R24)

