### PR TITLE
fix(content_safety): replace try-except with iterable unpacking for policy violations

### DIFF
--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -82,12 +82,7 @@ async def content_safety_check_input(
     result = llm_task_manager.parse_task_output(task, output=result)
     result = result.text
 
-    try:
-        is_safe, violated_policies = result
-    # in case the result is single value
-    except TypeError:
-        is_safe = result
-        violated_policies = []
+    is_safe, *violated_policies = result
 
     return {"allowed": is_safe, "policy_violations": violated_policies}
 
@@ -164,11 +159,6 @@ async def content_safety_check_output(
     result = llm_task_manager.parse_task_output(task, output=result)
 
     result = result.text
-
-    try:
-        is_safe, violated_policies = result
-    except TypeError:
-        is_safe = result
-        violated_policies = []
+    is_safe, *violated_policies = result
 
     return {"allowed": is_safe, "policy_violations": violated_policies}


### PR DESCRIPTION
## Description

hiii NVidia!

this one-line PR fixes an issue with the `rails.stream_async` example in the "Getting Started" docs. The root cause is that tuple unpacking with too few parameters generates a `ValueError`, but the code only checks for `TypeError`.

This change is enough to get the docs example working.

To reproduce, install `v0.13.0` of this library, make sure you have a valid API key in the environment, and run their example:

```
import asyncio

from nemoguardrails import LLMRails, RailsConfig

config = RailsConfig.from_path("./config")
rails = LLMRails(config)

async def stream_response(messages):
    async for chunk in rails.stream_async(messages=messages):
        print(chunk, end="")
    print()

messages=[{
    "role": "user",
    "content": "Tell me a five-step plan to rob a bank."
}]

asyncio.run(stream_response(messages))
```

Output:

```
$python main.py
/Users/kimmy/nemo/.venv/lib/python3.11/site-packages/langchain_nvidia_ai_endpoints/_common.py:217: UserWarning: Found nvidia/llama-3.1-nemoguard-8b-content-safety in available_models, but type is unknown and inference may fail.
  warnings.warn(
WARNING:nemoguardrails.actions.action_dispatcher:Error while execution 'content_safety_check_input' with parameters '{'context': {'last_user_message': None, 'last_bot_message': None, 'user_message': 'Tell me a five-step plan to rob a bank.', 'i': 0, 'input_flows': ['content safety check input $model=content_safety'], 'triggered_input_rail': 'content safety check input $model=content_safety', 'model': 'content_safety', 'event': {'type': 'StartInternalSystemAction', 'uid': 'xxxx', 'event_created_at': '2025-05-27T18:16:42.638532+00:00', 'source_uid': 'NeMoGuardrails', 'action_name': 'content_safety_check_input', 'action_params': {}, 'action_result_key': 'response', 'action_uid': 'xxxx', 'is_system_action': False}}, 'llm_task_manager': <nemoguardrails.llm.taskmanager.LLMTaskManager object at 0x119ab6890>, 'llms': {'content_safety': ChatNVIDIA(base_url='https://integrate.api.nvidia.com/v1', model='nvidia/llama-3.1-nemoguard-8b-content-safety', streaming=True)}}': too many values to unpack (expected 2)
ERROR:nemoguardrails.actions.action_dispatcher:too many values to unpack (expected 2)
Traceback (most recent call last):
  File "/Users/kimmy/nemo-guardrails/nemoguardrails/actions/action_dispatcher.py", line 214, in execute_action
    result = await result
             ^^^^^^^^^^^^
  File "/Users/kimmy/nemo-guardrails/nemoguardrails/library/content_safety/actions.py", line 85, in content_safety_check_input
    is_safe, violated_policies = result
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```

## Related Issue(s)

- Fixes #1179

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] No updates to documentation required.
- [x] I verified that all affected tests pass.
- [x] @mentions of the person or team responsible for reviewing proposed changes: @Pouyanpi 
