### PR TITLE
Feat/reasoning traces history

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -24,7 +24,7 @@ from langchain.schema import AIMessage, HumanMessage, SystemMessage
 
 from nemoguardrails.colang.v2_x.lang.colang_ast import Flow
 from nemoguardrails.colang.v2_x.runtime.flows import InternalEvent, InternalEvents
-from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.context import llm_call_info_var, reasoning_trace_var
 from nemoguardrails.logging.callbacks import logging_callbacks
 from nemoguardrails.logging.explain import LLMCallInfo
 
@@ -192,7 +192,7 @@ def get_colang_history(
                     and event["action_name"] == "retrieve_relevant_chunks"
                 ):
                     continue
-                history += f'execute {event["action_name"]}\n'
+                history += f"execute {event['action_name']}\n"
             elif event["type"] == "InternalSystemActionFinished" and not event.get(
                 "is_system_action"
             ):
@@ -577,3 +577,15 @@ def escape_flow_name(name: str) -> str:
     # removes non-word chars and leading digits in a word
     result = re.sub(r"\b\d+|[^\w\s]", "", result)
     return result
+
+
+def get_and_clear_reasoning_trace_contextvar() -> Optional[str]:
+    """Get the current reasoning trace and clear it from the context.
+
+    Returns:
+        Optional[str]: The reasoning trace if one exists, None otherwise.
+    """
+    if reasoning_trace := reasoning_trace_var.get():
+        reasoning_trace_var.set(None)
+        return reasoning_trace
+    return None

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -197,7 +197,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
             # We add these in reverse order so the most relevant is towards the end.
             for result in reversed(results):
-                examples += f"user action: user said \"{result.text}\"\nuser intent: {result.meta['intent']}\n\n"
+                examples += f'user action: user said "{result.text}"\nuser intent: {result.meta["intent"]}\n\n'
                 if result.meta["intent"] not in potential_user_intents:
                     potential_user_intents.append(result.meta["intent"])
 
@@ -302,6 +302,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             Task.GENERATE_USER_INTENT_FROM_USER_ACTION, output=result
         )
 
+        result = result.text
+
         user_intent = get_first_nonempty_line(result)
         # GTP-4o often adds 'user intent: ' in front
         if user_intent and ":" in user_intent:
@@ -377,6 +379,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         result = self.llm_task_manager.parse_task_output(
             Task.GENERATE_USER_INTENT_AND_BOT_ACTION_FROM_USER_ACTION, output=result
         )
+
+        result = result.text
 
         user_intent = get_first_nonempty_line(result)
 
@@ -457,6 +461,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             )
 
             text = self.llm_task_manager.parse_task_output(Task.GENERAL, output=text)
+
+            text = result.text
 
         return text
 
@@ -541,6 +547,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             task=Task.GENERATE_FLOW_FROM_INSTRUCTIONS, output=result
         )
 
+        result = result.text
+
         # TODO: why this is not part of a filter or output_parser?
         #
         lines = _remove_leading_empty_lines(result).split("\n")
@@ -613,6 +621,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             task=Task.GENERATE_FLOW_FROM_NAME, output=result
         )
 
+        result = result.text
+
         lines = _remove_leading_empty_lines(result).split("\n")
 
         if lines[0].startswith("flow"):
@@ -679,6 +689,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         result = self.llm_task_manager.parse_task_output(
             task=Task.GENERATE_FLOW_CONTINUATION, output=result
         )
+
+        result = result.text
 
         lines = _remove_leading_empty_lines(result).split("\n")
 
@@ -806,6 +818,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             Task.GENERATE_VALUE_FROM_INSTRUCTION, output=result
         )
 
+        result = result.text
+
         # We only use the first line for now
         # TODO: support multi-line values?
         value = result.strip().split("\n")[0]
@@ -912,6 +926,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         result = self.llm_task_manager.parse_task_output(
             Task.GENERATE_FLOW_CONTINUATION_FROM_NLD, output=result
         )
+
+        result = result.text
 
         result = _remove_leading_empty_lines(result)
         lines = result.split("\n")

--- a/nemoguardrails/context.py
+++ b/nemoguardrails/context.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import contextvars
+from typing import Optional
 
 streaming_handler_var = contextvars.ContextVar("streaming_handler", default=None)
 
@@ -32,3 +33,7 @@ llm_stats_var = contextvars.ContextVar("llm_stats", default=None)
 # The raw LLM request that comes from the user.
 # This is used in passthrough mode.
 raw_llm_request = contextvars.ContextVar("raw_llm_request", default=None)
+
+reasoning_trace_var: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "reasoning_trace", default=None
+)

--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -80,6 +80,7 @@ async def content_safety_check_input(
         result = await llm_call(llm, check_input_prompt, stop=stop)
 
     result = llm_task_manager.parse_task_output(task, output=result)
+    result = result.text
 
     try:
         is_safe, violated_policies = result
@@ -161,6 +162,8 @@ async def content_safety_check_output(
         result = await llm_call(llm, check_output_prompt, stop=stop)
 
     result = llm_task_manager.parse_task_output(task, output=result)
+
+    result = result.text
 
     try:
         is_safe, violated_policies = result

--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -82,6 +82,7 @@ async def self_check_facts(
             task, output=response, forced_output_parser="is_content_safe"
         )
 
+    result = result.text
     is_not_safe, _ = result
 
     result = float(not is_not_safe)

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -83,6 +83,7 @@ async def self_check_input(
                 task, output=response, forced_output_parser="is_content_safe"
             )
 
+        result = result.text
         is_safe, _ = result
 
         if not is_safe:

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -87,6 +87,7 @@ async def self_check_output(
                 task, output=response, forced_output_parser="is_content_safe"
             )
 
+        result = result.text
         is_safe, _ = result
 
         return is_safe

--- a/nemoguardrails/llm/filters.py
+++ b/nemoguardrails/llm/filters.py
@@ -15,12 +15,23 @@
 
 import re
 import textwrap
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
 
 from nemoguardrails.actions.llm.utils import (
     get_colang_history,
     remove_action_intent_identifiers,
 )
+
+
+@dataclass
+class ReasoningExtractionResult:
+    """
+    Holds cleaned response text and optional chain-of-thought reasoning trace extracted from LLM output.
+    """
+
+    text: str
+    reasoning_trace: Optional[str] = None
 
 
 def colang(events: List[dict]) -> str:
@@ -439,24 +450,98 @@ def conversation_to_events(conversation: List) -> List[dict]:
     return events
 
 
-def remove_reasoning_traces(response: str, start_token: str, end_token: str) -> str:
-    """Removes the text between the first occurrence of the start token and the
-    last occurrence of the last token, if these tokens exist in the response.
+def _find_token_positions_for_removal(
+    response: str, start_token: Optional[str], end_token: Optional[str]
+) -> Tuple[int, int]:
+    """Helper function to find token positions specifically for text removal.
 
-    This utility function is useful to strip reasoning traces from reasoning LLMs
-    that encode the reasoning traces between specific tokens.
+    This is useful, for example, to remove reasoning traces from a reasoning LLM response.
+
+    This is optimized for the removal use case:
+    1. Uses find() for first start token
+    2. Uses rfind() for last end token
+    3. Sets start_index to 0 if start token is missing
+
+    Args:
+        response(str): The text to search in
+        start_token(str): The token marking the start of text to remove
+        end_token(str): The token marking the end of text to remove
+
+    Returns:
+        A tuple of (start_index, end_index) marking the span to remove;
+            both indices are -1 if start_token and end_token are not provided.
     """
-    if start_token and end_token:
-        start_index = response.find(start_token)
-        # If the start index is missing, this is probably a continuation of a bot message
-        # started in the prompt.
-        if start_index == -1:
-            start_index = 0
-        end_index = response.rfind(end_token)
-        if end_index == -1:
-            return response
+    if not start_token or not end_token:
+        return -1, -1
 
-        if start_index != -1 and end_index != -1 and start_index < end_index:
-            return response[:start_index] + response[end_index + len(end_token) :]
+    start_index = response.find(start_token)
+    # if the start index is missing, this is probably a continuation of a bot message
+    # started in the prompt.
+    if start_index == -1:
+        start_index = 0
 
-    return response
+    end_index = response.rfind(end_token)
+
+    return start_index, end_index
+
+
+def find_reasoning_tokens_position(
+    response: str, start_token: Optional[str], end_token: Optional[str]
+) -> Tuple[int, int]:
+    """Finds the positions of the first start token and the last end token.
+
+    This is intended to find the outermost boundaries of potential
+    reasoning sections, typically for removal.
+
+    Args:
+        response(str): The text to search in.
+        start_token(Optional[str]): The token marking the start of reasoning.
+        end_token(Optional[str]): The token marking the end of reasoning.
+
+    Returns:
+        A tuple (start_index, end_index).
+        - start_index: Position of the first `start_token`, or 0 if not found.
+        - end_index: Position of the last `end_token`, or -1 if not found.
+    """
+
+    return _find_token_positions_for_removal(response, start_token, end_token)
+
+
+def extract_and_strip_trace(
+    response: str, start_token: str, end_token: str
+) -> ReasoningExtractionResult:
+    """Extracts and removes reasoning traces from the given text.
+
+    This function identifies reasoning traces in the text that are marked
+    by specific start and end tokens. It extracts these traces, removes
+    them from the original text, and returns both the cleaned text and
+    the extracted reasoning trace.
+
+    Args:
+        response (str): The text to process.
+        start_token (str): The token marking the start of a reasoning trace.
+        end_token (str): The token marking the end of a reasoning trace.
+
+    Returns:
+        ReasoningExtractionResult: An object containing the cleaned text
+        without reasoning traces and the extracted reasoning trace, if any.
+    """
+
+    start_index, end_index = find_reasoning_tokens_position(
+        response, start_token, end_token
+    )
+    # handles invalid/empty tokens returned as (-1, -1)
+    if start_index == -1 and end_index == -1:
+        return ReasoningExtractionResult(text=response, reasoning_trace=None)
+    # end token is missing
+    if end_index == -1:
+        return ReasoningExtractionResult(text=response, reasoning_trace=None)
+    # extrace if tokens are present and start < end
+    if start_index < end_index:
+        reasoning_trace = response[start_index : end_index + len(end_token)]
+        cleaned_text = response[:start_index] + response[end_index + len(end_token) :]
+        return ReasoningExtractionResult(
+            text=cleaned_text, reasoning_trace=reasoning_trace
+        )
+
+    return ReasoningExtractionResult(text=response, reasoning_trace=None)

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 import re
 from ast import literal_eval
@@ -22,6 +23,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
 
+from nemoguardrails.actions.llm.utils import get_and_clear_reasoning_trace_contextvar
 from nemoguardrails.llm.filters import (
     co_v2,
     colang,
@@ -154,6 +156,70 @@ class LLMTaskManager:
 
         return text
 
+    def _preprocess_events_for_prompt(
+        self, events: Optional[List[dict]]
+    ) -> Optional[List[dict]]:
+        """Remove reasoning traces from bot messages before rendering them in prompts.
+
+        This prevents reasoning traces from being included in LLM prompt history when
+        rails.output.apply_to_reasoning_traces=true is enabled.
+
+        Args:
+            events: The list of events to preprocess
+
+        Returns:
+            A new list of preprocessed events, or None if events was None
+        """
+        if not events:
+            return None
+
+        processed_events = copy.deepcopy(events)
+
+        for event in processed_events:
+            if (
+                isinstance(event, dict)
+                and event.get("type") == "BotMessage"
+                and "text" in event
+            ):
+                bot_utterance = event["text"]
+                for task in Task:
+                    start_token, end_token = get_reasoning_token_tags(self.config, task)
+                    if (
+                        start_token
+                        and end_token
+                        and output_has_reasoning_traces(
+                            bot_utterance, start_token, end_token
+                        )
+                    ):
+                        result = extract_and_strip_trace(
+                            bot_utterance, start_token, end_token
+                        )
+                        event["text"] = result.text
+                        break
+
+            elif (
+                isinstance(event, dict)
+                and event.get("type") == "StartUtteranceBotAction"
+                and "script" in event
+            ):
+                bot_utterance = event["script"]
+                for task in Task:
+                    start_token, end_token = get_reasoning_token_tags(self.config, task)
+                    if (
+                        start_token
+                        and end_token
+                        and output_has_reasoning_traces(
+                            bot_utterance, start_token, end_token
+                        )
+                    ):
+                        result = extract_and_strip_trace(
+                            bot_utterance, start_token, end_token
+                        )
+                        event["script"] = result.text
+                        break
+
+        return processed_events
+
     def _render_string(
         self,
         template_str: str,
@@ -168,6 +234,8 @@ class LLMTaskManager:
         :return: The rendered template.
         :rtype: str.
         """
+        # Preprocess events to remove reasoning traces from BotMessage events
+        processed_events = self._preprocess_events_for_prompt(events)
 
         template = self.env.from_string(template_str)
 
@@ -176,7 +244,7 @@ class LLMTaskManager:
 
         # This is the context that will be passed to the template when rendering.
         render_context = {
-            "history": events,
+            "history": processed_events,
             "general_instructions": self._get_general_instructions(),
             "sample_conversation": self.config.sample_conversation,
             "sample_conversation_two_turns": self.config.sample_conversation,
@@ -339,8 +407,11 @@ class LLMTaskManager:
 
             return task_prompt
         else:
+            # Process events to clean up reasoning traces
+            processed_events = self._preprocess_events_for_prompt(events)
+
             task_messages = self._render_messages(
-                prompt.messages, context=context, events=events
+                prompt.messages, context=context, events=processed_events
             )
             task_prompt_length = self._get_messages_text_length(task_messages)
             while task_prompt_length > prompt.max_length:
@@ -350,8 +421,9 @@ class LLMTaskManager:
                     )
                 # Remove events from the beginning of the history until the prompt fits.
                 events = events[1:]
+                processed_events = self._preprocess_events_for_prompt(events)
                 task_messages = self._render_messages(
-                    prompt.messages, context=context, events=events
+                    prompt.messages, context=context, events=processed_events
                 )
                 task_prompt_length = self._get_messages_text_length(task_messages)
             return task_messages

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -444,6 +444,15 @@ class OutputRails(BaseModel):
         description="Configuration for streaming output rails.",
     )
 
+    apply_to_reasoning_traces: bool = Field(
+        default=False,
+        description=(
+            "If True, output rails will apply guardrails to both reasoning traces and output response. "
+            "If False, output rails will only apply guardrails to the output response excluding the reasoning traces, "
+            "thus keeping reasoning traces unaltered."
+        ),
+    )
+
 
 class RetrievalRails(BaseModel):
     """Configuration of retrieval rails."""
@@ -1199,11 +1208,10 @@ class RailsConfig(BaseModel):
         ]
 
         # dialog rails are activated (explicitly or implicitly)
-        has_dialog_rails = (
-            bool(dialog_rails)
-            or bool(values.get("user_messages"))
-            or bool(values.get("bot_messages"))
-            or bool(values.get("flows"))
+        has_dialog_rails = bool(dialog_rails) or (
+            bool(values.get("user_messages"))
+            and bool(values.get("bot_messages"))
+            # and bool(values.get("flows"))
         )
 
         if has_dialog_rails:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -31,7 +31,10 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.language_models.llms import BaseLLM
 
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
-from nemoguardrails.actions.llm.utils import get_colang_history
+from nemoguardrails.actions.llm.utils import (
+    get_and_clear_reasoning_trace_contextvar,
+    get_colang_history,
+)
 from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
 from nemoguardrails.colang import parse_colang_file
@@ -48,6 +51,7 @@ from nemoguardrails.context import (
     generation_options_var,
     llm_stats_var,
     raw_llm_request,
+    reasoning_trace_var,
     streaming_handler_var,
 )
 from nemoguardrails.embeddings.index import EmbeddingsIndex
@@ -846,6 +850,14 @@ class LLMRails:
             else:
                 res = GenerationResponse(response=[new_message])
 
+            if reasoning_trace := get_and_clear_reasoning_trace_contextvar():
+                if prompt:
+                    res.response = reasoning_trace + res.response
+                else:
+                    res.response[0]["content"] = (
+                        reasoning_trace + res.response[0]["content"]
+                    )
+
             if self.config.colang_version == "1.0":
                 # If output variables are specified, we extract their values
                 if options.output_vars:
@@ -940,9 +952,14 @@ class LLMRails:
                     input=messages, response=res, adapters=self._log_adapters
                 )
                 await tracer.export_async()
+
             return res
         else:
             # If a prompt is used, we only return the content of the message.
+
+            if reasoning_trace := get_and_clear_reasoning_trace_contextvar():
+                new_message["content"] = reasoning_trace + new_message["content"]
+
             if prompt:
                 return new_message["content"]
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,27 @@ from unittest.mock import patch
 
 import pytest
 
+from nemoguardrails.context import reasoning_trace_var
+
 
 def pytest_configure(config):
     patch("prompt_toolkit.PromptSession", autospec=True).start()
+
+
+@pytest.fixture(autouse=True)
+def reset_reasoning_trace():
+    """Reset the reasoning_trace_var before each test.
+
+    This fixture runs automatically for every test (autouse=True) to ensure
+    a clean state for the reasoning trace context variable.
+
+    current Issues with ContextVar approach, not only specific to this case:
+        global State: ContextVar creates global state that's hard to track and manage
+        implicit Flow: The reasoning trace flows through the system in a non-obvious way
+        testing Complexity:  It causes test isolation problems that we are trying to avoid using this fixture
+    """
+    # reset the variable before the test
+    reasoning_trace_var.set(None)
+    yield
+    # reset the variable after the test as well (in case the test fails)
+    reasoning_trace_var.set(None)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -289,12 +289,16 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_thinking_traces: False
             """,
             colang_content="""
             define flow
               user express greeting
               bot express greeting
+            define user express greeting
+                "hi"
+            define bot express greeting
+                "HI HI"
             """,
         )
 
@@ -313,63 +317,39 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
 def test_reasoning_traces_with_implicit_dialog_rails_user_messages_only():
     """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru user messages only."""
 
-    with pytest.raises(ValueError) as exc_info:
-        _ = RailsConfig.from_content(
-            yaml_content="""
-            models:
-              - type: main
-                engine: openai
-                model: gpt-3.5-turbo-instruct
-                reasoning_config:
-                  remove_thinking_traces: false
-            """,
-            colang_content="""
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+        - type: main
+          engine: openai
+          model: gpt-3.5-turbo-instruct
+          reasoning_config:
+              remove_thinking_traces: False
+        """,
+        colang_content="""
             define user express greeting
               "hello"
               "hi"
-            """,
-        )
-
-    assert "Main model has reasoning traces enabled in config.yml" in str(
-        exc_info.value
-    )
-    assert "Reasoning traces must be disabled when dialog rails are present" in str(
-        exc_info.value
-    )
-    assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
-        in str(exc_info.value)
+        """,
     )
 
 
-def test_reasoning_traces_with_implicit_dialog_rails_bot_messages_only():
-    """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled thru bot messages only."""
+def test_reasoning_traces_with_bot_messages_only():
+    """Test that reasoning taces can exist with bot messages only."""
 
-    with pytest.raises(ValueError) as exc_info:
-        _ = RailsConfig.from_content(
-            yaml_content="""
-            models:
-              - type: main
-                engine: openai
-                model: gpt-3.5-turbo-instruct
-                reasoning_config:
-                  remove_thinking_traces: false
-            """,
-            colang_content="""
-            define bot express greeting
-              "Hello there!"
-            """,
-        )
-
-    assert "Main model has reasoning traces enabled in config.yml" in str(
-        exc_info.value
-    )
-    assert "Reasoning traces must be disabled when dialog rails are present" in str(
-        exc_info.value
-    )
-    assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
-        in str(exc_info.value)
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+        - type: main
+          engine: openai
+          model: gpt-3.5-turbo-instruct
+          reasoning_config:
+              remove_thinking_traces: False
+        """,
+        colang_content="""
+        define bot express greeting
+            "Hello there!"
+        """,
     )
 
 

--- a/tests/test_configs/with_custom_llm_prompt_action_v2_x/actions.py
+++ b/tests/test_configs/with_custom_llm_prompt_action_v2_x/actions.py
@@ -50,6 +50,7 @@ async def custom_llm_request(
         result = await llm_call(llm, prompt, stop=stop)
 
     result = llm_task_manager.parse_task_output(prompt_template_name, output=result)
+    result = result.text
 
     # Any additional parsing of the output
     value = result.strip().split("\n")[0]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -14,13 +14,16 @@
 # limitations under the License.
 
 import textwrap
+from typing import List, Tuple, Union
 
 import pytest
 
 from nemoguardrails.llm.filters import (
+    ReasoningExtractionResult,
+    extract_and_strip_trace,
+    find_reasoning_tokens_position,
     first_turns,
     last_turns,
-    remove_reasoning_traces,
     to_chat_messages,
     user_assistant_sequence,
 )
@@ -92,51 +95,228 @@ def test_last_turns():
     assert last_turns(colang_history, 2) == colang_history
 
 
+def _build_test_string(parts: List[Union[str, Tuple[str, int]]]) -> str:
+    """Builds a test string from a list of parts.
+
+    Each part can be a literal string or a (character, count) tuple.
+    Example: [("a", 3), "[START]", ("b", 5)] -> "aaa[START]bbbbb"
+    """
+    result = []
+    for part in parts:
+        if isinstance(part, str):
+            result.append(part)
+        elif isinstance(part, tuple) and len(part) == 2:
+            char, count = part
+            result.append(char * count)
+        else:
+            raise TypeError(f"Invalid part type in _build_test_string: {part}")
+    return "".join(result)
+
+
 @pytest.mark.parametrize(
     "response, start_token, end_token, expected",
+    [
+        (
+            _build_test_string(
+                [
+                    ("a", 5),
+                    "[START]",
+                    ("b", 10),
+                    "[END]",
+                    ("c", 5),
+                ]
+            ),
+            "[START]",
+            "[END]",
+            (5, 22),  # 5 a's + 7 START + 10 b = 22
+        ),
+        # multiple reasoning sections
+        (
+            _build_test_string(
+                [
+                    ("a", 3),
+                    "[START]",
+                    ("b", 4),
+                    "[END]",
+                    ("c", 3),
+                    "[START]",
+                    ("d", 4),
+                    "[END]",
+                    ("e", 3),
+                ]
+            ),
+            "[START]",
+            "[END]",
+            (
+                3,
+                33,
+            ),
+        ),
+        (
+            _build_test_string(
+                [
+                    ("a", 2),
+                    "[START]",
+                    ("b", 2),
+                    "[START]",
+                    ("c", 2),
+                    "[END]",
+                    ("d", 2),
+                    "[END]",
+                    ("e", 2),
+                ]
+            ),
+            "[START]",
+            "[END]",
+            (
+                2,
+                27,
+            ),
+        ),
+        (
+            _build_test_string([("a", 10)]),
+            "[START]",
+            "[END]",
+            (0, -1),  # no tokens found, start_index is 0
+        ),
+        (
+            _build_test_string(
+                [
+                    ("a", 5),
+                    "[START]",
+                    ("b", 5),
+                ]
+            ),
+            "[START]",
+            "[END]",
+            (5, -1),  # [START] at pos 5, no end token
+        ),
+        (
+            _build_test_string(
+                [
+                    ("a", 5),
+                    "[END]",
+                    ("b", 5),
+                ]
+            ),
+            "[START]",
+            "[END]",
+            (0, 5),  # no start token so 0, end at pos 5
+        ),
+        (
+            "",
+            "[START]",
+            "[END]",
+            (0, -1),  # empty string, start_index is 0
+        ),
+    ],
+)
+def test_find_token_positions_for_removal(response, start_token, end_token, expected):
+    """Test finding token positions for removal.
+
+    Test cases use _build_test_string for clarity and mathematical obviousness.
+    """
+    assert find_reasoning_tokens_position(response, start_token, end_token) == expected
+
+
+@pytest.mark.parametrize(
+    "response, start_token, end_token, expected_text, expected_trace",
     [
         (
             "This is an example [START]hidden reasoning[END] of a response.",
             "[START]",
             "[END]",
             "This is an example  of a response.",
+            "[START]hidden reasoning[END]",
         ),
         (
-            "This is an example without an end token.",
-            "[START]",
-            "[END]",
-            "This is an example without an end token.",
-        ),
-        (
-            "This is an example [START] with a start token but no end token.",
-            "[START]",
-            "[END]",
-            "This is an example [START] with a start token but no end token.",
-        ),
-        (
-            "Before [START]hidden[END] middle [START]extra hidden[END] after.",
+            "Before [START]first[END] middle [START]second[END] after.",
             "[START]",
             "[END]",
             "Before  after.",
+            "[START]first[END] middle [START]second[END]",
         ),
         (
             "Text [START] first [START] nested [END] second [END] more text.",
             "[START]",
             "[END]",
             "Text  more text.",
+            "[START] first [START] nested [END] second [END]",
         ),
         (
-            "[START]Remove this[END] but keep this.",
+            "No tokens here",
             "[START]",
             "[END]",
-            " but keep this.",
+            "No tokens here",
+            None,
         ),
-        ("", "[START]", "[END]", ""),
+        (
+            "Only [START] start token",
+            "[START]",
+            "[END]",
+            "Only [START] start token",
+            None,
+        ),
+        (
+            "Only end token [END]",
+            "[START]",
+            "[END]",
+            "",
+            "Only end token [END]",
+        ),
+        (
+            "",
+            "[START]",
+            "[END]",
+            "",
+            None,
+        ),
+        # End token before start token (tests the final return path)
+        (
+            "some [END] text [START]",
+            "[START]",
+            "[END]",
+            "some [END] text [START]",
+            None,
+        ),
+        # Original test cases adapted
+        (
+            "[END] Out of order [START] tokens [END] example.",
+            "[START]",
+            "[END]",
+            "[END] Out of order  example.",
+            "[START] tokens [END]",
+        ),
+        (
+            "[START] nested [START] tokens [END] out of [END] order.",
+            "[START]",
+            "[END]",
+            " order.",
+            "[START] nested [START] tokens [END] out of [END]",
+        ),
+        (
+            "[END] [START] [START] example [END] text.",
+            "[START]",
+            "[END]",
+            "[END]  text.",
+            "[START] [START] example [END]",
+        ),
+        (
+            "example text.",
+            "[START]",
+            "[END]",
+            "example text.",
+            None,
+        ),
     ],
 )
-def test_remove_reasoning_traces(response, start_token, end_token, expected):
-    """Test removal of text between start and end tokens with multiple cases."""
-    assert remove_reasoning_traces(response, start_token, end_token) == expected
+def test_extract_and_strip_trace(
+    response, start_token, end_token, expected_text, expected_trace
+):
+    """Tests the extraction and stripping of reasoning traces."""
+    result = extract_and_strip_trace(response, start_token, end_token)
+    assert result.text == expected_text
+    assert result.reasoning_trace == expected_trace
 
 
 class TestToChatMessages:

--- a/tests/test_llm_task_manager.py
+++ b/tests/test_llm_task_manager.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import textwrap
 
 import pytest
@@ -295,3 +296,164 @@ def test_stop_configuration_parameter():
     # Check if the stop tokens are correctly set in the rendered prompt
     for stop_token in expected_stop_tokens:
         assert stop_token in task_prompt.stop
+
+
+def test_preprocess_events_removes_reasoning_traces():
+    """Test that reasoning traces are removed from bot messages in rendered prompts."""
+    config = RailsConfig.from_content(
+        yaml_content=textwrap.dedent(
+            """
+            models:
+             - type: main
+               engine: openai
+               model: gpt-3.5-turbo-instruct
+               reasoning_config:
+                 start_token: "<think>"
+                 end_token: "</think>"
+            rails:
+             output:
+               apply_to_reasoning_traces: true
+            prompts:
+             - task: generate_user_intent
+               content: |-
+                 {% if examples %}{{ examples }}{% endif %}
+                 {{ history | colang }}
+                 user "{{ user_input }}"
+                 user intent:
+            """
+        )
+    )
+
+    llm_task_manager = LLMTaskManager(config)
+
+    events = [
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Hello"},
+        {
+            "type": "StartUtteranceBotAction",
+            "script": "<think>Let me think how to respond some crazy COT</think>Hi there!",
+        },
+        {"type": "UtteranceUserActionFinished", "final_transcript": "How are you?"},
+    ]
+
+    rendered_prompt = llm_task_manager.render_task_prompt(
+        task=Task.GENERATE_USER_INTENT,
+        context={"user_input": "How are you?", "examples": ""},
+        events=events,
+    )
+
+    assert isinstance(rendered_prompt, str)
+
+    assert "<think>" not in rendered_prompt
+    assert "</think>" not in rendered_prompt
+    assert "Let me think how to respond..." not in rendered_prompt
+
+    assert "Hi there!" in rendered_prompt
+
+
+def test_preprocess_events_preserves_original_events():
+    """Test that _preprocess_events_for_prompt doesn't modify the original events."""
+    config = RailsConfig.from_content(
+        yaml_content=textwrap.dedent(
+            """
+            models:
+             - type: main
+               engine: openai
+               model: gpt-3.5-turbo-instruct
+               reasoning_config:
+                 start_token: "<think>"
+                 end_token: "</think>"
+            rails:
+             output:
+               apply_to_reasoning_traces: true
+            """
+        )
+    )
+
+    llm_task_manager = LLMTaskManager(config)
+
+    original_events = [
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Hello"},
+        {
+            "type": "StartUtteranceBotAction",
+            "script": "<think>Let me think how to respond some crazy COT</think>Hi there!",
+        },
+        {"type": "UtteranceUserActionFinished", "final_transcript": "How are you?"},
+    ]
+
+    events_copy = copy.deepcopy(original_events)
+
+    processed_events = llm_task_manager._preprocess_events_for_prompt(events_copy)
+
+    assert events_copy == original_events
+
+    assert "<think>" not in processed_events[1]["script"]
+    assert "</think>" not in processed_events[1]["script"]
+    assert processed_events[1]["script"] == "Hi there!"
+
+
+def test_reasoning_traces_not_included_in_prompt_history():
+    """Test that reasoning traces don't get included in prompt history for subsequent LLM calls."""
+    config = RailsConfig.from_content(
+        yaml_content=textwrap.dedent(
+            """
+            models:
+             - type: main
+               engine: openai
+               model: gpt-3.5-turbo-instruct
+               reasoning_config:
+                 start_token: "<think>"
+                 end_token: "</think>"
+            rails:
+             output:
+               apply_to_reasoning_traces: true
+            prompts:
+             - task: generate_user_intent
+               content: |-
+                 {% if examples %}{{ examples }}{% endif %}
+                 Previous conversation:
+                 {{ history | colang }}
+
+                 Current user message:
+                 user "{{ user_input }}"
+                 user intent:
+            """
+        )
+    )
+
+    llm_task_manager = LLMTaskManager(config)
+
+    events = [
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Hello"},
+        {
+            "type": "StartUtteranceBotAction",
+            "script": "<think>I should greet the user back.</think>Hi there!",
+        },
+        {
+            "type": "UtteranceUserActionFinished",
+            "final_transcript": "What's the weather like?",
+        },
+        {
+            "type": "StartUtteranceBotAction",
+            "script": "<think>I should explain I don't have real-time weather data.</think>I don't have access to real-time weather information.",
+        },
+        {"type": "UtteranceUserActionFinished", "final_transcript": "Tell me about AI"},
+    ]
+
+    rendered_prompt = llm_task_manager.render_task_prompt(
+        task=Task.GENERATE_USER_INTENT,
+        context={"user_input": "Tell me about AI", "examples": ""},
+        events=events,
+    )
+
+    assert isinstance(rendered_prompt, str)
+
+    assert "<think>I should greet the user back.</think>" not in rendered_prompt
+    assert (
+        "<think>I should explain I don't have real-time weather data.</think>"
+        not in rendered_prompt
+    )
+
+    assert (
+        "Hi there!" in rendered_prompt
+        or "I don't have access to real-time weather information." in rendered_prompt
+    )

--- a/tests/test_llmrails_reasoning.py
+++ b/tests/test_llmrails_reasoning.py
@@ -69,10 +69,10 @@ def rails_config():
 async def test_1(rails_config):
     llm = FakeLLM(
         responses=[
-            "<think>some text</think>\n  express greeting",
-            "<think>some text</think>\n  ask math question",
-            '<think>some text</think>\n  "The answer is 5"',
-            '<think>some text</think>\n  "Are you happy with the result?"',
+            "<think>some redundant CoT text 1</think>\n  express greeting",
+            "<think>some redundant CoT text 2</think>\n  ask math question",
+            '<think>some redundant CoT text 3</think>\n  "The answer is 5"',
+            '<think>some important COT text</think>\n  "Are you happy with the result?"',
         ]
     )
 
@@ -92,5 +92,5 @@ async def test_1(rails_config):
     bot_message = await llm_rails.generate_async(messages=messages)
     assert bot_message == {
         "role": "assistant",
-        "content": "The answer is 5\nAre you happy with the result?",
+        "content": "<think>some important COT text</think>The answer is 5\nAre you happy with the result?",
     }

--- a/tests/test_llmrails_reasoning_output_rails.py
+++ b/tests/test_llmrails_reasoning_output_rails.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for LLM Rails reasoning output configuration and behavior.
+
+This module contains tests that verify the behavior of LLM Rails when handling
+reasoning traces in the output, including configuration options and guardrail
+behavior.
+"""
+
+from typing import Any, Dict, NamedTuple
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+
+class ReasoningTraceTestCase(NamedTuple):
+    """Test case for reasoning trace configuration.
+
+    Attributes:
+        description: description of the test case
+        remove_thinking_traces: Whether to remove thinking traces in the model config
+        apply_to_reasoning_traces: Whether to apply output rails to reasoning traces
+        expected_think_tag: Whether the think tag should be present in the response
+        expected_error_message: Whether the error message should be present in the response
+    """
+
+    description: str
+    remove_thinking_traces: bool
+    apply_to_reasoning_traces: bool
+    expected_think_tag: bool
+    expected_error_message: bool
+
+
+async def check_sensitive_info(context: Dict[str, Any]) -> bool:
+    """Check if the response contains sensitive information."""
+    response = context.get("bot_message", "")
+    prompt = context.get("user_message", "")
+    input_text = response or prompt
+    return "credit card" in input_text.lower() or any(
+        c.isdigit() for c in input_text if c.isdigit() or c == "-"
+    )
+
+
+async def check_think_tag_present(context: Dict[str, Any]) -> bool:
+    """Check if the think tag is present in the bot's response."""
+    response = context.get("bot_message", "")
+    return "<think>" in response
+
+
+@pytest.fixture
+def base_config() -> RailsConfig:
+    """Creates a base RailsConfig with common test configuration."""
+    return RailsConfig.from_content(
+        colang_content="""
+        define flow check think tag
+            $not_allowed = execute check_think_tag_present
+            if $not_allowed
+                bot informs tag not allowed
+                stop
+
+        define bot informs tag not allowed
+            "think tag is not allowed it must be removed"
+        """,
+        yaml_content="""
+        models:
+          - type: main
+            engine: fake
+            model: fake
+        colang_version: "1.0"
+        rails:
+          output:
+            flows:
+              - check think tag
+        """,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ReasoningTraceTestCase(
+            description="Remove thinking traces and show error when guardrail is enabled",
+            remove_thinking_traces=True,
+            apply_to_reasoning_traces=True,
+            expected_think_tag=True,
+            expected_error_message=True,
+        ),
+        ReasoningTraceTestCase(
+            description="Preserve thinking traces and hide error when guardrail is disabled",
+            remove_thinking_traces=True,
+            apply_to_reasoning_traces=False,
+            expected_think_tag=True,
+            expected_error_message=False,
+        ),
+        ReasoningTraceTestCase(
+            description="Preserve thinking traces and show error when guardrail is enabled",
+            remove_thinking_traces=False,
+            apply_to_reasoning_traces=True,
+            expected_think_tag=True,
+            expected_error_message=True,
+        ),
+        ReasoningTraceTestCase(
+            description="Remove thinking traces and show error when both flags are disabled",
+            remove_thinking_traces=False,
+            apply_to_reasoning_traces=False,
+            expected_think_tag=True,
+            expected_error_message=True,
+        ),
+    ],
+    ids=lambda tc: tc.description,
+)
+async def test_output_rails_reasoning_traces_configuration(
+    base_config: RailsConfig,
+    test_case: ReasoningTraceTestCase,
+) -> None:
+    """Test output rails with different reasoning traces configurations.
+
+    The test verifies the following behaviors based on configuration:
+
+    1. When remove_thinking_traces=True:
+       - The model is configured to remove thinking traces
+       - However, the actual removal depends on apply_to_reasoning_traces
+
+    2. When apply_to_reasoning_traces=True:
+       - The output rail will check for and report think tags
+       - Because we expect the think tag to be present as output rails explicitly requires it
+
+    3. When apply_to_reasoning_traces=False:
+       - The output rails will check for think tags
+       - No error message will be shown because it is not there to get blocked
+
+    """
+    base_config.models[
+        0
+    ].reasoning_config.remove_thinking_traces = test_case.remove_thinking_traces
+    base_config.rails.output.apply_to_reasoning_traces = (
+        test_case.apply_to_reasoning_traces
+    )
+
+    chat = TestChat(
+        base_config,
+        llm_completions=[
+            "<think> I should think more </think> Your kindness is appreciated"
+        ],
+    )
+
+    chat.app.runtime.register_action(check_think_tag_present)
+
+    messages = [{"role": "user", "content": "you are nice"}]
+    response = await chat.app.generate_async(messages=messages)
+
+    if test_case.expected_think_tag:
+        assert (
+            "<think>" in response["content"]
+        ), "Think tag should be present in response"
+    else:
+        assert (
+            "<think>" not in response["content"]
+        ), "Think tag should not be present in response"
+
+    if test_case.expected_error_message:
+        assert (
+            "think tag is not allowed" in response["content"]
+        ), "Error message should be present"
+    else:
+        assert (
+            "think tag is not allowed" not in response["content"]
+        ), "Error message should not be present"
+
+
+@pytest.mark.asyncio
+async def test_output_rails_preserves_reasoning_traces() -> None:
+    """Test that output rails preserve reasoning traces when configured to do so."""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define flow check sensitive info
+            $not_allowed = execute check_sensitive_info
+            if $not_allowed
+                bot provide sanitized response
+                stop
+        define bot provide sanitized response
+            "I cannot share sensitive information."
+        """,
+        yaml_content="""
+        models:
+          - type: main
+            engine: fake
+            model: fake
+            reasoning_config:
+              remove_thinking_traces: True
+        colang_version: "1.0"
+        rails:
+          output:
+            flows:
+              - check sensitive info
+            apply_to_reasoning_traces: True
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            '<think> I should not share sensitive info </think>\n  "Here is my credit card: 1234-5678-9012-3456"',
+        ],
+    )
+
+    chat.app.runtime.register_action(check_sensitive_info)
+
+    messages = [{"role": "user", "content": "What's your credit card number?"}]
+    response = await chat.app.generate_async(messages=messages)
+
+    assert "<think>" in response["content"], "Reasoning traces should be preserved"
+    assert (
+        "I should not share sensitive info" in response["content"]
+    ), "Reasoning content should be preserved"
+    assert (
+        "credit card" not in response["content"].lower()
+    ), "Sensitive information should be removed"
+
+
+@pytest.mark.asyncio
+async def test_output_rails_without_reasoning_traces() -> None:
+    """Test that output rails properly handle responses when reasoning traces are disabled."""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define flow check sensitive info
+            $not_allowed = execute check_sensitive_info
+            if $not_allowed
+                bot provide sanitized response
+                stop
+        define flow check think tag
+            $not_allowed = execute check_think_tag_present
+            if $not_allowed
+                bot says tag not allowed
+                stop
+
+        define bot says tag not allowed
+            "<think> tag is not allowed it must be removed"
+
+        define bot provide sanitized response
+            "I cannot share sensitive information."
+        """,
+        yaml_content="""
+        models:
+          - type: main
+            engine: fake
+            model: fake
+            reasoning_config:
+              remove_thinking_traces: True
+        colang_version: "1.0"
+        rails:
+          input:
+            flows:
+              - check sensitive info
+          output:
+            flows:
+              - check sensitive info
+              - check think tag
+            apply_to_reasoning_traces: false
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "<think> I should think more </think> Your credit card number is 1234-5678-9012-3456",
+        ],
+    )
+
+    chat.app.runtime.register_action(check_sensitive_info)
+    chat.app.runtime.register_action(check_think_tag_present)
+
+    # case 1: Sensitive information is blocked by input rail
+    messages = [{"role": "user", "content": "What's your credit card number?"}]
+    response = await chat.app.generate_async(messages=messages)
+
+    assert "<think>" not in response["content"], "Think tag should not be present"
+    assert (
+        "I should not share sensitive info" not in response["content"]
+    ), "Reasoning content should not be present"
+    assert (
+        response["content"] == "I cannot share sensitive information."
+    ), "Should return sanitized response"
+
+    # case 2: Think tag is preserved but content is sanitized
+    messages = [{"role": "user", "content": "Tell me some numbers"}]
+    response = await chat.app.generate_async(messages=messages)
+
+    assert "<think>" in response["content"], "Think tag should be present"
+    assert (
+        "I should not share sensitive info" not in response["content"]
+    ), "Reasoning content should not be present"
+    assert (
+        response["content"]
+        == "<think> I should think more </think>I cannot share sensitive information."
+    ), "Should preserve think tag but sanitize content"

--- a/tests/test_reasoning_trace_context.py
+++ b/tests/test_reasoning_trace_context.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions.llm.utils import get_and_clear_reasoning_trace_contextvar
+from nemoguardrails.context import reasoning_trace_var
+from nemoguardrails.rails.llm.llmrails import GenerationOptions, GenerationResponse
+from tests.utils import TestChat
+
+
+def test_get_and_clear_reasoning_trace_contextvar():
+    """Test that it correctly gets and clears the trace."""
+    reasoning_trace_var.set("<think> oh COT again </think>")
+
+    result = get_and_clear_reasoning_trace_contextvar()
+
+    assert result == "<think> oh COT again </think>"
+    assert reasoning_trace_var.get() is None
+
+
+def test_get_and_clear_reasoning_trace_contextvar_empty():
+    """Test that it returns None when no trace exists."""
+    reasoning_trace_var.set(None)
+
+    result = get_and_clear_reasoning_trace_contextvar()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_trace_with_messages_and_options():
+    """Test generate_async prepends reasoning trace when using generation options and messages."""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define user express greeting
+            "hi"
+            "hello"
+
+        define bot express greeting
+            "Hello! How can I assist you today?"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """,
+        yaml_content="""
+        models: []
+        rails:
+          output:
+            apply_to_reasoning_traces: true
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "user express greeting",
+            "bot express greeting",
+            "Hello! How can I assist you today?",
+        ],
+    )
+
+    reasoning_trace_var.set("<think> yet another COT </think>")
+
+    options = GenerationOptions()
+    result = await chat.app.generate_async(
+        messages=[{"role": "user", "content": "hi"}], options=options
+    )
+
+    assert isinstance(result, GenerationResponse)
+    assert isinstance(result.response, list)
+    assert len(result.response) == 1
+    assert (
+        result.response[0]["content"]
+        == "<think> yet another COT </think>Hello! How can I assist you today?"
+    )
+    assert reasoning_trace_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_trace_with_prompt_and_options():
+    """Test generate_async prepends reasoning trace using prompt and options"""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define user express greeting
+            "hi"
+            "hello"
+
+        define bot express greeting
+            "Hello! How can I assist you today?"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """,
+        yaml_content="""
+        models: []
+        rails:
+          output:
+            apply_to_reasoning_traces: true
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "user express greeting",
+            "bot express greeting",
+            "Hello! How can I assist you today?",
+        ],
+    )
+
+    reasoning_trace_var.set("<think> yet another COT </think>")
+
+    options = GenerationOptions()
+    result = await chat.app.generate_async(options=options, prompt="test prompt")
+
+    assert isinstance(result, GenerationResponse)
+    assert isinstance(result.response, str)
+    assert (
+        result.response
+        == "<think> yet another COT </think>Hello! How can I assist you today?"
+    )
+    assert reasoning_trace_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_trace_messages_only():
+    """Test generate_async prepends reasoning trace when using only messages."""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define user express greeting
+            "hi"
+            "hello"
+
+        define bot express greeting
+            "Hello! How can I assist you today?"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """,
+        yaml_content="""
+        models: []
+        rails:
+          output:
+            apply_to_reasoning_traces: true
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "user express greeting",
+            "bot express greeting",
+            "Hello! How can I assist you today?",
+        ],
+    )
+
+    reasoning_trace_var.set("<think> yet another COT </think>")
+
+    result = await chat.app.generate_async(messages=[{"role": "user", "content": "hi"}])
+
+    assert isinstance(result, dict)
+    assert result.get("role") == "assistant"
+    assert (
+        result.get("content")
+        == "<think> yet another COT </think>Hello! How can I assist you today?"
+    )
+    assert reasoning_trace_var.get() is None
+
+
+@pytest.mark.asyncio
+async def test_generate_async_trace_with_prompt_only():
+    """Test generate_async prepends reasoning trace when using prompt."""
+    config = RailsConfig.from_content(
+        colang_content="""
+        define user express greeting
+            "hi"
+            "hello"
+
+        define bot express greeting
+            "Hello! How can I assist you today?"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """,
+        yaml_content="""
+        models: []
+        rails:
+          output:
+            apply_to_reasoning_traces: true
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "user express greeting",
+            "bot express greeting",
+            "Hello! How can I assist you today?",
+        ],
+    )
+
+    reasoning_trace_var.set("<think> yet another COT </think>")
+
+    result = await chat.app.generate_async(prompt="hi")
+
+    assert (
+        result == "<think> yet another COT </think>Hello! How can I assist you today?"
+    )
+    assert reasoning_trace_var.get() is None


### PR DESCRIPTION
This change addresses an issue where reasoning traces (like <think>...</think>) from previous bot messages were included in the prompt history for subsequent LLM calls when rails.output.apply_to_reasoning_traces=true was enabled.

The fix adds event preprocessing in LLMTaskManager to strip reasoning traces from both BotMessage.text and StartUtteranceBotAction.script fields before including them in prompt rendering, preventing the LLM from seeing its own internal reasoning from previous turns.

Comprehensive tests were added to verify:
1. Preprocessing doesn't modify original events
2. Reasoning traces are properly removed from prompt history
3. The clean bot messages are still included in rendered prompt