### PR TITLE
feat(config): rename `remove_thinking_traces`

### DIFF
--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -103,6 +103,7 @@ nemoguardrails find-providers [--list]
 ```
 
 The command supports two modes:
+
 - Interactive mode (default): Guides you through selecting a provider type (text completion or chat completion) and then shows available providers for that type
 - List mode (`--list`): Simply lists all available providers without interactive selection
 
@@ -126,7 +127,7 @@ models:
     engine: deepseek
     model: deepseek-reasoner
     reasoning_config:
-      remove_thinking_traces: True
+      remove_reasoning_traces: True
       start_token: "<think>"
       end_token: "</think>"
 ```
@@ -136,7 +137,7 @@ By removing the traces, the guardrails runtime processes only the actual respons
 
 You can specify the following parameters for a reasoning model:
 
-- `remove_thinking_traces`: if the reasoning traces should be ignored (default `True`).
+- `remove_reasoning_traces`: if the reasoning traces should be ignored (default `True`).
 - `start_token`: the start token for the reasoning process (default `<think>`).
 - `end_token`: the end token for the reasoning process (default `</think>`).
 

--- a/examples/configs/llm/deepseek-r1/config.yml
+++ b/examples/configs/llm/deepseek-r1/config.yml
@@ -3,6 +3,6 @@ models:
     engine: deepseek
     model: deepseek-reasoner
     reasoning_config:
-      remove_thinking_traces: True
+      remove_reasoning_traces: True
       start_token: "<think>"
       end_token: "</think>"

--- a/nemoguardrails/llm/taskmanager.py
+++ b/nemoguardrails/llm/taskmanager.py
@@ -83,7 +83,7 @@ def should_remove_reasoning_traces_from_output(config, task):
     model_config = (
         model
         and model.reasoning_config
-        and model.reasoning_config.remove_thinking_traces
+        and model.reasoning_config.remove_reasoning_traces
     )
 
     if config.rails.output.apply_to_reasoning_traces:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -71,9 +71,13 @@ colang_path_dirs.append(guardrails_stdlib_path)
 class ReasoningModelConfig(BaseModel):
     """Configuration for reasoning models/LLMs, including start and end tokens for reasoning traces."""
 
-    remove_thinking_traces: Optional[bool] = Field(
+    remove_reasoning_traces: Optional[bool] = Field(
         default=True,
-        description="For reasoning models (e.g. DeepSeek-r1), if the output parser should remove thinking traces.",
+        description="For reasoning models (e.g. DeepSeek-r1), if the output parser should remove reasoning traces.",
+    )
+    remove_thinking_traces: Optional[bool] = Field(
+        default=None,
+        description="[DEPRECATED] Use remove_reasoning_traces instead. For reasoning models (e.g. DeepSeek-r1), if the output parser should remove thinking traces.",
     )
     start_token: Optional[str] = Field(
         default="<think>",
@@ -83,6 +87,21 @@ class ReasoningModelConfig(BaseModel):
         default="</think>",
         description="The end token used for reasoning traces.",
     )
+
+    @model_validator(mode="after")
+    def handle_deprecated_field(self) -> "ReasoningModelConfig":
+        """Handle the deprecated remove_thinking_traces field."""
+        if self.remove_thinking_traces is not None:
+            import warnings
+
+            warnings.warn(
+                "The 'remove_thinking_traces' field is deprecated and will be removed in 0.15.0 version. "
+                "Please use 'remove_reasoning_traces' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.remove_reasoning_traces = self.remove_thinking_traces
+        return self
 
 
 class Model(BaseModel):
@@ -1250,11 +1269,11 @@ class RailsConfig(BaseModel):
                         if hasattr(task_model, "reasoning_config")
                         else task_model.get("reasoning_config", {})
                     )
-                    if not reasoning_config.get("remove_thinking_traces", True):
+                    if not reasoning_config.get("remove_reasoning_traces", True):
                         violations.append(
                             f"Model '{task_model.get('type')}' has reasoning traces enabled in config.yml. "
                             f"Reasoning traces must be disabled for dialog rail tasks. "
-                            f"Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config for this model."
+                            f"Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config for this model."
                         )
                 elif main_model:
                     reasoning_config = (
@@ -1262,11 +1281,11 @@ class RailsConfig(BaseModel):
                         if hasattr(main_model, "reasoning_config")
                         else main_model.get("reasoning_config", {})
                     )
-                    if not reasoning_config.get("remove_thinking_traces", True):
+                    if not reasoning_config.get("remove_reasoning_traces", True):
                         violations.append(
                             f"Main model has reasoning traces enabled in config.yml and is being used for dialog rail task '{task.value}'. "
                             f"Reasoning traces must be disabled when dialog rails are present. "
-                            f"Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config for the main model."
+                            f"Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config for the main model."
                         )
 
             if violations:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -135,7 +135,7 @@ def test_reasoning_traces_with_explicit_dialog_rails():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             rails:
               dialog:
                 single_call:
@@ -150,7 +150,7 @@ def test_reasoning_traces_with_explicit_dialog_rails():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -165,7 +165,7 @@ def test_reasoning_traces_without_dialog_rails():
             engine: openai
             model: gpt-3.5-turbo-instruct
             reasoning_config:
-              remove_thinking_traces: false
+              remove_reasoning_traces: false
         """,
     )
 
@@ -195,7 +195,7 @@ def test_input_rails_only_no_dialog_rails():
             engine: openai
             model: gpt-3.5-turbo-instruct
             reasoning_config:
-                remove_thinking_traces: false
+                remove_reasoning_traces: false
         rails:
           input:
             flows:
@@ -222,7 +222,7 @@ def test_no_dialog_tasks_with_only_output_rails():
             engine: openai
             model: gpt-3.5-turbo-instruct
             reasoning_config:
-                remove_thinking_traces: false
+                remove_reasoning_traces: false
         rails:
           output:
             flows:
@@ -250,7 +250,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_user_bot_messages():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             """,
             colang_content="""
             define user express greeting
@@ -273,7 +273,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_user_bot_messages():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -289,7 +289,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: False
             """,
             colang_content="""
             define flow
@@ -309,7 +309,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_flows_only():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -325,7 +325,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_user_messages_only():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             """,
             colang_content="""
             define user express greeting
@@ -350,7 +350,7 @@ def test_reasoning_traces_with_bot_messages_only():
               engine: openai
               model: gpt-3.5-turbo-instruct
               reasoning_config:
-                  remove_thinking_traces: False
+                  remove_reasoning_traces: False
             """,
             colang_content="""
             define bot express greeting
@@ -377,12 +377,12 @@ def test_reasoning_traces_with_dedicated_task_models():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
               - type: generate_user_intent
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             rails:
               dialog:
                 single_call:
@@ -398,7 +398,7 @@ def test_reasoning_traces_with_dedicated_task_models():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -414,7 +414,7 @@ def test_reasoning_traces_with_mixed_task_models():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
               - type: generate_bot_message
                 engine: openai
                 model: gpt-3.5-turbo-instruct
@@ -422,7 +422,7 @@ def test_reasoning_traces_with_mixed_task_models():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             rails:
               dialog:
                 single_call:
@@ -438,7 +438,7 @@ def test_reasoning_traces_with_mixed_task_models():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -457,7 +457,7 @@ def test_reasoning_traces_with_all_dialog_tasks():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
               - type: generate_user_intent
                 engine: openai
                 model: gpt-3.5-turbo-instruct
@@ -465,7 +465,7 @@ def test_reasoning_traces_with_all_dialog_tasks():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
               - type: generate_intent_steps_message
                 engine: openai
                 model: gpt-3.5-turbo-instruct
@@ -487,7 +487,7 @@ def test_reasoning_traces_with_all_dialog_tasks():
     )
     assert "Reasoning traces must be disabled for dialog rail tasks" in error_message
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in error_message
     )
 
@@ -505,12 +505,12 @@ def test_reasoning_traces_with_dedicated_models_no_dialog_rails():
             engine: openai
             model: gpt-3.5-turbo-instruct
             reasoning_config:
-              remove_thinking_traces: false
+              remove_reasoning_traces: false
           - type: generate_user_intent
             engine: openai
             model: gpt-3.5-turbo-instruct
             reasoning_config:
-              remove_thinking_traces: false
+              remove_reasoning_traces: false
         """,
     )
 
@@ -529,7 +529,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_and_dedicated_models():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
             """,
             colang_content="""
             define user express greeting
@@ -553,7 +553,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_and_dedicated_models():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -569,7 +569,7 @@ def test_reasoning_traces_with_partial_dedicated_models():
                 engine: openai
                 model: gpt-3.5-turbo-instruct
                 reasoning_config:
-                  remove_thinking_traces: false
+                  remove_reasoning_traces: false
               - type: generate_bot_message
                 engine: openai
                 model: gpt-3.5-turbo-instruct
@@ -587,7 +587,7 @@ def test_reasoning_traces_with_partial_dedicated_models():
         exc_info.value
     )
     assert (
-        "Please update your config.yml to set 'remove_thinking_traces: true' under reasoning_config"
+        "Please update your config.yml to set 'remove_reasoning_traces: true' under reasoning_config"
         in str(exc_info.value)
     )
 
@@ -602,7 +602,7 @@ def test_reasoning_traces_with_implicit_dialog_rails_embeddings_only():
           engine: openai
           model: gpt-3.5-turbo-instruct
           reasoning_config:
-              remove_thinking_traces: False
+              remove_reasoning_traces: False
         rails:
           dialog:
             user_messages:
@@ -626,7 +626,7 @@ def test_reasoning_traces_with_bot_messages_embeddings_only():
           engine: openai
           model: gpt-3.5-turbo-instruct
           reasoning_config:
-              remove_thinking_traces: False
+              remove_reasoning_traces: False
         rails:
           dialog:
             user_messages:

--- a/tests/test_llmrails_reasoning_output_rails.py
+++ b/tests/test_llmrails_reasoning_output_rails.py
@@ -33,14 +33,14 @@ class ReasoningTraceTestCase(NamedTuple):
 
     Attributes:
         description: description of the test case
-        remove_thinking_traces: Whether to remove thinking traces in the model config
+        remove_reasoning_traces: Whether to remove reasoning traces in the model config
         apply_to_reasoning_traces: Whether to apply output rails to reasoning traces
         expected_think_tag: Whether the think tag should be present in the response
         expected_error_message: Whether the error message should be present in the response
     """
 
     description: str
-    remove_thinking_traces: bool
+    remove_reasoning_traces: bool
     apply_to_reasoning_traces: bool
     expected_think_tag: bool
     expected_error_message: bool
@@ -95,29 +95,29 @@ def base_config() -> RailsConfig:
     "test_case",
     [
         ReasoningTraceTestCase(
-            description="Remove thinking traces and show error when guardrail is enabled",
-            remove_thinking_traces=True,
+            description="Remove reasoning traces and show error when guardrail is enabled",
+            remove_reasoning_traces=True,
             apply_to_reasoning_traces=True,
             expected_think_tag=True,
             expected_error_message=True,
         ),
         ReasoningTraceTestCase(
-            description="Preserve thinking traces and hide error when guardrail is disabled",
-            remove_thinking_traces=True,
+            description="Preserve reasoning traces and hide error when guardrail is disabled",
+            remove_reasoning_traces=True,
             apply_to_reasoning_traces=False,
             expected_think_tag=True,
             expected_error_message=False,
         ),
         ReasoningTraceTestCase(
-            description="Preserve thinking traces and show error when guardrail is enabled",
-            remove_thinking_traces=False,
+            description="Preserve reasoning traces and show error when guardrail is enabled",
+            remove_reasoning_traces=False,
             apply_to_reasoning_traces=True,
             expected_think_tag=True,
             expected_error_message=True,
         ),
         ReasoningTraceTestCase(
-            description="Remove thinking traces and show error when both flags are disabled",
-            remove_thinking_traces=False,
+            description="Remove reasoning traces and show error when both flags are disabled",
+            remove_reasoning_traces=False,
             apply_to_reasoning_traces=False,
             expected_think_tag=True,
             expected_error_message=True,
@@ -133,8 +133,8 @@ async def test_output_rails_reasoning_traces_configuration(
 
     The test verifies the following behaviors based on configuration:
 
-    1. When remove_thinking_traces=True:
-       - The model is configured to remove thinking traces
+    1. When remove_reasoning_traces=True:
+       - The model is configured to remove reasoning traces
        - However, the actual removal depends on apply_to_reasoning_traces
 
     2. When apply_to_reasoning_traces=True:
@@ -148,7 +148,7 @@ async def test_output_rails_reasoning_traces_configuration(
     """
     base_config.models[
         0
-    ].reasoning_config.remove_thinking_traces = test_case.remove_thinking_traces
+    ].reasoning_config.remove_reasoning_traces = test_case.remove_reasoning_traces
     base_config.rails.output.apply_to_reasoning_traces = (
         test_case.apply_to_reasoning_traces
     )
@@ -203,7 +203,7 @@ async def test_output_rails_preserves_reasoning_traces() -> None:
             engine: fake
             model: fake
             reasoning_config:
-              remove_thinking_traces: True
+              remove_reasoning_traces: True
         colang_version: "1.0"
         rails:
           output:
@@ -262,7 +262,7 @@ async def test_output_rails_without_reasoning_traces() -> None:
             engine: fake
             model: fake
             reasoning_config:
-              remove_thinking_traces: True
+              remove_reasoning_traces: True
         colang_version: "1.0"
         rails:
           input:


### PR DESCRIPTION
Renamed `remove_thinking_traces` to `remove_reasoning_traces` across the codebase for consistency. Added a deprecated field `remove_thinking_traces` with a warning to ensure backward compatibility.

- Updated documentation, tests, and configurations.
- Added a model validator to handle deprecated field usage.
- Issued deprecation warnings when `remove_thinking_traces` is used.

BREAKING CHANGE: Configurations using `remove_thinking_traces` must migrate to `remove_reasoning_traces` from 0.15.0.
