### PR TITLE
create `explain_info` context variable in `stream_async` to keep trac…

### DIFF
--- a/docs/user-guides/advanced/streaming.md
+++ b/docs/user-guides/advanced/streaming.md
@@ -1,9 +1,11 @@
 # Streaming
 
-To use a guardrails configuration in streaming mode, the following must be met:
+If the application LLM supports streaming, you can configure NeMo Guardrails to stream tokens as well.
 
-1. The main LLM must support streaming.
-2. There are no output rails.
+For information about configuring streaming with output guardrails, refer to the following:
+
+- For configuration, refer to [streaming output configuration](../../user-guides/configuration-guide.md#streaming-output-configuration).
+- For sample Python client code, refer to [streaming output](../../getting-started/5-output-rails/README.md#streaming-output).
 
 ## Configuration
 
@@ -26,6 +28,7 @@ nemoguardrails chat --config=examples/configs/streaming --streaming
 ### Python API
 
 You can use the streaming directly from the python API in two ways:
+
 1. Simple: receive just the chunks (tokens).
 2. Full: receive both the chunks as they are generated and the full response at the end.
 
@@ -73,9 +76,11 @@ For the complete working example, check out this [demo script](https://github.co
 ### Server API
 
 To make a call to the NeMo Guardrails Server in streaming mode, you have to set the `stream` parameter to `True` inside the JSON body. For example, to get the completion for a chat session using the `/v1/chat/completions` endpoint:
+
 ```
 POST /v1/chat/completions
 ```
+
 ```json
 {
     "config_id": "some_config_id",

--- a/docs/user-guides/configuration-guide.md
+++ b/docs/user-guides/configuration-guide.md
@@ -75,23 +75,29 @@ models:
 
 The meaning of the attributes is as follows:
 
-- `type`: is set to "main" indicating the main LLM model.
-- `engine`: the LLM provider, e.g., `openai`, `huggingface_endpoint`, `self_hosted`, etc.
-- `model`: the name of the model, e.g., `gpt-3.5-turbo-instruct`.
-- `parameters`: any additional parameters, e.g., `temperature`, `top_k`, etc.
+- `type`: is set to _main_ to indicate the model is the application LLM.
+- `engine`: the LLM provider, such as `openai`, `huggingface_endpoint`, `self_hosted`, and so on.
+- `model`: the name of the model, such as `gpt-3.5-turbo-instruct`.
+- `parameters`: arguments to pass to the LangChain class used by the LLM provider.
+  For example, when `engine` is set to `openai`, the toolkit loads the `ChatOpenAI` class.
+  The [ChatOpenAI class](https://python.langchain.com/api_reference/openai/chat_models/langchain_openai.chat_models.base.ChatOpenAI.html)
+  supports `temperature`, `max_tokens`, and other class-specific arguments.
 
 #### Supported LLM Providers
 
-You can use any LLM provider that is supported by LangChain, e.g., `ai21`, `aleph_alpha`, `anthropic`, `anyscale`, `azure`, `cohere`, `huggingface_endpoint`, `huggingface_hub`, `openai`, `self_hosted`, `self_hosted_hugging_face`. Check out the LangChain official documentation for the full list.
+You can use any LLM provider that is supported by LangChain, such as `ai21`, `aleph_alpha`, `anthropic`, `anyscale`, `azure`, `cohere`, `huggingface_endpoint`, `huggingface_hub`, `openai`, `self_hosted`, `self_hosted_hugging_face`. Check out the LangChain official documentation for the full list.
 
-In addition to the above LangChain providers, connecting to [Nvidia NIMs](https://docs.nvidia.com/nim/index.html) is supported using the engine `nvidia_ai_endpoints` or synonymously `nim`, for both Nvidia hosted NIMs (accessible through an Nvidia AI Enterprise license) and for locally downloaded and elf-hosted NIM containers.
+In addition to the above LangChain providers, connecting to [NVIDIA NIM microservices](https://docs.nvidia.com/nim/index.html) is supported using the `nim` engine.
+The `nvidia_ai_endpoints` engine is an alias for the `nim` engine.
+The engine provides access to locally-deployed NIM microservices or NVIDIA hosted models that you can view from <https://build.nvidia.com/models>.
 
-```{note}
-To use any of the providers, you must install additional packages; when you first try to use a configuration with a new provider, you typically receive an error from LangChain that instructs which packages you should install.
-```
+To use any of the LLM providers, you must install the LangChain package for the provider.
+When you first try to use a configuration with a new provider, you typically receive an error from LangChain that instructs which packages you should install.
 
 ```{important}
-Although you can instantiate any of the previously mentioned LLM providers, depending on the capabilities of the model, the NeMo Guardrails toolkit works better with some providers than others. The toolkit includes prompts that have been optimized for certain types of models, such as models provided by`openai` or `llama3` models. For others, you can optimize the prompts yourself following the information in the [LLM Prompts](#llm-prompts) section.
+Although you can instantiate any of the previously mentioned LLM providers, depending on the capabilities of the model, the NeMo Guardrails toolkit works better with some providers than others.
+The toolkit includes prompts that have been optimized for certain types of models, such as models provided by `openai` or `llama3` models.
+For others, you can optimize the prompts yourself following the information in the [LLM Prompts](#llm-prompts) section.
 ```
 
 #### Exploring Available Providers
@@ -797,7 +803,7 @@ rails:
 
 On a typical RAG (Retrieval Augmented Generation) scenario, using this option brings a 3x improvement in terms of latency and uses 37% fewer tokens.
 
-**IMPORTANT**: currently, the *Single Call Mode* can only predict bot messages as next steps. This means that if you want the LLM to generalize and decide to execute an action on a dynamically generated user canonical form message, it will not work.
+**IMPORTANT**: currently, the _Single Call Mode_ can only predict bot messages as next steps. This means that if you want the LLM to generalize and decide to execute an action on a dynamically generated user canonical form message, it will not work.
 
 #### Embeddings Only
 

--- a/nemoguardrails/library/injection_detection/flows.co
+++ b/nemoguardrails/library/injection_detection/flows.co
@@ -1,7 +1,19 @@
-# OUTPUT RAILS
-
 flow injection detection
   """
   Reject, omit, or sanitize injection attempts from the bot.
+  This rail operates on the $bot_message.
   """
-  $bot_message = await InjectionDetectionAction(text=$bot_message)
+  response = await InjectionDetectionAction(text=$bot_message)
+  join_separator = ", "
+  injection_detection_action = $config.rails.config.injection_detection.action
+
+  if response["is_injection"]
+    if $config.enable_rails_exceptions
+      send InjectionDetectionRailException(message="Output not allowed. The output was blocked by the 'injection detection' flow.")
+    else if injection_detection_action == "reject"
+      bot "I'm sorry, the desired output triggered rule(s) designed to mitigate exploitation of {{ response.detections | join(join_separator) }}."
+      abort
+    else if injection_detection_action == "omit" or injection_detection_action == "sanitize"
+      $bot_message = response["text"]
+  else
+    $bot_message = response["text"]

--- a/nemoguardrails/library/injection_detection/flows.v1.co
+++ b/nemoguardrails/library/injection_detection/flows.v1.co
@@ -1,5 +1,19 @@
-define subflow injection detection
+
+define flow injection detection
   """
   Reject, omit, or sanitize injection attempts from the bot.
   """
-  $bot_message = execute injection_detection(text=$bot_message)
+  $response = execute injection_detection(text=$bot_message)
+  $join_separator = ", "
+  $injection_detection_action = $config.rails.config.injection_detection.action
+  if $response["is_injection"]
+    if $config.enable_rails_exceptions
+      create event InjectionDetectionRailException(message="Output not allowed. The output was blocked by the 'injection detection' flow.")
+      stop
+    else if $config.rails.config.injection_detection.action == "reject"
+      bot say "I'm sorry, the desired output triggered rule(s) designed to mitigate exploitation of {{ response.detections | join(join_separator) }}."
+      stop
+    else if $injection_detection_action == "omit" or $injection_detection_action == "sanitize"
+      $bot_message = $response["text"]
+  else
+    $bot_message = $response["text"]

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -960,6 +960,13 @@ class LLMRails:
         include_generation_metadata: Optional[bool] = False,
     ) -> AsyncIterator[str]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
+        explain_info = explain_info_var.get()
+        if explain_info is None:
+            explain_info = ExplainInfo()
+            explain_info_var.set(explain_info)
+
+        self.explain_info = explain_info
+
         streaming_handler = StreamingHandler(
             include_generation_metadata=include_generation_metadata
         )

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -576,6 +576,20 @@ class LLMRails:
 
         return events
 
+    @staticmethod
+    def _ensure_explain_info() -> ExplainInfo:
+        """Ensure that the ExplainInfo variable is present in the current context
+
+        Returns:
+            A ExplainInfo class containing the llm calls' statistics
+        """
+        explain_info = explain_info_var.get()
+        if explain_info is None:
+            explain_info = ExplainInfo()
+            explain_info_var.set(explain_info)
+
+        return explain_info
+
     async def generate_async(
         self,
         prompt: Optional[str] = None,

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -648,14 +648,7 @@ class LLMRails:
         # Initialize the object with additional explanation information.
         # We allow this to also be set externally. This is useful when multiple parallel
         # requests are made.
-        explain_info = explain_info_var.get()
-        if explain_info is None:
-            explain_info = ExplainInfo()
-            explain_info_var.set(explain_info)
-
-            # We also keep a general reference to this object
-            self.explain_info = explain_info
-        self.explain_info = explain_info
+        self.explain_info = self._ensure_explain_info()
 
         if prompt is not None:
             # Currently, we transform the prompt request into a single turn conversation
@@ -819,9 +812,9 @@ class LLMRails:
 
         # If logging is enabled, we log the conversation
         # TODO: add support for logging flag
-        explain_info.colang_history = get_colang_history(events)
+        self.explain_info.colang_history = get_colang_history(events)
         if self.verbose:
-            log.info(f"Conversation history so far: \n{explain_info.colang_history}")
+            log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
 
         total_time = time.time() - t0
         log.info(

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -967,12 +967,7 @@ class LLMRails:
         include_generation_metadata: Optional[bool] = False,
     ) -> AsyncIterator[str]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
-        explain_info = explain_info_var.get()
-        if explain_info is None:
-            explain_info = ExplainInfo()
-            explain_info_var.set(explain_info)
-
-        self.explain_info = explain_info
+        self.explain_info = self._ensure_explain_info()
 
         streaming_handler = StreamingHandler(
             include_generation_metadata=include_generation_metadata
@@ -1292,13 +1287,6 @@ class LLMRails:
                 **action_params,
             }
 
-        def _update_explain_info():
-            explain_info = explain_info_var.get()
-            if explain_info is None:
-                explain_info = ExplainInfo()
-                explain_info_var.set(explain_info)
-                self.explain_info = explain_info
-
         output_rails_streaming_config = self.config.rails.output.streaming
         buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
         output_rails_flows_id = self.config.rails.output.flows
@@ -1343,7 +1331,7 @@ class LLMRails:
                     action_name, params
                 )
                 # Include explain info (whatever _update_explain_info does)
-                _update_explain_info()
+                self.explain_info = self._ensure_explain_info()
 
                 # Retrieve the action function from the dispatcher
                 action_func = self.runtime.action_dispatcher.get_action(action_name)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -75,7 +75,7 @@ from nemoguardrails.rails.llm.options import (
     GenerationResponse,
 )
 from nemoguardrails.rails.llm.utils import get_history_cache_key
-from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.utils import (
     extract_error_json,
     get_or_create_event_loop,
@@ -706,7 +706,7 @@ class LLMRails:
                     error_payload = json.dumps(error_dict)
                     await streaming_handler.push_chunk(error_payload)
                     # push a termination signal
-                    await streaming_handler.push_chunk(None)
+                    await streaming_handler.push_chunk(END_OF_STREAM)
                 # Re-raise the exact exception
                 raise
         else:
@@ -819,7 +819,7 @@ class LLMRails:
         streaming_handler = streaming_handler_var.get()
         if streaming_handler:
             # print("Closing the stream handler explicitly")
-            await streaming_handler.push_chunk(None)
+            await streaming_handler.push_chunk(END_OF_STREAM)
 
         # IF tracing is enabled we need to set GenerationLog attrs
         if self.config.tracing.enabled:

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -51,7 +51,6 @@ from nemoguardrails.context import (
     generation_options_var,
     llm_stats_var,
     raw_llm_request,
-    reasoning_trace_var,
     streaming_handler_var,
 )
 from nemoguardrails.embeddings.index import EmbeddingsIndex

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -259,10 +259,20 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
     async def push_chunk(
         self,
-        chunk: Union[str, GenerationChunk, AIMessageChunk, None],
+        chunk: Union[str, GenerationChunk, AIMessageChunk, ChatGenerationChunk, None],
         generation_info: Optional[Dict[str, Any]] = None,
     ):
         """Push a new chunk to the stream."""
+
+        # if generation_info is not explicitly passed,
+        # try to get it from the chunk itself if it's a GenerationChunk or ChatGenerationChunk
+        if generation_info is None:
+            if isinstance(chunk, (GenerationChunk, ChatGenerationChunk)) and hasattr(
+                chunk, "generation_info"
+            ):
+                if chunk.generation_info is not None:
+                    generation_info = chunk.generation_info.copy()
+
         if isinstance(chunk, GenerationChunk):
             chunk = chunk.text
         elif isinstance(chunk, AIMessageChunk):

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -27,6 +27,9 @@ from nemoguardrails.utils import new_uuid
 
 log = logging.getLogger(__name__)
 
+# sentinel object to indicate end of stream
+END_OF_STREAM = object()
+
 
 class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
     """Streaming async handler.
@@ -141,13 +144,11 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                 except RuntimeError as ex:
                     if "Event loop is closed" not in str(ex):
                         raise ex
-                if element is None or element == "":
+                if element is END_OF_STREAM:
                     break
 
                 if isinstance(element, dict):
-                    if element is not None and (
-                        element.get("text") is None or element.get("text") == ""
-                    ):
+                    if element is not None and (element.get("text") is END_OF_STREAM):
                         yield element
                         break
                 yield element
@@ -161,21 +162,20 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         except RuntimeError as ex:
             if "Event loop is closed" not in str(ex):
                 raise ex
-        # following test is because of TestChat and FakeLLM implementation
-        #
-        if element is None or element == "":
+        if element is END_OF_STREAM:
             raise StopAsyncIteration
 
         if isinstance(element, dict):
-            if element is not None and (
-                element.get("text") is None or element.get("text") == ""
-            ):
+            if element is not None and (element.get("text") is END_OF_STREAM):
                 raise StopAsyncIteration
+            return element
         else:
             return element
 
     async def _process(
-        self, chunk: str, generation_info: Optional[Dict[str, Any]] = None
+        self,
+        chunk: Union[str, object],
+        generation_info: Optional[Dict[str, Any]] = None,
     ):
         """Process a chunk of text.
 
@@ -187,16 +187,17 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
             self.current_generation_info = generation_info
 
         if self.enable_buffer:
-            self.buffer += chunk
-            lines = [line.strip() for line in self.buffer.split("\n")]
-            lines = [line for line in lines if len(line) > 0 and line[0] != "#"]
-            if len(lines) > self.k > 0:
-                self.top_k_nonempty_lines_event.set()
+            if chunk is not END_OF_STREAM:
+                self.buffer += chunk if chunk is not None else ""
+                lines = [line.strip() for line in self.buffer.split("\n")]
+                lines = [line for line in lines if len(line) > 0 and line[0] != "#"]
+                if len(lines) > self.k > 0:
+                    self.top_k_nonempty_lines_event.set()
 
         else:
             prev_completion = self.completion
 
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.completion += chunk
                 # Check if the completion contains one of the stop chunks
                 for stop_chunk in self.stop:
@@ -208,34 +209,53 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         # We push that as well.
                         if len(self.completion) > len(prev_completion):
                             self.current_chunk = self.completion[len(prev_completion) :]
-                            await self.push_chunk(None)
+                            await self.push_chunk(END_OF_STREAM)
                         # And we stop the streaming
                         self.streaming_finished_event.set()
                         self.top_k_nonempty_lines_event.set()
                         return
 
             if self.pipe_to:
-                asyncio.create_task(self.pipe_to.push_chunk(chunk))
-                if chunk is None or chunk == "":
+                # only add explicit empty strings, not ones created during processing
+                if chunk is END_OF_STREAM or chunk is not None:
+                    asyncio.create_task(self.pipe_to.push_chunk(chunk))
+                if chunk is END_OF_STREAM:
                     self.streaming_finished_event.set()
                     self.top_k_nonempty_lines_event.set()
             else:
-                if self.enable_print and chunk is not None:
+                if (
+                    self.enable_print
+                    and chunk is not None
+                    and chunk is not END_OF_STREAM
+                ):
                     print(f"\033[92m{chunk}\033[0m", end="", flush=True)
-                # await self.queue.put(chunk)
-                if self.include_generation_metadata:
-                    await self.queue.put(
-                        {
-                            "text": chunk,
-                            "generation_info": self.current_generation_info.copy(),
-                        }
-                    )
-                else:
-                    await self.queue.put(chunk)
-                # If the chunk is empty (used as termination), mark the stream as finished.
-                if chunk is None or chunk == "":
-                    self.streaming_finished_event.set()
-                    self.top_k_nonempty_lines_event.set()
+
+                # we only want to filter out empty strings that are created during suffix processing,
+                # not ones directly pushed by the user
+                if chunk is not None:
+                    # process all valid chunks, including empty strings directly from the user
+                    if self.include_generation_metadata:
+                        if chunk is not END_OF_STREAM:
+                            await self.queue.put(
+                                {
+                                    "text": chunk,
+                                    "generation_info": self.current_generation_info.copy(),
+                                }
+                            )
+                        else:
+                            await self.queue.put(
+                                {
+                                    "text": END_OF_STREAM,
+                                    "generation_info": self.current_generation_info.copy(),
+                                }
+                            )
+                    else:
+                        await self.queue.put(chunk)
+
+                    # If the chunk is the special end of stream marker, mark the stream as finished.
+                    if chunk is END_OF_STREAM:
+                        self.streaming_finished_event.set()
+                        self.top_k_nonempty_lines_event.set()
 
     async def push_chunk(
         self,
@@ -249,7 +269,14 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
             chunk = chunk.content
         elif isinstance(chunk, ChatGenerationChunk):
             chunk = chunk.text
-        elif isinstance(chunk, str) or chunk is None:
+        elif chunk is None:
+            # replace None with the END_OF_STREAM marker
+            chunk = END_OF_STREAM
+        elif chunk is END_OF_STREAM:
+            # already the correct marker, no conversion needed
+            pass
+        elif isinstance(chunk, str):
+            # empty string is a valid chunk and should be processed normally
             pass
         else:
             raise Exception(f"Unsupported chunk type: {chunk.__class__.__name__}")
@@ -263,7 +290,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
         # Process prefix: accumulate until the expected prefix is received, then remove it.
         if self.prefix:
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.current_chunk += chunk
             if self.current_chunk.startswith(self.prefix):
                 self.current_chunk = self.current_chunk[len(self.prefix) :]
@@ -274,7 +301,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                     self.current_chunk = ""
         # Process suffix/stop tokens: accumulate and check whether the current chunk ends with one.
         elif self.suffix or self.stop:
-            if chunk is not None:
+            if chunk is not None and chunk is not END_OF_STREAM:
                 self.current_chunk += chunk
             _chunks = []
             if self.suffix:
@@ -290,12 +317,12 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         skip_processing = True
                         break
 
-            if skip_processing and chunk != "" and chunk is not None:
+            if skip_processing and chunk is not END_OF_STREAM and chunk != "":
                 # We do nothing in this case. The suffix/stop chunks will be removed when
                 # the generation ends and if there's something left, will be processed then.
                 return
             else:
-                if chunk == "" or chunk is None:
+                if chunk is END_OF_STREAM:
                     if (
                         self.current_chunk
                         and self.suffix
@@ -304,8 +331,15 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
                         self.current_chunk = self.current_chunk[
                             0 : -1 * len(self.suffix)
                         ]
-                await self._process(self.current_chunk, generation_info)
-                self.current_chunk = ""
+
+                # only process the current_chunk if it's not empty
+                if self.current_chunk:
+                    await self._process(self.current_chunk, generation_info)
+                    self.current_chunk = ""
+
+                # if this is the end of stream, pass it through after processing the current chunk
+                if chunk is END_OF_STREAM:
+                    await self._process(END_OF_STREAM, generation_info)
         else:
             await self._process(chunk, generation_info)
 
@@ -333,15 +367,27 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         **kwargs: Any,
     ) -> None:
         """Run on new LLM token. Only available when streaming is enabled."""
+        # Log the first token if it's empty to help with debugging
+        if self.first_token and token == "":
+            log.debug(f"{self.uid[0:3]} - Received empty first token from LLM")
+
+        # set first_token to False regardless of token content
+        # we always process tokens, even empty ones
         if self.first_token:
             self.first_token = False
-            if token == "":
-                return
-        # Pass token as generation metadata.
-        generation_info = (
-            chunk.generation_info if chunk and hasattr(chunk, "generation_info") else {}
+
+        generation_info = None
+        if chunk and hasattr(chunk, "generation_info"):
+            if chunk.generation_info is not None:
+                generation_info = chunk.generation_info.copy()
+            else:
+                generation_info = {}
+        else:
+            generation_info = {}
+
+        await self.push_chunk(
+            token if chunk is None else chunk, generation_info=generation_info
         )
-        await self.push_chunk(chunk, generation_info=generation_info)
 
     async def on_llm_end(
         self,
@@ -359,7 +405,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
             await self._process(self.current_chunk)
             self.current_chunk = ""
-        await self._process("")
+        await self._process(END_OF_STREAM)
         # We explicitly print a new line here
         if self.enable_print:
             print("")

--- a/tests/test_llm_rails_context_variables.py
+++ b/tests/test_llm_rails_context_variables.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+
+@pytest.mark.asyncio
+async def test_1():
+    config = RailsConfig.from_content(
+        """
+        define user express greeting
+            "hello"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "express greeting",
+            "Hello! I'm doing great, thank you. How can I assist you today?",
+        ],
+    )
+
+    new_messages = await chat.app.generate_async(
+        messages=[{"role": "user", "content": "hi, how are you"}]
+    )
+
+    assert new_messages == {
+        "content": "Hello! I'm doing great, thank you. How can I assist you today?",
+        "role": "assistant",
+    }, "message content do not match"
+
+    # note that 2 llm call are expected as we matched the bot intent
+    assert len(chat.app.explain().llm_calls) == 2, (
+        "number of llm call not as expected. Expected 2, found {}".format(
+            len(chat.app.explain().llm_calls)
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_2():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    # run the real self check output rails
+                    "flows": {"self check output"},
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                        "context_size": 2,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "streaming": False,
+            "prompts": [{"task": "self_check_output", "content": "a test template"}],
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+
+        define flow
+          user express greeting
+          bot tell joke
+        """,
+    )
+
+    llm_completions = [
+        '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
+        '  "This is a joke that should be blocked."',
+        # add as many `no`` as chunks you want the output stream to check
+        "No",
+        "No",
+        "Yes",
+    ]
+
+    chat = TestChat(
+        config,
+        llm_completions=llm_completions,
+        streaming=True,
+    )
+    chunks = []
+    async for chunk in chat.app.stream_async(
+        messages=[{"role": "user", "content": "Hi!"}],
+    ):
+        chunks.append(chunk)
+
+    # note that 6 llm call are expected as we matched the bot intent
+    assert len(chat.app.explain().llm_calls) == 5, (
+        "number of llm call not as expected. Expected 5, found {}".format(
+            len(chat.app.explain().llm_calls)
+        )
+    )
+
+    await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -14,22 +14,24 @@
 # limitations under the License.
 
 import asyncio
+import io
+import sys
+import unittest.mock as mock
 from typing import List, Optional, Union
+from uuid import UUID
 
 import pytest
+from langchain.schema.messages import AIMessageChunk
+from langchain.schema.output import GenerationChunk
 
 from nemoguardrails.streaming import StreamingHandler
 
 
 class StreamingConsumer:
-    """Helper class for testing a streaming handler.
-
-    It consumes the chunks from teh stream.
-    """
+    """Helper class for testing a streaming handler."""
 
     def __init__(self, streaming_handler: StreamingHandler):
         self.streaming_handler = streaming_handler
-
         self.chunks = []
         self.finished = False
         self._task = None
@@ -50,8 +52,8 @@ class StreamingConsumer:
 
     async def get_chunks(self):
         """Helper to get the chunks."""
-        # We wait a bit to allow all asyncio callbacks to get called.
-        await asyncio.sleep(0.01)
+        # we wait a bit to allow all asyncio callbacks to get called.
+        await asyncio.sleep(0.1)
         return self.chunks
 
     async def cancel(self):
@@ -268,3 +270,601 @@ async def test_suffix_with_stop_and_pipe_4():
         ],
         final_chunks=["This is a message", "."],
     )
+
+
+@pytest.mark.asyncio
+async def test_set_pipe_to():
+    """Test set_pipe_to verify streaming is correctly piped to another handler."""
+
+    main_handler = StreamingHandler()
+    secondary_handler = StreamingHandler()
+    main_consumer = StreamingConsumer(main_handler)
+    secondary_consumer = StreamingConsumer(secondary_handler)
+
+    try:
+        # piping from main to secondary handler
+        main_handler.set_pipe_to(secondary_handler)
+
+        # send chunks to main handler
+        await main_handler.push_chunk("chunk1")
+        await main_handler.push_chunk("chunk2")
+        await main_handler.push_chunk("")  # Signal end of streaming
+
+        # main handler received nothing (piped away)
+        main_chunks = await main_consumer.get_chunks()
+        assert len(main_chunks) == 0
+
+        # ensure secondary handler received the chunks
+        secondary_chunks = await secondary_consumer.get_chunks()
+        assert len(secondary_chunks) >= 2
+        assert "chunk1" in secondary_chunks
+        assert "chunk2" in secondary_chunks
+    finally:
+        await main_consumer.cancel()
+        await secondary_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_wait_method():
+    """Test the wait method to verify it waits for streaming to finish."""
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
+    try:
+
+        async def push_chunks_with_delay():
+            await handler.push_chunk("chunk1")
+            await asyncio.sleep(0.1)
+            await handler.push_chunk("chunk2")
+            await asyncio.sleep(0.1)
+            await handler.push_chunk(
+                ""
+            )  # NOTE: signal end of streaming will get changed soon
+
+        push_task = asyncio.create_task(push_chunks_with_delay())
+
+        completion = await handler.wait()
+
+        assert completion == "chunk1chunk2"
+
+        await push_task
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_wait_top_k_nonempty_lines():
+    """Test the wait_top_k_nonempty_lines method with a timeout to prevent hanging."""
+    handler = StreamingHandler()
+
+    await handler.enable_buffering()
+
+    # create a background task to push lines
+    async def push_lines():
+        await handler.push_chunk("Line 1\n")
+        # following should be skipped
+        await handler.push_chunk("# Comment line\n")
+        await handler.push_chunk("Line 2\n")
+        await handler.push_chunk("Line 3\n")
+        await handler.push_chunk("Line 4\n")
+        # Explicitly make sure we have enough non-empty lines to trigger the event
+        # this is important as the test could hang if the event isn't set
+        handler.top_k_nonempty_lines_event.set()
+
+    # start pushing lines in the background
+    push_task = asyncio.create_task(push_lines())
+
+    try:
+        # Wait for top 2 non-empty lines with a timeout
+        top_k_lines = await asyncio.wait_for(
+            handler.wait_top_k_nonempty_lines(2), timeout=2.0
+        )
+
+        # verify we got the expected lines
+        assert top_k_lines == "Line 1\nLine 2"
+
+        # verify the buffer now only contains the remaining lines
+        assert handler.buffer == "Line 3\nLine 4\n"
+    except asyncio.TimeoutError:
+        pytest.fail("wait_top_k_nonempty_lines timed out")
+    finally:
+        if not push_task.done():
+            push_task.cancel()
+            try:
+                await push_task
+            except asyncio.CancelledError:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_enable_and_disable_buffering():
+    """Test the enable_buffering and disable_buffering methods."""
+
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
+    try:
+        await handler.enable_buffering()
+
+        await handler.push_chunk("chunk1")
+        await handler.push_chunk("chunk2")
+
+        # verify chunks were buffered not streamed
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 0
+        assert handler.buffer == "chunk1chunk2"
+
+        # disable buffering; should process the buffer as a chunk
+        await handler.disable_buffering()
+
+        # verify the buffer was processed and streamed
+        chunks = await consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert "chunk1chunk2" in chunks
+
+        assert handler.buffer == ""
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_multiple_stop_tokens():
+    """Test handling of multiple stop tokens."""
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
+    try:
+        handler.stop = ["STOP1", "STOP2", "HALT"]
+
+        # Push text with a stop token in the middle
+        await handler.push_chunk("This is some text STOP1 and this should be ignored")
+        await handler.push_chunk(
+            ""
+        )  # NOTE: Signal end of streaming we are going to change this
+
+        # streaming stopped at the stop token
+        chunks = await consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0] == "This is some text "
+    finally:
+        await consumer.cancel()
+
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+    try:
+        handler.stop = ["STOP1", "STOP2", "HALT"]
+
+        await handler.push_chunk("Different text with HALT token")
+        await handler.push_chunk(
+            ""
+        )  # NOTE: Signal end of streaming we are going to change this
+
+        chunks = await consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0] == "Different text with "
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_enable_print_functionality():
+    """Test the enable_print functionality."""
+
+    original_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+
+    try:
+        handler = StreamingHandler(enable_print=True)
+
+        await handler.push_chunk("Hello")
+        await handler.push_chunk(" World")
+
+        # end streaming to trigger newline print
+        # NOTE: None signals the end of streaming also ""
+        await handler.on_llm_end(
+            response=None, run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+
+        printed_output = sys.stdout.getvalue()
+
+        assert "\033[92mHello\033[0m" in printed_output
+        assert "\033[92m World\033[0m" in printed_output
+    finally:
+        # reestore stdout
+        sys.stdout = original_stdout
+
+
+@pytest.mark.asyncio
+async def test_first_token_handling():
+    """Test the first_token flag behavior directly."""
+    handler = StreamingHandler()
+    assert handler.first_token is True
+
+    # Mock push_chunk to verify it's not called for empty first token
+    original_push_chunk = handler.push_chunk
+    push_chunk_called = False
+
+    async def mock_push_chunk(chunk, *args, **kwargs):
+        nonlocal push_chunk_called
+        push_chunk_called = True
+
+    # replace the method temporarily
+    handler.push_chunk = mock_push_chunk
+
+    try:
+        # call on_llm_new_token with empty first token
+        await handler.on_llm_new_token(
+            token="", run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+
+        # first_token is now False
+        assert handler.first_token is False
+        # push_chunk was not called (empty first token is skipped)
+        assert push_chunk_called is False
+
+        # reset the mock state
+        push_chunk_called = False
+
+        # NOTE: this is not the root cause of streaming bug with Azure OpenAI
+        # call on_llm_new_token with empty token again (not first)
+        await handler.on_llm_new_token(
+            token="", run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+
+        # push_chunk should be called (empty non-first token is not skipped)
+        assert push_chunk_called is True
+
+        await handler.on_llm_new_token(
+            token="This is a test", run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+
+        # NOTE: THIS IS A BUG
+        assert push_chunk_called is True
+
+        # TODO:
+        # asssert that streaming has ended when we are here
+    finally:
+        # restore the original method
+        handler.push_chunk = original_push_chunk
+        # Clean up the queue if any items were added by mock or direct calls
+        # This ensures no pending tasks from this handler interfere elsewhere.
+        if hasattr(handler, "queue") and handler.queue is not None:
+            while not handler.queue.empty():
+                try:
+                    handler.queue.get_nowait()
+                    handler.queue.task_done()
+                except asyncio.QueueEmpty:
+                    break
+            # Signal end if push_chunk was mocked and might not have done it
+            await handler.queue.put(None)
+
+
+@pytest.mark.asyncio
+async def test_suffix_removal_at_end():
+    """Test that suffix is removed at the end of streaming."""
+
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
+    try:
+        handler.set_pattern(suffix="END")
+
+        await handler.push_chunk("This is a test E")
+        await handler.push_chunk("N")
+
+        # should be buffered in current_chunk, not streamed yet
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 0
+
+        await handler.push_chunk("D")
+        await handler.push_chunk("")  # NOTE: will get changed to SENTINEL
+
+        # Check that suffix was removed
+        chunks = await consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0] == "This is a test "
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_none_element():
+    """Test __anext__ method with None element."""
+
+    streaming_handler = StreamingHandler()
+
+    # put None into the queue (signal to stop streaming)
+    await streaming_handler.queue.put(None)
+
+    # call __anext__ directly
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_empty_string():
+    """Test __anext__ method with empty string."""
+    streaming_handler = StreamingHandler()
+
+    # NOTE: azure openai issue
+    # put empty string into the queue
+    await streaming_handler.queue.put("")
+
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_dict_empty_text():
+    """Test __anext__ method with dict containing empty text."""
+    streaming_handler = StreamingHandler()
+
+    # put dict with empty text into the queue
+    await streaming_handler.queue.put({"text": "", "generation_info": {}})
+
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_dict_none_text():
+    """Test __anext__ method with dict containing None text."""
+    streaming_handler = StreamingHandler()
+
+    # NOTE: azure openai issue
+    # put dict with None text into the queue
+    await streaming_handler.queue.put({"text": None, "generation_info": {}})
+
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_normal_text():
+    """Test __anext__ method with normal text."""
+    streaming_handler = StreamingHandler()
+
+    test_text = "test text"
+    await streaming_handler.queue.put(test_text)
+
+    result = await streaming_handler.__anext__()
+    assert result == test_text
+
+
+@pytest.mark.asyncio
+async def test_anext_with_event_loop_closed():
+    """Test __anext__ method with RuntimeError 'Event loop is closed'."""
+
+    streaming_handler = StreamingHandler()
+
+    # mock queue.get to raise RuntimeError
+    with mock.patch.object(
+        streaming_handler.queue, "get", side_effect=RuntimeError("Event loop is closed")
+    ):
+        with pytest.raises(StopAsyncIteration):
+            await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_other_runtime_error():
+    """Test __anext__ method with other RuntimeError."""
+    streaming_handler = StreamingHandler()
+
+    # mock queue.get to raise other RuntimeError
+    with mock.patch.object(
+        streaming_handler.queue, "get", side_effect=RuntimeError("Some other error")
+    ):
+        # should propagate the error
+        with pytest.raises(RuntimeError, match="Some other error"):
+            await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_include_generation_metadata():
+    """Test push_chunk with generation_info when include_generation_metadata is True."""
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        test_text = "test text"
+        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
+
+        await streaming_handler.push_chunk(
+            test_text, generation_info=test_generation_info
+        )
+        await streaming_handler.push_chunk(
+            ""
+        )  # NOTE: sjignal end of streaming using "" will get changed soon
+
+        chunks = await streaming_consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0]["text"] == test_text
+        assert chunks[0]["generation_info"] == test_generation_info
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_include_generation_metadata_with_different_chunk_types():
+    """Test push_chunk with different chunk types when include_generation_metadata is True."""
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        test_text = "test text"
+        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
+
+        generation_chunk = GenerationChunk(
+            text=test_text, generation_info=test_generation_info
+        )
+        await streaming_handler.push_chunk(
+            generation_chunk, generation_info=test_generation_info
+        )
+        await streaming_handler.push_chunk(
+            ""
+        )  # NOTE: sjignal end of streaming using "" will get changed soon
+
+        chunks = await streaming_consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0]["text"] == test_text
+        assert chunks[0]["generation_info"] == test_generation_info
+    finally:
+        await streaming_consumer.cancel()
+
+    # reset handler and consumer for a clean test
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        ai_message_chunk = AIMessageChunk(content=test_text)
+        await streaming_handler.push_chunk(
+            ai_message_chunk, generation_info=test_generation_info
+        )
+        await streaming_handler.push_chunk(
+            ""
+        )  # NOTE: sjignal end of streaming using "" will get changed soon
+
+        chunks = await streaming_consumer.get_chunks()
+        assert len(chunks) >= 1
+        assert chunks[0]["text"] == test_text
+        assert chunks[0]["generation_info"] == test_generation_info
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_on_chat_model_start():
+    """Test on_chat_model_start method."""
+    streaming_handler = StreamingHandler()
+
+    streaming_handler.current_chunk = "existing chunk"
+
+    await streaming_handler.on_chat_model_start(
+        serialized={},
+        messages=[[]],
+        run_id=UUID("00000000-0000-0000-0000-000000000000"),
+    )
+
+    # current_chunk is reset
+    assert streaming_handler.current_chunk == ""
+
+
+@pytest.mark.asyncio
+async def test_on_llm_new_token_empty_then_nonempty():
+    """Test on_llm_new_token method with empty token followed by non-empty token."""
+    streaming_handler = StreamingHandler()
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        # first token is empty,  this will be skipped based on implementation
+        # NOTE: not azure openai bug
+        await streaming_handler.on_llm_new_token(
+            token="",
+            run_id=UUID("00000000-0000-0000-0000-000000000000"),
+        )
+
+        # second token is not empty, this should be processed
+        await streaming_handler.push_chunk("second")
+
+        # NOTE: will chnage to sentinel soon to explicitly end the streaming
+        await streaming_handler.push_chunk("")
+
+        # wait for the chunks to be processed
+        await asyncio.sleep(0.1)
+
+        chunks = await streaming_consumer.get_chunks()
+        assert len(chunks) == 1
+        assert chunks[0] == "second"
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_on_llm_new_token_with_generation_info():
+    """Test on_llm_new_token method with chunk that has generation_info."""
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        test_text = "test token"
+        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
+        chunk = GenerationChunk(text=test_text, generation_info=test_generation_info)
+
+        await streaming_handler.on_llm_new_token(
+            token=test_text,
+            chunk=chunk,
+            run_id=UUID("00000000-0000-0000-0000-000000000000"),
+        )
+
+        # NOTE: end streaming with None
+        await streaming_handler.on_llm_end(
+            response=None, run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+
+        chunks = await streaming_consumer.get_chunks()
+        # print(chunks)
+        # sounds like a bug
+        # assert len(chunks) == 1
+        # assert chunks[1]["text"] == ""
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == test_text
+        assert chunks[0]["generation_info"] == test_generation_info
+        assert chunks[1]["text"] == ""
+    finally:
+        await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_processing_metadata():
+    """Test that metadata is properly passed through the processing chain."""
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+
+    try:
+        streaming_handler.set_pattern(prefix="PREFIX: ", suffix="SUFFIX")
+
+        test_text = "PREFIX: This is a test message SUFFIX"
+        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
+
+        await streaming_handler.push_chunk(
+            test_text, generation_info=test_generation_info
+        )
+        await streaming_handler.push_chunk("")  # Signal end of streaming
+
+        chunks = await streaming_consumer.get_chunks()
+        assert len(chunks) >= 1
+        # NOTE: The suffix is only removed at the end of generation
+        assert "This is a test message" in chunks[0]["text"]
+        assert chunks[0]["generation_info"] == test_generation_info
+    finally:
+        await streaming_consumer.cancel()
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    streaming_consumer = StreamingConsumer(streaming_handler)
+    try:
+        streaming_handler.set_pattern(prefix="PREFIX: ", suffix="SUFFIX")
+
+        await streaming_handler.push_chunk("PRE", generation_info={"part": 1})
+        await streaming_handler.push_chunk("FIX: ", generation_info={"part": 2})
+        await streaming_handler.push_chunk("Test ", generation_info={"part": 3})
+        await streaming_handler.push_chunk("message", generation_info={"part": 4})
+        await streaming_handler.push_chunk(" SUFF", generation_info={"part": 5})
+        await streaming_handler.push_chunk("IX", generation_info={"part": 6})
+        await streaming_handler.push_chunk("")  # End of streaming
+
+        chunks = await streaming_consumer.get_chunks()
+        # the prefix removal should happen first, then streaming happens
+        # verify the text chunks are delivered correctly
+        assert len(chunks) >= 2
+        for i, expected in enumerate(
+            [
+                {"text": "Test ", "part": 3},
+                {"text": "message", "part": 4},
+            ]
+        ):
+            if i < len(chunks) and "text" in chunks[i]:
+                assert chunks[i]["text"] == expected["text"]
+                assert chunks[i]["generation_info"]["part"] == expected["part"]
+    finally:
+        await streaming_consumer.cancel()

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -24,7 +24,7 @@ import pytest
 from langchain.schema.messages import AIMessageChunk
 from langchain.schema.output import GenerationChunk
 
-from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
 
 class StreamingConsumer:
@@ -124,7 +124,7 @@ async def _test_pattern_case(
                 await streaming_handler.push_chunk(chunk)
 
         # Push an empty chunk to signal the ending.
-        await streaming_handler.push_chunk("")
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         assert await streaming_consumer.get_chunks() == final_chunks
     finally:
@@ -288,7 +288,7 @@ async def test_set_pipe_to():
         # send chunks to main handler
         await main_handler.push_chunk("chunk1")
         await main_handler.push_chunk("chunk2")
-        await main_handler.push_chunk("")  # Signal end of streaming
+        await main_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
 
         # main handler received nothing (piped away)
         main_chunks = await main_consumer.get_chunks()
@@ -318,7 +318,7 @@ async def test_wait_method():
             await handler.push_chunk("chunk2")
             await asyncio.sleep(0.1)
             await handler.push_chunk(
-                ""
+                END_OF_STREAM
             )  # NOTE: signal end of streaming will get changed soon
 
         push_task = asyncio.create_task(push_chunks_with_delay())
@@ -419,7 +419,7 @@ async def test_multiple_stop_tokens():
         # Push text with a stop token in the middle
         await handler.push_chunk("This is some text STOP1 and this should be ignored")
         await handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: Signal end of streaming we are going to change this
 
         # streaming stopped at the stop token
@@ -436,7 +436,7 @@ async def test_multiple_stop_tokens():
 
         await handler.push_chunk("Different text with HALT token")
         await handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: Signal end of streaming we are going to change this
 
         chunks = await consumer.get_chunks()
@@ -500,7 +500,7 @@ async def test_first_token_handling():
         # first_token is now False
         assert handler.first_token is False
         # push_chunk was not called (empty first token is skipped)
-        assert push_chunk_called is False
+        assert push_chunk_called is True
 
         # reset the mock state
         push_chunk_called = False
@@ -536,7 +536,7 @@ async def test_first_token_handling():
                 except asyncio.QueueEmpty:
                     break
             # Signal end if push_chunk was mocked and might not have done it
-            await handler.queue.put(None)
+            await handler.queue.put(END_OF_STREAM)
 
 
 @pytest.mark.asyncio
@@ -557,7 +557,7 @@ async def test_suffix_removal_at_end():
         assert len(chunks) == 0
 
         await handler.push_chunk("D")
-        await handler.push_chunk("")  # NOTE: will get changed to SENTINEL
+        await handler.push_chunk(END_OF_STREAM)  # NOTE: will get changed to SENTINEL
 
         # Check that suffix was removed
         chunks = await consumer.get_chunks()
@@ -569,14 +569,27 @@ async def test_suffix_removal_at_end():
 
 @pytest.mark.asyncio
 async def test_anext_with_none_element():
-    """Test __anext__ method with None element."""
+    """Test __anext__ method with None element (now END_OF_STREAM sentinel)."""
 
     streaming_handler = StreamingHandler()
 
-    # put None into the queue (signal to stop streaming)
-    await streaming_handler.queue.put(None)
+    # put END_OF_STREAM into the queue (signal to stop streaming)
+    await streaming_handler.queue.put(END_OF_STREAM)
 
     # call __anext__ directly
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_end_of_stream_sentinel():
+    """Test __anext__ method explicitly with END_OF_STREAM sentinel."""
+    streaming_handler = StreamingHandler()
+
+    # Put END_OF_STREAM into the queue
+    await streaming_handler.queue.put(END_OF_STREAM)
+
+    # Call __anext__ and expect StopAsyncIteration
     with pytest.raises(StopAsyncIteration):
         await streaming_handler.__anext__()
 
@@ -590,33 +603,35 @@ async def test_anext_with_empty_string():
     # put empty string into the queue
     await streaming_handler.queue.put("")
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == ""
 
 
 @pytest.mark.asyncio
 async def test_anext_with_dict_empty_text():
     """Test __anext__ method with dict containing empty text."""
     streaming_handler = StreamingHandler()
+    test_val = {"text": "", "generation_info": {}}
 
     # put dict with empty text into the queue
-    await streaming_handler.queue.put({"text": "", "generation_info": {}})
+    await streaming_handler.queue.put(test_val)
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == test_val
 
 
 @pytest.mark.asyncio
 async def test_anext_with_dict_none_text():
     """Test __anext__ method with dict containing None text."""
     streaming_handler = StreamingHandler()
+    test_val = {"text": None, "generation_info": {}}
 
     # NOTE: azure openai issue
     # put dict with None text into the queue
-    await streaming_handler.queue.put({"text": None, "generation_info": {}})
+    await streaming_handler.queue.put(test_val)
 
-    with pytest.raises(StopAsyncIteration):
-        await streaming_handler.__anext__()
+    result = await streaming_handler.__anext__()
+    assert result == test_val
 
 
 @pytest.mark.asyncio
@@ -641,8 +656,8 @@ async def test_anext_with_event_loop_closed():
     with mock.patch.object(
         streaming_handler.queue, "get", side_effect=RuntimeError("Event loop is closed")
     ):
-        with pytest.raises(StopAsyncIteration):
-            await streaming_handler.__anext__()
+        result = await streaming_handler.__anext__()
+        assert result is None
 
 
 @pytest.mark.asyncio
@@ -673,7 +688,7 @@ async def test_include_generation_metadata():
             test_text, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -702,7 +717,7 @@ async def test_include_generation_metadata_with_different_chunk_types():
             generation_chunk, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -722,7 +737,7 @@ async def test_include_generation_metadata_with_different_chunk_types():
             ai_message_chunk, generation_info=test_generation_info
         )
         await streaming_handler.push_chunk(
-            ""
+            END_OF_STREAM
         )  # NOTE: sjignal end of streaming using "" will get changed soon
 
         chunks = await streaming_consumer.get_chunks()
@@ -768,14 +783,15 @@ async def test_on_llm_new_token_empty_then_nonempty():
         await streaming_handler.push_chunk("second")
 
         # NOTE: will chnage to sentinel soon to explicitly end the streaming
-        await streaming_handler.push_chunk("")
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         # wait for the chunks to be processed
         await asyncio.sleep(0.1)
 
         chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) == 1
-        assert chunks[0] == "second"
+        assert len(chunks) == 2
+        assert chunks[0] == ""
+        assert chunks[1] == "second"
     finally:
         await streaming_consumer.cancel()
 
@@ -803,14 +819,11 @@ async def test_on_llm_new_token_with_generation_info():
         )
 
         chunks = await streaming_consumer.get_chunks()
-        # print(chunks)
-        # sounds like a bug
-        # assert len(chunks) == 1
-        # assert chunks[1]["text"] == ""
         assert len(chunks) == 2
         assert chunks[0]["text"] == test_text
         assert chunks[0]["generation_info"] == test_generation_info
-        assert chunks[1]["text"] == ""
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == test_generation_info
     finally:
         await streaming_consumer.cancel()
 
@@ -830,7 +843,7 @@ async def test_processing_metadata():
         await streaming_handler.push_chunk(
             test_text, generation_info=test_generation_info
         )
-        await streaming_handler.push_chunk("")  # Signal end of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
 
         chunks = await streaming_consumer.get_chunks()
         assert len(chunks) >= 1
@@ -851,7 +864,7 @@ async def test_processing_metadata():
         await streaming_handler.push_chunk("message", generation_info={"part": 4})
         await streaming_handler.push_chunk(" SUFF", generation_info={"part": 5})
         await streaming_handler.push_chunk("IX", generation_info={"part": 6})
-        await streaming_handler.push_chunk("")  # End of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)  # End of streaming
 
         chunks = await streaming_consumer.get_chunks()
         # the prefix removal should happen first, then streaming happens

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -22,7 +22,7 @@ from uuid import UUID
 
 import pytest
 from langchain.schema.messages import AIMessageChunk
-from langchain.schema.output import GenerationChunk
+from langchain.schema.output import ChatGenerationChunk, GenerationChunk
 
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
@@ -881,3 +881,88 @@ async def test_processing_metadata():
                 assert chunks[i]["generation_info"]["part"] == expected["part"]
     finally:
         await streaming_consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_anext_with_dict_end_of_stream_sentinel():
+    """Test __anext__ with a dict-wrapped END_OF_STREAM sentinel."""
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    await streaming_handler.queue.put({"text": END_OF_STREAM, "generation_info": {}})
+    with pytest.raises(StopAsyncIteration):
+        await streaming_handler.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_with_chat_generation_chunk():
+    """Test push_chunk with a ChatGenerationChunk."""
+
+    streaming_handler = StreamingHandler()
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        chat_chunk = ChatGenerationChunk(message=AIMessageChunk(content="chat text"))
+        await streaming_handler.push_chunk(chat_chunk)
+        await streaming_handler.push_chunk(END_OF_STREAM)
+        chunks = await consumer.get_chunks()
+        assert chunks == ["chat text"]
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_with_chat_generation_chunk_with_metadata():
+    """Test push_chunk with a ChatGenerationChunk when metadata is included."""
+
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        message_chunk = AIMessageChunk(content="chat text")
+        chat_chunk = ChatGenerationChunk(
+            message=message_chunk, generation_info={"details": "some details"}
+        )
+        await streaming_handler.push_chunk(chat_chunk)
+        await streaming_handler.push_chunk(END_OF_STREAM)
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "chat text"
+        assert chunks[0]["generation_info"] == {"details": "some details"}
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == {"details": "some details"}
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_push_chunk_unsupported_type():
+    """Test push_chunk with an unsupported data type."""
+
+    streaming_handler = StreamingHandler()
+    with pytest.raises(Exception, match="Unsupported chunk type: int"):
+        await streaming_handler.push_chunk(123)
+    with pytest.raises(Exception, match="Unsupported chunk type: list"):
+        await streaming_handler.push_chunk([1, 2])
+
+
+@pytest.mark.asyncio
+async def test_on_llm_new_token_with_chunk_having_none_generation_info():
+    """Test on_llm_new_token when chunk.generation_info is None."""
+    streaming_handler = StreamingHandler(include_generation_metadata=True)
+    consumer = StreamingConsumer(streaming_handler)
+    try:
+        mock_chunk = GenerationChunk(text="test text", generation_info=None)
+        await streaming_handler.on_llm_new_token(
+            token="test text",
+            chunk=mock_chunk,
+            run_id=UUID("00000000-0000-0000-0000-000000000000"),
+        )
+        await streaming_handler.on_llm_end(
+            response=None, run_id=UUID("00000000-0000-0000-0000-000000000000")
+        )
+        chunks = await consumer.get_chunks()
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "test text"
+        assert chunks[0]["generation_info"] == {}
+        assert chunks[1]["text"] is END_OF_STREAM
+        assert chunks[1]["generation_info"] == {}
+    finally:
+        await consumer.cancel()


### PR DESCRIPTION

## Description

@Pouyanpi this PR is meant to solve a minor bug on tracking the llm call done by nemo guardrails when used in streaming async mode


## Related Issue(s)

[issue-1192](https://github.com/NVIDIA/NeMo-Guardrails/issues/1192)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
