### PR TITLE
docs: fix output rail doc

### DIFF
--- a/docs/getting-started/5-output-rails/README.md
+++ b/docs/getting-started/5-output-rails/README.md
@@ -185,9 +185,11 @@ You can enable streaming to provide asynchronous responses and reduce the time t
        streaming:
           chunk_size: 200
           context_size: 50
+          enabled: True
 
    streaming: True
    ```
+   Note that, the `enabled: True` filed is needed to enable streaming output rails while `streaming: True` is needed to enable streaming generation.
 
 1. Call the `stream_async` method and handle the chunked response:
 

--- a/docs/getting-started/5-output-rails/README.md
+++ b/docs/getting-started/5-output-rails/README.md
@@ -183,13 +183,14 @@ You can enable streaming to provide asynchronous responses and reduce the time t
        flows:
          - self check output
        streaming:
+          enabled: True
           chunk_size: 200
           context_size: 50
-          enabled: True
 
    streaming: True
    ```
-   Note that, the `enabled: True` filed is needed to enable streaming output rails while `streaming: True` is needed to enable streaming generation.
+
+  The `enabled: True` field is required to enable streaming output rails while the `streaming: True` field is needed to enable streaming generation.
 
 1. Call the `stream_async` method and handle the chunked response:
 

--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -679,7 +679,7 @@ You can enable streaming to begin receiving responses from the output rail soone
 
 You must set the top-level `streaming: True` field in your `config.yml` file.
 
-For each output rail, add the `streaming` field and configuration parameters.
+For the output rails, add the `streaming` field and configuration parameters.
 
 ```yaml
 rails:
@@ -689,6 +689,7 @@ rails:
     chunk_size: 200
     context_size: 50
     stream_first: True
+    enabled: True
 
 streaming: True
 ```
@@ -742,6 +743,11 @@ The following table describes the subfields for the `streaming` field:
     By default, the toolkit streams the chunks as soon as possible and before applying output rails to them.
 
   - `True`
+
+* - streaming.enabled
+  - When set to True enable the execution of the output rails in streaming mode.
+
+  - `False`
 ```
 
 The following table shows how the number of tokens, chunk size, and context size interact to trigger the number of rails invocations.

--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -103,6 +103,7 @@ nemoguardrails find-providers [--list]
 ```
 
 The command supports two modes:
+
 - Interactive mode (default): Guides you through selecting a provider type (text completion or chat completion) and then shows available providers for that type
 - List mode (`--list`): Simply lists all available providers without interactive selection
 
@@ -686,10 +687,10 @@ rails:
   output:
     - rail name
   streaming:
+    enabled: True
     chunk_size: 200
     context_size: 50
     stream_first: True
-    enabled: True
 
 streaming: True
 ```
@@ -736,6 +737,11 @@ The following table describes the subfields for the `streaming` field:
     Specifying approximately 25% of `chunk_size` provides a good compromise.
   - `50`
 
+* - streaming.enabled
+  - When set to `True`, the toolkit executes output rails in streaming mode.
+
+  - `False`
+
 * - streaming.stream_first
   - When set to `False`, the toolkit applies the output rails to the chunks before streaming them to the client.
     If you set this field to `False`, you can avoid streaming chunks of blocked content.
@@ -743,11 +749,6 @@ The following table describes the subfields for the `streaming` field:
     By default, the toolkit streams the chunks as soon as possible and before applying output rails to them.
 
   - `True`
-
-* - streaming.enabled
-  - When set to True enable the execution of the output rails in streaming mode.
-
-  - `False`
 ```
 
 The following table shows how the number of tokens, chunk size, and context size interact to trigger the number of rails invocations.


### PR DESCRIPTION
## Description

Fix some issues on output streaming rails documentation.
Specifically the `streaming.enabled` field was missing

## Related Issue(s)

I haven't opened a proper issue for that

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
