### PR TITLE
ci: add Codecov integration to workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false # if true: only post the comment if coverage changes
+  require_base: false # [true :: must have a base report to post]
+  require_head: true # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,8 +1,9 @@
 name: PR Tests
 
 on:
+  push:
+
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     # we don't ignore markdkowns to run pre-commits
     paths-ignore:
       - ".github/**"

--- a/.github/workflows/test-coverage-report.yml
+++ b/.github/workflows/test-coverage-report.yml
@@ -1,0 +1,48 @@
+name: Coverage Report
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Bootstrap poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | POETRY_VERSION=1.8.2 python -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Configure poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Install dependencies
+        run: poetry install --with dev
+
+      - name: Run pre-commit hooks
+        run: poetry run make pre_commit
+
+      - name: Run tests with coverage
+        run: poetry run pytest --cov=nemoguardrails tests/ --cov-report=xml:coverage.xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage/reports/
+          env_vars: PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          flags: python
+          name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true


### PR DESCRIPTION
The workflow is triggered on pushes and pull requests to the `develop` branch. Codecov integration ensures better visibility into test coverage metrics.

https://docs.codecov.com/docs/common-recipe-list



