### PR TITLE
refactor(streaming): introduce END_OF_STREAM sentinel and update handling

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -74,7 +74,7 @@ from nemoguardrails.rails.llm.options import (
     GenerationResponse,
 )
 from nemoguardrails.rails.llm.utils import get_history_cache_key
-from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.utils import (
     extract_error_json,
     get_or_create_event_loop,
@@ -712,7 +712,7 @@ class LLMRails:
                     error_payload = json.dumps(error_dict)
                     await streaming_handler.push_chunk(error_payload)
                     # push a termination signal
-                    await streaming_handler.push_chunk(None)
+                    await streaming_handler.push_chunk(END_OF_STREAM)
                 # Re-raise the exact exception
                 raise
         else:
@@ -827,7 +827,7 @@ class LLMRails:
         streaming_handler = streaming_handler_var.get()
         if streaming_handler:
             # print("Closing the stream handler explicitly")
-            await streaming_handler.push_chunk(None)
+            await streaming_handler.push_chunk(END_OF_STREAM)
 
         # IF tracing is enabled we need to set GenerationLog attrs
         if self.config.tracing.enabled:

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -259,10 +259,20 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
     async def push_chunk(
         self,
-        chunk: Union[str, GenerationChunk, AIMessageChunk, None],
+        chunk: Union[str, GenerationChunk, AIMessageChunk, ChatGenerationChunk, None],
         generation_info: Optional[Dict[str, Any]] = None,
     ):
         """Push a new chunk to the stream."""
+
+        # if generation_info is not explicitly passed,
+        # try to get it from the chunk itself if it's a GenerationChunk or ChatGenerationChunk
+        if generation_info is None:
+            if isinstance(chunk, (GenerationChunk, ChatGenerationChunk)) and hasattr(
+                chunk, "generation_info"
+            ):
+                if chunk.generation_info is not None:
+                    generation_info = chunk.generation_info.copy()
+
         if isinstance(chunk, GenerationChunk):
             chunk = chunk.text
         elif isinstance(chunk, AIMessageChunk):

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -27,6 +27,9 @@ from nemoguardrails.utils import new_uuid
 
 log = logging.getLogger(__name__)
 
+# sentinel object to indicate end of stream
+END_OF_STREAM = object()
+
 
 class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
     """Streaming async handler.
@@ -141,13 +144,11 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                 except RuntimeError as ex:
                     if "Event loop is closed" not in str(ex):
                         raise ex
-                if element is None or element == "":
+                if element is END_OF_STREAM:
                     break
 
                 if isinstance(element, dict):
-                    if element is not None and (
-                        element.get("text") is None or element.get("text") == ""
-                    ):
+                    if element is not None and (element.get("text") is END_OF_STREAM):
                         yield element
                         break
                 yield element
@@ -161,21 +162,20 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         except RuntimeError as ex:
             if "Event loop is closed" not in str(ex):
                 raise ex
-        # following test is because of TestChat and FakeLLM implementation
-        #
-        if element is None or element == "":
+        if element is END_OF_STREAM:
             raise StopAsyncIteration
 
         if isinstance(element, dict):
-            if element is not None and (
-                element.get("text") is None or element.get("text") == ""
-            ):
+            if element is not None and (element.get("text") is END_OF_STREAM):
                 raise StopAsyncIteration
+            return element
         else:
             return element
 
     async def _process(
-        self, chunk: str, generation_info: Optional[Dict[str, Any]] = None
+        self,
+        chunk: Union[str, object],
+        generation_info: Optional[Dict[str, Any]] = None,
     ):
         """Process a chunk of text.
 
@@ -187,16 +187,17 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
             self.current_generation_info = generation_info
 
         if self.enable_buffer:
-            self.buffer += chunk
-            lines = [line.strip() for line in self.buffer.split("\n")]
-            lines = [line for line in lines if len(line) > 0 and line[0] != "#"]
-            if len(lines) > self.k > 0:
-                self.top_k_nonempty_lines_event.set()
+            if chunk is not END_OF_STREAM:
+                self.buffer += chunk if chunk is not None else ""
+                lines = [line.strip() for line in self.buffer.split("\n")]
+                lines = [line for line in lines if len(line) > 0 and line[0] != "#"]
+                if len(lines) > self.k > 0:
+                    self.top_k_nonempty_lines_event.set()
 
         else:
             prev_completion = self.completion
 
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.completion += chunk
                 # Check if the completion contains one of the stop chunks
                 for stop_chunk in self.stop:
@@ -208,34 +209,53 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         # We push that as well.
                         if len(self.completion) > len(prev_completion):
                             self.current_chunk = self.completion[len(prev_completion) :]
-                            await self.push_chunk(None)
+                            await self.push_chunk(END_OF_STREAM)
                         # And we stop the streaming
                         self.streaming_finished_event.set()
                         self.top_k_nonempty_lines_event.set()
                         return
 
             if self.pipe_to:
-                asyncio.create_task(self.pipe_to.push_chunk(chunk))
-                if chunk is None or chunk == "":
+                # only add explicit empty strings, not ones created during processing
+                if chunk is END_OF_STREAM or chunk is not None:
+                    asyncio.create_task(self.pipe_to.push_chunk(chunk))
+                if chunk is END_OF_STREAM:
                     self.streaming_finished_event.set()
                     self.top_k_nonempty_lines_event.set()
             else:
-                if self.enable_print and chunk is not None:
+                if (
+                    self.enable_print
+                    and chunk is not None
+                    and chunk is not END_OF_STREAM
+                ):
                     print(f"\033[92m{chunk}\033[0m", end="", flush=True)
-                # await self.queue.put(chunk)
-                if self.include_generation_metadata:
-                    await self.queue.put(
-                        {
-                            "text": chunk,
-                            "generation_info": self.current_generation_info.copy(),
-                        }
-                    )
-                else:
-                    await self.queue.put(chunk)
-                # If the chunk is empty (used as termination), mark the stream as finished.
-                if chunk is None or chunk == "":
-                    self.streaming_finished_event.set()
-                    self.top_k_nonempty_lines_event.set()
+
+                # we only want to filter out empty strings that are created during suffix processing,
+                # not ones directly pushed by the user
+                if chunk is not None:
+                    # process all valid chunks, including empty strings directly from the user
+                    if self.include_generation_metadata:
+                        if chunk is not END_OF_STREAM:
+                            await self.queue.put(
+                                {
+                                    "text": chunk,
+                                    "generation_info": self.current_generation_info.copy(),
+                                }
+                            )
+                        else:
+                            await self.queue.put(
+                                {
+                                    "text": END_OF_STREAM,
+                                    "generation_info": self.current_generation_info.copy(),
+                                }
+                            )
+                    else:
+                        await self.queue.put(chunk)
+
+                    # If the chunk is the special end of stream marker, mark the stream as finished.
+                    if chunk is END_OF_STREAM:
+                        self.streaming_finished_event.set()
+                        self.top_k_nonempty_lines_event.set()
 
     async def push_chunk(
         self,
@@ -249,7 +269,14 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
             chunk = chunk.content
         elif isinstance(chunk, ChatGenerationChunk):
             chunk = chunk.text
-        elif isinstance(chunk, str) or chunk is None:
+        elif chunk is None:
+            # replace None with the END_OF_STREAM marker
+            chunk = END_OF_STREAM
+        elif chunk is END_OF_STREAM:
+            # already the correct marker, no conversion needed
+            pass
+        elif isinstance(chunk, str):
+            # empty string is a valid chunk and should be processed normally
             pass
         else:
             raise Exception(f"Unsupported chunk type: {chunk.__class__.__name__}")
@@ -263,7 +290,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
         # Process prefix: accumulate until the expected prefix is received, then remove it.
         if self.prefix:
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.current_chunk += chunk
             if self.current_chunk.startswith(self.prefix):
                 self.current_chunk = self.current_chunk[len(self.prefix) :]
@@ -274,7 +301,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                     self.current_chunk = ""
         # Process suffix/stop tokens: accumulate and check whether the current chunk ends with one.
         elif self.suffix or self.stop:
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.current_chunk += chunk
             _chunks = []
             if self.suffix:
@@ -290,12 +317,12 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         skip_processing = True
                         break
 
-            if skip_processing and chunk != "" and chunk is not None:
+            if skip_processing and chunk is not END_OF_STREAM and chunk != "":
                 # We do nothing in this case. The suffix/stop chunks will be removed when
                 # the generation ends and if there's something left, will be processed then.
                 return
             else:
-                if chunk == "" or chunk is None:
+                if chunk is END_OF_STREAM:
                     if (
                         self.current_chunk
                         and self.suffix
@@ -304,8 +331,15 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         self.current_chunk = self.current_chunk[
                             0 : -1 * len(self.suffix)
                         ]
-                await self._process(self.current_chunk, generation_info)
-                self.current_chunk = ""
+
+                # only process the current_chunk if it's not empty
+                if self.current_chunk:
+                    await self._process(self.current_chunk, generation_info)
+                    self.current_chunk = ""
+
+                # if this is the end of stream, pass it through after processing the current chunk
+                if chunk is END_OF_STREAM:
+                    await self._process(END_OF_STREAM, generation_info)
         else:
             await self._process(chunk, generation_info)
 
@@ -333,15 +367,27 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         **kwargs: Any,
     ) -> None:
         """Run on new LLM token. Only available when streaming is enabled."""
+        # Log the first token if it's empty to help with debugging
+        if self.first_token and token == "":
+            log.debug(f"{self.uid[0:3]} - Received empty first token from LLM")
+
+        # set first_token to False regardless of token content
+        # we always process tokens, even empty ones
         if self.first_token:
             self.first_token = False
-            if token == "":
-                return
-        # Pass token as generation metadata.
-        generation_info = (
-            chunk.generation_info if chunk and hasattr(chunk, "generation_info") else {}
+
+        generation_info = None
+        if chunk and hasattr(chunk, "generation_info"):
+            if chunk.generation_info is not None:
+                generation_info = chunk.generation_info.copy()
+            else:
+                generation_info = {}
+        else:
+            generation_info = {}
+
+        await self.push_chunk(
+            token if chunk is None else chunk, generation_info=generation_info
         )
-        await self.push_chunk(chunk, generation_info=generation_info)
 
     async def on_llm_end(
         self,
@@ -359,7 +405,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
             await self._process(self.current_chunk)
             self.current_chunk = ""
-        await self._process("")
+        await self._process(END_OF_STREAM)
         # We explicitly print a new line here
         if self.enable_print:
             print("")

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -24,7 +24,7 @@ import pytest
 from langchain.schema.messages import AIMessageChunk
 from langchain.schema.output import GenerationChunk
 
-from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
 
 class StreamingConsumer:
@@ -124,7 +124,7 @@ async def _test_pattern_case(
                 await streaming_handler.push_chunk(chunk)
 
         # Push an empty chunk to signal the ending.
-        await streaming_handler.push_chunk("")
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         assert await streaming_consumer.get_chunks() == final_chunks
     finally:
@@ -288,7 +288,7 @@ async def test_set_pipe_to():
         # send chunks to main handler
         await main_handler.push_chunk("chunk1")
         await main_handler.push_chunk("chunk2")
-        await main_handler.push_chunk("")  # Signal end of streaming
+        await main_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
 
         # main handler received nothing (piped away)
         main_chunks = await main_consumer.get_chunks()
@@ -318,7 +318,7 @@ async def test_wait_method():
             await handler.push_chunk("chunk2")
             await asyncio.sleep(0.1)
             await handler.push_chunk(
-                ""
+                END_OF_STREAM
             )  # NOTE: signal end of streaming will get changed soon
 
         push_task = asyncio.create_task(push_chunks_with_delay())
@@ -419,7 +419,7 @@ async def test_multiple_stop_tokens():
         # Push text with a stop token in the middle
         await handler.push_chunk("This is some text STOP1 and this should be ignored")
         await handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: Signal end of streaming we are going to change this
 
         # streaming stopped at the stop token
@@ -436,7 +436,7 @@ async def test_multiple_stop_tokens():
 
         await handler.push_chunk("Different text with HALT token")
         await handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: Signal end of streaming we are going to change this
 
         chunks = await consumer.get_chunks()
@@ -500,7 +500,7 @@ async def test_first_token_handling():
         # first_token is now False
         assert handler.first_token is False
         # push_chunk was not called (empty first token is skipped)
-        assert push_chunk_called is False
+        assert push_chunk_called is True
 
         # reset the mock state
         push_chunk_called = False
@@ -536,7 +536,7 @@ async def test_first_token_handling():
                 except asyncio.QueueEmpty:
                     break
             # Signal end if push_chunk was mocked and might not have done it
-            await handler.queue.put(None)
+            await handler.queue.put(END_OF_STREAM)
 
 
 @pytest.mark.asyncio
@@ -557,7 +557,7 @@ async def test_suffix_removal_at_end():
         assert len(chunks) == 0
 
         await handler.push_chunk("D")
-        await handler.push_chunk("")  # NOTE: will get changed to SENTINEL
+        await handler.push_chunk(END_OF_STREAM)  # NOTE: will get changed to SENTINEL
 
         # Check that suffix was removed
         chunks = await consumer.get_chunks()
@@ -569,14 +569,27 @@ async def test_suffix_removal_at_end():
 
 @pytest.mark.asyncio
 async def test_anext_with_none_element():
-    """Test __anext__ method with None element."""
+    """Test __anext__ method with None element (now END_OF_STREAM sentinel)."""
 
     streaming_handler = StreamingHandler()
 
-    # put None into the queue (signal to stop streaming)
-    await streaming_handler.queue.put(None)
+    # put END_OF_STREAM into the queue (signal to stop streaming)
+    await streaming_handler.queue.put(END_OF_STREAM)
 
     # call __anext__ directly
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_end_of_stream_sentinel():
+    """Test __anext__ method explicitly with END_OF_STREAM sentinel."""
+    streaming_handler = StreamingHandler()
+
+    # Put END_OF_STREAM into the queue
+    await streaming_handler.queue.put(END_OF_STREAM)
+
+    # Call __anext__ and expect StopAsyncIteration
     with pytest.raises(StopAsyncIteration):
         await streaming_handler.__anext__()
 
@@ -590,33 +603,35 @@ async def test_anext_with_empty_string():
     # put empty string into the queue
     await streaming_handler.queue.put("")
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == ""
 
 
 @pytest.mark.asyncio
 async def test_anext_with_dict_empty_text():
     """Test __anext__ method with dict containing empty text."""
     streaming_handler = StreamingHandler()
+    test_val = {"text": "", "generation_info": {}}
 
     # put dict with empty text into the queue
-    await streaming_handler.queue.put({"text": "", "generation_info": {}})
+    await streaming_handler.queue.put(test_val)
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == test_val
 
 
 @pytest.mark.asyncio
 async def test_anext_with_dict_none_text():
     """Test __anext__ method with dict containing None text."""
     streaming_handler = StreamingHandler()
+    test_val = {"text": None, "generation_info": {}}
 
     # NOTE: azure openai issue
     # put dict with None text into the queue
-    await streaming_handler.queue.put({"text": None, "generation_info": {}})
+    await streaming_handler.queue.put(test_val)
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == test_val
 
 
 @pytest.mark.asyncio
@@ -641,8 +656,8 @@ async def test_anext_with_event_loop_closed():
     with mock.patch.object(
         streaming_handler.queue, "get", side_effect=RuntimeError("Event loop is closed")
     ):
-        with pytest.raises(StopAsyncIteration):
-            await streaming_handler.__anext__()
+        result = await streaming_handler.__anext__()
+        assert result is None
 
 
 @pytest.mark.asyncio
@@ -673,7 +688,7 @@ async def test_include_generation_metadata():
             test_text, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -702,7 +717,7 @@ async def test_include_generation_metadata_with_different_chunk_types():
             generation_chunk, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -722,7 +737,7 @@ async def test_include_generation_metadata_with_different_chunk_types():
             ai_message_chunk, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -768,14 +783,15 @@ async def test_on_llm_new_token_empty_then_nonempty():
         await streaming_handler.push_chunk("second")
 
         # NOTE: will chnage to sentinel soon to explicitly end the streaming
-        await streaming_handler.push_chunk("")
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         # wait for the chunks to be processed
         await asyncio.sleep(0.1)
 
         chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) == 1
-        assert chunks[0] == "second"
+        assert len(chunks) == 2
+        assert chunks[0] == ""
+        assert chunks[1] == "second"
     finally:
         await streaming_consumer.cancel()
 
@@ -803,14 +819,11 @@ async def test_on_llm_new_token_with_generation_info():
         )
 
         chunks = await streaming_consumer.get_chunks()
-        # print(chunks)
-        # sounds like a bug
-        # assert len(chunks) == 1
-        # assert chunks[1]["text"] == ""
         assert len(chunks) == 2
         assert chunks[0]["text"] == test_text
         assert chunks[0]["generation_info"] == test_generation_info
-        assert chunks[1]["text"] == ""
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == test_generation_info
     finally:
         await streaming_consumer.cancel()
 
@@ -830,7 +843,7 @@ async def test_processing_metadata():
         await streaming_handler.push_chunk(
             test_text, generation_info=test_generation_info
         )
-        await streaming_handler.push_chunk("")  # Signal end of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
 
         chunks = await streaming_consumer.get_chunks()
         assert len(chunks) >= 1
@@ -851,7 +864,7 @@ async def test_processing_metadata():
         await streaming_handler.push_chunk("message", generation_info={"part": 4})
         await streaming_handler.push_chunk(" SUFF", generation_info={"part": 5})
         await streaming_handler.push_chunk("IX", generation_info={"part": 6})
-        await streaming_handler.push_chunk("")  # End of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)  # End of streaming
 
         chunks = await streaming_consumer.get_chunks()
         # the prefix removal should happen first, then streaming happens

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -22,7 +22,7 @@ from uuid import UUID
 
 import pytest
 from langchain.schema.messages import AIMessageChunk
-from langchain.schema.output import GenerationChunk
+from langchain.schema.output import ChatGenerationChunk, GenerationChunk
 
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
@@ -881,3 +881,88 @@ async def test_processing_metadata():
                 assert chunks[i]["generation_info"]["part"] == expected["part"]
     finally:
         await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_dict_end_of_stream_sentinel():
+    """Test __anext__ with a dict-wrapped END_OF_STREAM sentinel."""
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    await streaming_handler.queue.put({"text": END_OF_STREAM, "generation_info": {}})
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_with_chat_generation_chunk():
+    """Test push_chunk with a ChatGenerationChunk."""
+
+    streaming_handler = StreamingHandler()
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        chat_chunk = ChatGenerationChunk(message=AIMessageChunk(content="chat text"))
+        await streaming_handler.push_chunk(chat_chunk)
+        await streaming_handler.push_chunk(END_OF_STREAM)
+        chunks = await consumer.get_chunks()
+        assert chunks == ["chat text"]
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_with_chat_generation_chunk_with_metadata():
+    """Test push_chunk with a ChatGenerationChunk when metadata is included."""
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        message_chunk = AIMessageChunk(content="chat text")
+        chat_chunk = ChatGenerationChunk(
+            message=message_chunk, generation_info={"details": "some details"}
+        )
+        await streaming_handler.push_chunk(chat_chunk)
+        await streaming_handler.push_chunk(END_OF_STREAM)
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "chat text"
+        assert chunks[0]["generation_info"] == {"details": "some details"}
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == {"details": "some details"}
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_unsupported_type():
+    """Test push_chunk with an unsupported data type."""
+
+    streaming_handler = StreamingHandler()
+    with pytest.raises(Exception, match="Unsupported chunk type: int"):
+        await streaming_handler.push_chunk(123)
+    with pytest.raises(Exception, match="Unsupported chunk type: list"):
+        await streaming_handler.push_chunk([1, 2])
+
+
+@pytest.mark.asyncio
+async def test_on_llm_new_token_with_chunk_having_none_generation_info():
+    """Test on_llm_new_token when chunk.generation_info is None."""
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        mock_chunk = GenerationChunk(text="test text", generation_info=None)
+        await streaming_handler.on_llm_new_token(
+            token="test text",
+            chunk=mock_chunk,
+            run_id=UUID("00000000-0000-0000-0000-000000000000"),
+        )
+        await streaming_handler.on_llm_end(
+            response=None, run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "test text"
+        assert chunks[0]["generation_info"] == {}
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == {}
+    finally:
+        await consumer.cancel()


### PR DESCRIPTION
This PR resolves #1184 by  introducing END_OF_STREAM sentinel and update streaming handling.

- Replaced inconsistent use of `None` and `""` for stream termination
  in `StreamingHandler` with a dedicated `END_OF_STREAM` sentinel object.
- Modified `push_chunk` to convert `None` to `END_OF_STREAM`.
- Updated `__anext__` to raise `StopAsyncIteration` only for `END_OF_STREAM`
  and to return empty strings or dicts with empty/None text as data.
- Adjusted `_process` to correctly handle `END_OF_STREAM` for buffering
  and queueing logic.
- Updated `on_llm_end` to use `END_OF_STREAM`.
- Revised tests in `test_streaming_handler.py` to reflect these changes,
  including how empty first tokens are handled and how `__anext__` behaves
  with various inputs.
  
  requires:

- [ ] #1182 
- [ ] #1183 