### PR TITLE
fix: allow reasoning traces when embeddings_only is True

### DIFF
--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1207,12 +1207,21 @@ class RailsConfig(BaseModel):
             Task.GENERATE_INTENT_STEPS_MESSAGE,
         ]
 
-        # dialog rails are activated (explicitly or implicitly)
-        has_dialog_rails = bool(dialog_rails) or (
-            bool(values.get("user_messages"))
-            and bool(values.get("bot_messages"))
-            # and bool(values.get("flows"))
+        embeddings_only = dialog_rails.get("user_messages", {}).get(
+            "embeddings_only", False
         )
+
+        has_dialog_rail_configs = (
+            bool(values.get("user_messages"))
+            or bool(values.get("bot_messages"))
+            or bool(values.get("flows"))
+        )
+
+        # dialog rails are activated (explicitly or implicitly) and require validation
+        # skip validation when embeddings_only is True
+        has_dialog_rails = (
+            bool(dialog_rails) or has_dialog_rail_configs
+        ) and not embeddings_only
 
         if has_dialog_rails:
             main_model = next(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -317,39 +317,49 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
 def test_reasoning_traces_with_implicit_dialog_rails_user_messages_only():
     """Test that reasoning traces cannot be enabled when dialog rails are implicitly enabled through user messages (user canonical forms) only."""
 
-    _ = RailsConfig.from_content(
-        yaml_content="""
-        models:
-        - type: main
-          engine: openai
-          model: gpt-3.5-turbo-instruct
-          reasoning_config:
-              remove_thinking_traces: false
-        """,
-        colang_content="""
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+              - type: main
+                engine: openai
+                model: gpt-3.5-turbo-instruct
+                reasoning_config:
+                  remove_thinking_traces: false
+            """,
+            colang_content="""
             define user express greeting
-              "hello"
-              "hi"
-        """,
+                "hello"
+                "hi"
+            """,
+        )
+
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
     )
 
 
 def test_reasoning_traces_with_bot_messages_only():
-    """Test that reasoning traces can exist with bot messages only."""
+    """Test that reasoning traces cannot be enabled when bot messages are present."""
 
-    _ = RailsConfig.from_content(
-        yaml_content="""
-        models:
-        - type: main
-          engine: openai
-          model: gpt-3.5-turbo-instruct
-          reasoning_config:
-              remove_thinking_traces: False
-        """,
-        colang_content="""
-        define bot express greeting
-            "Hello there!"
-        """,
+    with pytest.raises(ValueError) as exc_info:
+        _ = RailsConfig.from_content(
+            yaml_content="""
+            models:
+            - type: main
+              engine: openai
+              model: gpt-3.5-turbo-instruct
+              reasoning_config:
+                  remove_thinking_traces: False
+            """,
+            colang_content="""
+            define bot express greeting
+                "Hello there!"
+            """,
+        )
+
+    assert "Reasoning traces must be disabled when dialog rails are present" in str(
+        exc_info.value
     )
 
 
@@ -579,4 +589,51 @@ def test_reasoning_traces_with_partial_dedicated_models():
     assert (
         "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
         in str(exc_info.value)
+    )
+
+
+def test_reasoning_traces_with_implicit_dialog_rails_embeddings_only():
+    """Test that reasoning traces can be enabled when embeddings_only is True, even with user messages."""
+
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+        - type: main
+          engine: openai
+          model: gpt-3.5-turbo-instruct
+          reasoning_config:
+              remove_thinking_traces: False
+        rails:
+          dialog:
+            user_messages:
+              embeddings_only: True
+        """,
+        colang_content="""
+        define user express greeting
+            "hello"
+            "hi"
+        """,
+    )
+
+
+def test_reasoning_traces_with_bot_messages_embeddings_only():
+    """Test that reasoning traces can be enabled when embeddings_only is True, even with bot messages."""
+
+    _ = RailsConfig.from_content(
+        yaml_content="""
+        models:
+        - type: main
+          engine: openai
+          model: gpt-3.5-turbo-instruct
+          reasoning_config:
+              remove_thinking_traces: False
+        rails:
+          dialog:
+            user_messages:
+              embeddings_only: True
+        """,
+        colang_content="""
+        define bot express greeting
+            "Hello there!"
+        """,
     )


### PR DESCRIPTION
Refactors the dialog rails validation logic to properly respect the embeddings_only flag, allowing reasoning traces to be enabled when this flag is set to True. Adds tests to verify this behavior.

related to #1161 and #1137 