### PR TITLE
feat: add inline YARA rules support

### DIFF
--- a/nemoguardrails/library/injection_detection/actions.py
+++ b/nemoguardrails/library/injection_detection/actions.py
@@ -32,7 +32,7 @@ import logging
 import re
 from functools import lru_cache
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 yara = None
 try:
@@ -57,21 +57,23 @@ def _check_yara_available():
         )
 
 
-def _validate_unpack_config(config: RailsConfig) -> Tuple[str, Path, Tuple[str]]:
+def _check_yara_available():
+    if yara is None:
+        raise ImportError(
+            "The yara module is required for injection detection. "
+            "Please install it using: pip install yara-python"
+        )
+
+def validate_injection_config(config: RailsConfig) -> None:
     """
-    Validates and unpacks the injection detection configuration.
+    Validates the injection detection configuration.
 
     Args:
         config (RailsConfig): The Rails configuration object containing injection detection settings.
 
-    Returns:
-        Tuple[str, Path, Tuple[str]]: A tuple containing the action option, the YARA path,
-        and the injection rules.
-
     Raises:
+        ValueError: If the configuration is missing or invalid.
         FileNotFoundError: If the provided `yara_path` is not a directory.
-        ValueError: If `yara_path` is not a string, the action option is invalid,
-        or the injection rules contain invalid elements.
     """
     command_injection_config = config.rails.config.injection_detection
 
@@ -81,25 +83,8 @@ def _validate_unpack_config(config: RailsConfig) -> Tuple[str, Path, Tuple[str]]
         )
         log.error(msg)
         raise ValueError(msg)
-    yara_path = command_injection_config.yara_path
-    if not yara_path:
-        yara_path = YARA_DIR
-    elif isinstance(yara_path, str):
-        yara_path = Path(yara_path)
-        if not yara_path.exists() or not yara_path.is_dir():
-            msg = (
-                "Provided `yara_path` value in injection config %s is not a directory."
-                % yara_path
-            )
-            log.error(msg)
-            raise FileNotFoundError(msg)
-    else:
-        msg = "Expected a string value for `yara_path` but got %r instead." % type(
-            yara_path
-        )
 
-        log.error(msg)
-        raise ValueError(msg)
+    # Validate action option
     action_option = command_injection_config.action
     if action_option not in ActionOptions:
         msg = (
@@ -108,9 +93,59 @@ def _validate_unpack_config(config: RailsConfig) -> Tuple[str, Path, Tuple[str]]
         )
         log.error(msg)
         raise ValueError(msg)
+
+    # Validate yara_path if no yara_rules provided
+    if not command_injection_config.yara_rules:
+        yara_path = command_injection_config.yara_path
+        if yara_path and isinstance(yara_path, str):
+            yara_path = Path(yara_path)
+            if not yara_path.exists() or not yara_path.is_dir():
+                msg = (
+                    "Provided `yara_path` value in injection config %s is not a directory."
+                    % yara_path
+                )
+                log.error(msg)
+                raise FileNotFoundError(msg)
+        elif yara_path and not isinstance(yara_path, str):
+            msg = "Expected a string value for `yara_path` but got %r instead." % type(
+                yara_path
+            )
+            log.error(msg)
+            raise ValueError(msg)
+
+
+def extract_injection_config(
+    config: RailsConfig,
+) -> Tuple[str, Path, Tuple[str], Optional[Dict[str, str]]]:
+    """
+    Extracts and processes the injection detection configuration values.
+
+    Args:
+        config (RailsConfig): The Rails configuration object containing injection detection settings.
+
+    Returns:
+        Tuple[str, Path, Tuple[str], Optional[Dict[str, str]]]: A tuple containing the action option,
+        the YARA path, the injection rules, and optional yara_rules dictionary.
+
+    Raises:
+        ValueError: If the injection rules contain invalid elements.
+    """
+    command_injection_config = config.rails.config.injection_detection
+    yara_rules = command_injection_config.yara_rules
+
+    # Set yara_path
+    if yara_rules:
+        # we'll use this for validation only
+        yara_path = YARA_DIR
+    else:
+        yara_path = command_injection_config.yara_path or YARA_DIR
+        if isinstance(yara_path, str):
+            yara_path = Path(yara_path)
+
     injection_rules = tuple(command_injection_config.injections)
-    if not set(injection_rules) <= Rules:
-        # Do the easy check above first. If they provide a custom dir or a custom rules file, check the filesystem
+
+    # only validate rule names against available rules if using yara_path
+    if not yara_rules and not set(injection_rules) <= Rules:
         if not all(
             [
                 yara_path.joinpath(f"{module_name}.yara").is_file()
@@ -125,17 +160,19 @@ def _validate_unpack_config(config: RailsConfig) -> Tuple[str, Path, Tuple[str]]
             log.error(msg)
             raise ValueError(msg)
 
-    return action_option, yara_path, injection_rules
+    return command_injection_config.action, yara_path, injection_rules, yara_rules
 
 
-@lru_cache()
-def _load_rules(yara_path: Path, rule_names: Tuple) -> Union["yara.Rules", None]:
+def _load_rules(
+    yara_path: Path, rule_names: Tuple, yara_rules: Optional[Dict[str, str]] = None
+) -> Union["yara.Rules", None]:
     """
-    Loads and compiles YARA rules from the specified path and rule names.
+    Loads and compiles YARA rules from either file paths or direct rule strings.
 
     Args:
         yara_path (Path): The path to the directory containing YARA rule files.
         rule_names (Tuple): A tuple of YARA rule names to load.
+        yara_rules (Optional[Dict[str, str]]): Dictionary mapping rule names to YARA rule strings.
 
     Returns:
         Union['yara.Rules', None]: The compiled YARA rules object if successful,
@@ -151,12 +188,21 @@ def _load_rules(yara_path: Path, rule_names: Tuple) -> Union["yara.Rules", None]
             "Injection config was provided but no modules were specified. Returning None."
         )
         return None
-    rules_to_load = {
-        rule_name: str(yara_path.joinpath(f"{rule_name}.yara"))
-        for rule_name in rule_names
-    }
+
     try:
-        rules = yara.compile(filepaths=rules_to_load)
+        if yara_rules:
+            rules_source = {
+                name: rule for name, rule in yara_rules.items() if name in rule_names
+            }
+            rules = yara.compile(
+                sources={rule_name: rules_source[rule_name] for rule_name in rule_names}
+            )
+        else:
+            rules_to_load = {
+                rule_name: str(yara_path.joinpath(f"{rule_name}.yara"))
+                for rule_name in rule_names
+            }
+            rules = yara.compile(filepaths=rules_to_load)
     except yara.SyntaxError as e:
         msg = f"Encountered SyntaxError: {e}"
         log.error(msg)
@@ -282,8 +328,11 @@ async def injection_detection(text: str, config: RailsConfig) -> str:
     """
     _check_yara_available()
 
-    action_option, yara_path, rule_names = _validate_unpack_config(config)
-    rules = _load_rules(yara_path, rule_names)
+    validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+
+    rules = _load_rules(yara_path, rule_names, yara_rules)
+
     if action_option == "reject":
         verdict, detections = _reject_injection(text, rules)
         if verdict:

--- a/nemoguardrails/library/injection_detection/actions.py
+++ b/nemoguardrails/library/injection_detection/actions.py
@@ -57,14 +57,7 @@ def _check_yara_available():
         )
 
 
-def _check_yara_available():
-    if yara is None:
-        raise ImportError(
-            "The yara module is required for injection detection. "
-            "Please install it using: pip install yara-python"
-        )
-
-def validate_injection_config(config: RailsConfig) -> None:
+def _validate_injection_config(config: RailsConfig) -> None:
     """
     Validates the injection detection configuration.
 
@@ -114,7 +107,7 @@ def validate_injection_config(config: RailsConfig) -> None:
             raise ValueError(msg)
 
 
-def extract_injection_config(
+def _extract_injection_config(
     config: RailsConfig,
 ) -> Tuple[str, Path, Tuple[str], Optional[Dict[str, str]]]:
     """
@@ -328,8 +321,8 @@ async def injection_detection(text: str, config: RailsConfig) -> str:
     """
     _check_yara_available()
 
-    validate_injection_config(config)
-    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    _validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = _extract_injection_config(config)
 
     rules = _load_rules(yara_path, rule_names, yara_rules)
 

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -177,10 +177,15 @@ class InjectionDetection(BaseModel):
         "'omit' to mask the offending content, and 'sanitize' to pass the content as-is in the safest way. "
         "These options are listed in descending order of relative safety. 'sanitize' is not implemented at this time.",
     )
-    yara_path: str = Field(
+    yara_path: Optional[str] = Field(
         default="",
         description="Location on disk where YARA rules are located. If this parameter is an empty string, "
         "the default location defined in injection_detection's actions.py file will be used.",
+    )
+    yara_rules: Optional[Dict[str, str]] = Field(
+        default_factory=dict,
+        description="Dictionary mapping rule names to YARA rule strings. If provided, these rules will be used "
+        "instead of loading rules from yara_path. Each rule should be a valid YARA rule string.",
     )
 
 

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -43,8 +43,9 @@ from nemoguardrails.library.injection_detection.actions import (
     _load_rules,
     _omit_injection,
     _reject_injection,
-    _validate_unpack_config,
+    extract_injection_config,
     injection_detection,
+    validate_injection_config,
 )
 from tests.utils import TestChat
 
@@ -101,15 +102,17 @@ def test_load_custom_rules():
                   execute check_user_message(user_message=$user_message)
             """,
     )
-    _action_option, yara_path, rule_names = _validate_unpack_config(config)
-    rules = _load_rules(yara_path, rule_names)
+    validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    rules = _load_rules(yara_path, rule_names, yara_rules)
     assert isinstance(rules, yara.Rules)
 
 
 def test_load_all_rules():
     config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "injection_detection"))
-    _action_option, yara_path, rule_names = _validate_unpack_config(config)
-    rules = _load_rules(yara_path, rule_names)
+    validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    rules = _load_rules(yara_path, rule_names, yara_rules)
     assert isinstance(rules, yara.Rules)
 
 
@@ -160,7 +163,7 @@ def test_invalid_yara_path():
             """
     )
     with pytest.raises(FileNotFoundError):
-        _validate_unpack_config(config)
+        validate_injection_config(config)
 
 
 def test_invalid_action_option():
@@ -170,7 +173,7 @@ def test_invalid_action_option():
     config.rails.config.injection_detection.action = "invalid_action"
 
     with pytest.raises(ValueError):
-        _validate_unpack_config(config)
+        validate_injection_config(config)
 
 
 def test_invalid_injection_rule():
@@ -187,8 +190,9 @@ def test_invalid_injection_rule():
                         reject
             """
     )
+    validate_injection_config(config)
     with pytest.raises(ValueError):
-        _validate_unpack_config(config)
+        extract_injection_config(config)
 
 
 def test_empty_injection_rules():
@@ -204,9 +208,50 @@ def test_empty_injection_rules():
                         reject
             """
     )
-    _action_option, yara_path, rule_names = _validate_unpack_config(config)
-    rules = _load_rules(yara_path, rule_names)
+    validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    rules = _load_rules(yara_path, rule_names, yara_rules)
     assert rules is None
+
+
+def test_load_inline_yara_rules():
+    """Test loading YARA rules defined inline in the config."""
+    inline_rule_name = "inline_test_rule"
+    inline_rule_content = "rule test_inline { condition: true }"
+
+    config = RailsConfig.from_content(
+        yaml_content=f"""
+                models: []
+                rails:
+                  config:
+                    injection_detection:
+                      injections:
+                        - {inline_rule_name}
+                      action:
+                        reject
+                      yara_rules:
+                        {inline_rule_name}: |-
+                          {inline_rule_content}
+            """,
+        colang_content="",
+    )
+
+    validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+
+    assert yara_rules is not None
+    assert inline_rule_name in yara_rules
+    assert yara_rules[inline_rule_name] == inline_rule_content
+    assert rule_names == (inline_rule_name,)
+
+    rules = load_rules(yara_path, rule_names, yara_rules)
+    assert isinstance(rules, yara.Rules)
+
+    # Test that the loaded rule actually matches
+    matches = rules.match(data="any data")
+    assert len(matches) == 1
+    assert matches[0].rule == "test_inline"
+    assert matches[0].namespace == inline_rule_name
 
 
 @pytest.mark.asyncio
@@ -511,3 +556,64 @@ def test_yara_import_error():
 
     with patch("nemoguardrails.library.injection_detection.actions.yara", yara):
         _check_yara_available()
+
+
+@pytest.mark.asyncio
+async def test_multiple_injection_types_reject_inline_rules():
+    """Test reject action for multiple injection types using inline YARA rules."""
+
+    # inline YARA rules
+    sqli_rule_content = (
+        "rule simple_sqli { strings: $sql = /SELECT.*FROM/ condition: $sql }"
+    )
+    xss_rule_content = "rule simple_xss { strings: $tag = /<script/ condition: $tag }"
+    template_rule_content = (
+        "rule simple_template { strings: $tpl = /{{.*}}/ condition: $tpl }"
+    )
+    code_rule_content = (
+        "rule simple_code { strings: $code = /__import__/ condition: $code }"
+    )
+
+    config = RailsConfig.from_content(
+        yaml_content=f"""
+                models: []
+                rails:
+                  config:
+                    injection_detection:
+                      injections:
+                        - sqli_inline
+                        - xss_inline
+                        - template_inline
+                        - code_inline
+                      action:
+                        reject
+                      yara_rules:
+                        sqli_inline: |
+                          {sqli_rule_content}
+                        xss_inline: |
+                          {xss_rule_content}
+                        template_inline: |
+                          {template_rule_content}
+                        code_inline: |
+                          {code_rule_content}
+                  output:
+                    flows:
+                      - injection detection
+            """,
+        colang_content="",
+    )
+
+    multi_injection = "Hello <script>alert('xss')</script> {{ evil }} __import__('os') SELECT * FROM users; -- comment world"
+    chat = TestChat(config, llm_completions=[multi_injection])
+    rails = chat.app
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": "trigger multiple injections"}]
+    )
+
+    assert result["content"].startswith(
+        "I'm sorry, the desired output triggered rule(s) designed to mitigate exploitation of"
+    )
+    assert "simple_sqli" in result["content"]
+    assert "simple_xss" in result["content"]
+    assert "simple_template" in result["content"]
+    assert "simple_code" in result["content"]

--- a/tests/test_injection_detection.py
+++ b/tests/test_injection_detection.py
@@ -40,12 +40,11 @@ from nemoguardrails.actions import action
 from nemoguardrails.actions.actions import ActionResult
 from nemoguardrails.library.injection_detection.actions import (
     _check_yara_available,
+    _extract_injection_config,
     _load_rules,
     _omit_injection,
     _reject_injection,
-    extract_injection_config,
-    injection_detection,
-    validate_injection_config,
+    _validate_injection_config,
 )
 from tests.utils import TestChat
 
@@ -102,16 +101,16 @@ def test_load_custom_rules():
                   execute check_user_message(user_message=$user_message)
             """,
     )
-    validate_injection_config(config)
-    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    _validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = _extract_injection_config(config)
     rules = _load_rules(yara_path, rule_names, yara_rules)
     assert isinstance(rules, yara.Rules)
 
 
 def test_load_all_rules():
     config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "injection_detection"))
-    validate_injection_config(config)
-    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    _validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = _extract_injection_config(config)
     rules = _load_rules(yara_path, rule_names, yara_rules)
     assert isinstance(rules, yara.Rules)
 
@@ -163,7 +162,7 @@ def test_invalid_yara_path():
             """
     )
     with pytest.raises(FileNotFoundError):
-        validate_injection_config(config)
+        _validate_injection_config(config)
 
 
 def test_invalid_action_option():
@@ -173,7 +172,7 @@ def test_invalid_action_option():
     config.rails.config.injection_detection.action = "invalid_action"
 
     with pytest.raises(ValueError):
-        validate_injection_config(config)
+        _validate_injection_config(config)
 
 
 def test_invalid_injection_rule():
@@ -190,9 +189,9 @@ def test_invalid_injection_rule():
                         reject
             """
     )
-    validate_injection_config(config)
+    _validate_injection_config(config)
     with pytest.raises(ValueError):
-        extract_injection_config(config)
+        _extract_injection_config(config)
 
 
 def test_empty_injection_rules():
@@ -208,8 +207,8 @@ def test_empty_injection_rules():
                         reject
             """
     )
-    validate_injection_config(config)
-    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    _validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = _extract_injection_config(config)
     rules = _load_rules(yara_path, rule_names, yara_rules)
     assert rules is None
 
@@ -236,15 +235,15 @@ def test_load_inline_yara_rules():
         colang_content="",
     )
 
-    validate_injection_config(config)
-    action_option, yara_path, rule_names, yara_rules = extract_injection_config(config)
+    _validate_injection_config(config)
+    action_option, yara_path, rule_names, yara_rules = _extract_injection_config(config)
 
     assert yara_rules is not None
     assert inline_rule_name in yara_rules
     assert yara_rules[inline_rule_name] == inline_rule_content
     assert rule_names == (inline_rule_name,)
 
-    rules = load_rules(yara_path, rule_names, yara_rules)
+    rules = _load_rules(yara_path, rule_names, yara_rules)
     assert isinstance(rules, yara.Rules)
 
     # Test that the loaded rule actually matches


### PR DESCRIPTION
## PR Description by GH Copilot

This pull request refactors and enhances the injection detection module by improving configuration validation, supporting inline YARA rules, and adding new tests. The changes aim to make the code more modular, robust, and easier to extend.

### Refactoring and Validation Improvements:
* Renamed `_validate_unpack_config` to `validate_injection_config` and updated it to focus solely on validating the configuration without unpacking values. [[1]](diffhunk://#diff-2e8e7fb15761a3d7ce33b9010d2c4e1c7ae19dc092a5747dfeb1c70653695219L48-L62) [[2]](diffhunk://#diff-2e8e7fb15761a3d7ce33b9010d2c4e1c7ae19dc092a5747dfeb1c70653695219R67-R81)
* Introduced `extract_injection_config` to handle the extraction and processing of configuration values, separating concerns for better modularity.
* Enhanced validation logic for `action_option` and `yara_path` to ensure stricter checks and clearer error messages. [[1]](diffhunk://#diff-2e8e7fb15761a3d7ce33b9010d2c4e1c7ae19dc092a5747dfeb1c70653695219R67-R81) [[2]](diffhunk://#diff-2e8e7fb15761a3d7ce33b9010d2c4e1c7ae19dc092a5747dfeb1c70653695219L84-R128)

### Support for Inline YARA Rules:
* Added support for defining YARA rules inline via a new `yara_rules` dictionary in the configuration. This allows rules to be loaded directly from strings instead of files. [[1]](diffhunk://#diff-d75262fb6ee9294e60713c17483e15d961566e75a9591e46dd0b29e619afe0d0L180-R189) [[2]](diffhunk://#diff-2e8e7fb15761a3d7ce33b9010d2c4e1c7ae19dc092a5747dfeb1c70653695219R169-L144)
* Updated the `load_rules` function to handle both file-based and inline rule sources.

### Test Suite Enhancements:
* Updated existing tests to use the new `validate_injection_config` and `extract_injection_config` functions. [[1]](diffhunk://#diff-e3377e30bb9064a790bca4ea01e34ba87d42ae5af0f8177d547fd17d4d4460c5L103-R114) [[2]](diffhunk://#diff-e3377e30bb9064a790bca4ea01e34ba87d42ae5af0f8177d547fd17d4d4460c5L162-R165)
* Added a new test, `test_load_inline_yara_rules`, to validate the functionality of inline YARA rules.

### Other Changes:
* Made `yara_path` optional in the `InjectionDetection` configuration and added the new `yara_rules` field.
* Updated imports and removed unused `_validate_unpack_config` references across the codebase.