### PR TITLE
fix the introduction of an additional space and split words in subtokens

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1297,7 +1297,7 @@ class LLMRails:
         )
 
         async for chunk_list, chunk_str_rep in buffer_strategy(streaming_handler):
-            chunk_str = " ".join(chunk_list)
+            chunk_str = "".join(chunk_list)
 
             # Check if chunk_str_rep is a JSON string
             # we yield a json error payload in generate_async when


### PR DESCRIPTION
## Description

Fix a problem in which words composed in sub-tokens are spitted in the based sub-tokens.
@Pouyanpi 

## Related Issue(s)

Solve issue: https://github.com/NVIDIA/NeMo-Guardrails/issues/1197


## Checklist

- [ x ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ x ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ x ] @mentions of the person or team responsible for reviewing proposed changes.
