### PR TITLE
fix: Prevent explain_info overwrite during stream_async

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -51,7 +51,6 @@ from nemoguardrails.context import (
     generation_options_var,
     llm_stats_var,
     raw_llm_request,
-    reasoning_trace_var,
     streaming_handler_var,
 )
 from nemoguardrails.embeddings.index import EmbeddingsIndex
@@ -576,6 +575,20 @@ class LLMRails:
 
         return events
 
+    @staticmethod
+    def _ensure_explain_info() -> ExplainInfo:
+        """Ensure that the ExplainInfo variable is present in the current context
+
+        Returns:
+            A ExplainInfo class containing the llm calls' statistics
+        """
+        explain_info = explain_info_var.get()
+        if explain_info is None:
+            explain_info = ExplainInfo()
+            explain_info_var.set(explain_info)
+
+        return explain_info
+
     async def generate_async(
         self,
         prompt: Optional[str] = None,
@@ -634,14 +647,7 @@ class LLMRails:
         # Initialize the object with additional explanation information.
         # We allow this to also be set externally. This is useful when multiple parallel
         # requests are made.
-        explain_info = explain_info_var.get()
-        if explain_info is None:
-            explain_info = ExplainInfo()
-            explain_info_var.set(explain_info)
-
-            # We also keep a general reference to this object
-            self.explain_info = explain_info
-        self.explain_info = explain_info
+        self.explain_info = self._ensure_explain_info()
 
         if prompt is not None:
             # Currently, we transform the prompt request into a single turn conversation
@@ -805,9 +811,9 @@ class LLMRails:
 
         # If logging is enabled, we log the conversation
         # TODO: add support for logging flag
-        explain_info.colang_history = get_colang_history(events)
+        self.explain_info.colang_history = get_colang_history(events)
         if self.verbose:
-            log.info(f"Conversation history so far: \n{explain_info.colang_history}")
+            log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
 
         total_time = time.time() - t0
         log.info(
@@ -960,6 +966,8 @@ class LLMRails:
         include_generation_metadata: Optional[bool] = False,
     ) -> AsyncIterator[str]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
+        self.explain_info = self._ensure_explain_info()
+
         streaming_handler = StreamingHandler(
             include_generation_metadata=include_generation_metadata
         )
@@ -1278,13 +1286,6 @@ class LLMRails:
                 **action_params,
             }
 
-        def _update_explain_info():
-            explain_info = explain_info_var.get()
-            if explain_info is None:
-                explain_info = ExplainInfo()
-                explain_info_var.set(explain_info)
-                self.explain_info = explain_info
-
         output_rails_streaming_config = self.config.rails.output.streaming
         buffer_strategy = get_buffer_strategy(output_rails_streaming_config)
         output_rails_flows_id = self.config.rails.output.flows
@@ -1329,7 +1330,7 @@ class LLMRails:
                     action_name, params
                 )
                 # Include explain info (whatever _update_explain_info does)
-                _update_explain_info()
+                self.explain_info = self._ensure_explain_info()
 
                 # Retrieve the action function from the dispatcher
                 action_func = self.runtime.action_dispatcher.get_action(action_name)

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -813,7 +813,9 @@ class LLMRails:
         # TODO: add support for logging flag
         self.explain_info.colang_history = get_colang_history(events)
         if self.verbose:
-            log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
+            log.info(
+                f"Conversation history so far: \n{self.explain_info.colang_history}"
+            )
 
         total_time = time.time() - t0
         log.info(

--- a/tests/test_llm_rails_context_variables.py
+++ b/tests/test_llm_rails_context_variables.py
@@ -50,10 +50,10 @@ async def test_1():
     }, "message content do not match"
 
     # note that 2 llm call are expected as we matched the bot intent
-    assert len(chat.app.explain().llm_calls) == 2, (
-        "number of llm call not as expected. Expected 2, found {}".format(
-            len(chat.app.explain().llm_calls)
-        )
+    assert (
+        len(chat.app.explain().llm_calls) == 2
+    ), "number of llm call not as expected. Expected 2, found {}".format(
+        len(chat.app.explain().llm_calls)
     )
 
 
@@ -108,10 +108,10 @@ async def test_2():
         chunks.append(chunk)
 
     # note that 6 llm call are expected as we matched the bot intent
-    assert len(chat.app.explain().llm_calls) == 5, (
-        "number of llm call not as expected. Expected 5, found {}".format(
-            len(chat.app.explain().llm_calls)
-        )
+    assert (
+        len(chat.app.explain().llm_calls) == 5
+    ), "number of llm call not as expected. Expected 5, found {}".format(
+        len(chat.app.explain().llm_calls)
     )
 
     await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})

--- a/tests/test_llm_rails_context_variables.py
+++ b/tests/test_llm_rails_context_variables.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+
+@pytest.mark.asyncio
+async def test_1():
+    config = RailsConfig.from_content(
+        """
+        define user express greeting
+            "hello"
+
+        define flow
+            user express greeting
+            bot express greeting
+        """
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "express greeting",
+            "Hello! I'm doing great, thank you. How can I assist you today?",
+        ],
+    )
+
+    new_messages = await chat.app.generate_async(
+        messages=[{"role": "user", "content": "hi, how are you"}]
+    )
+
+    assert new_messages == {
+        "content": "Hello! I'm doing great, thank you. How can I assist you today?",
+        "role": "assistant",
+    }, "message content do not match"
+
+    # note that 2 llm call are expected as we matched the bot intent
+    assert len(chat.app.explain().llm_calls) == 2, (
+        "number of llm call not as expected. Expected 2, found {}".format(
+            len(chat.app.explain().llm_calls)
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_2():
+    config = RailsConfig.from_content(
+        config={
+            "models": [],
+            "rails": {
+                "output": {
+                    # run the real self check output rails
+                    "flows": {"self check output"},
+                    "streaming": {
+                        "enabled": True,
+                        "chunk_size": 4,
+                        "context_size": 2,
+                        "stream_first": False,
+                    },
+                }
+            },
+            "streaming": False,
+            "prompts": [{"task": "self_check_output", "content": "a test template"}],
+        },
+        colang_content="""
+        define user express greeting
+          "hi"
+
+        define flow
+          user express greeting
+          bot tell joke
+        """,
+    )
+
+    llm_completions = [
+        '  express greeting\nbot express greeting\n  "Hi, how are you doing?"',
+        '  "This is a joke that should be blocked."',
+        # add as many `no`` as chunks you want the output stream to check
+        "No",
+        "No",
+        "Yes",
+    ]
+
+    chat = TestChat(
+        config,
+        llm_completions=llm_completions,
+        streaming=True,
+    )
+    chunks = []
+    async for chunk in chat.app.stream_async(
+        messages=[{"role": "user", "content": "Hi!"}],
+    ):
+        chunks.append(chunk)
+
+    # note that 6 llm call are expected as we matched the bot intent
+    assert len(chat.app.explain().llm_calls) == 5, (
+        "number of llm call not as expected. Expected 5, found {}".format(
+            len(chat.app.explain().llm_calls)
+        )
+    )
+
+    await asyncio.gather(*asyncio.all_tasks() - {asyncio.current_task()})


### PR DESCRIPTION
## Description


This PR addresses an issue where `self.explain_info` could be overwritten during calls to `stream_async`, potentially leading to incomplete explanation data.

The root cause was that the `generate_async` task and the `_run_output_rails_in_streaming` function (if output streaming rails were active) could independently initialize `ExplainInfo` objects if the `explain_info_var` context variable was not set prior to the `generate_async` task's creation.

The fix ensures that `explain_info_var` and `self.explain_info` are initialized at the beginning of the `stream_async` method. This guarantees that both the `generate_async` task (via context variable inheritance) and `_run_output_rails_in_streaming` use the same `ExplainInfo` instance, preserving data integrity.

[same as https://github.com/NVIDIA/NeMo-Guardrails/pull/1193 but with pre-commit hooks done]

## Related Issue(s)

#1192 

## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [ x ] I've added tests if applicable.
- [ x ] @mentions of the person or team responsible for reviewing proposed changes.
