### PR TITLE
Support NIM API key for NemoGuard JailbreakDetect

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -96,6 +96,7 @@ async def jailbreak_detection_model(
     jailbreak_api_url = jailbreak_config.server_endpoint
     nim_url = jailbreak_config.nim_url
     nim_port = jailbreak_config.nim_port
+    nim_auth_token = jailbreak_config.nim_auth_token
 
     if context is not None:
         prompt = context.get("user_message", "")
@@ -116,7 +117,10 @@ async def jailbreak_detection_model(
 
     if nim_url:
         jailbreak = await jailbreak_nim_request(
-            prompt=prompt, nim_url=nim_url, nim_port=nim_port
+            prompt=prompt,
+            nim_url=nim_url,
+            nim_port=nim_port,
+            nim_auth_token=nim_auth_token,
         )
     elif jailbreak_api_url:
         jailbreak = await jailbreak_detection_model_request(

--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -97,6 +97,7 @@ async def jailbreak_detection_model(
     nim_url = jailbreak_config.nim_url
     nim_port = jailbreak_config.nim_port
     nim_auth_token = jailbreak_config.nim_auth_token
+    nim_classification_path = jailbreak_config.nim_classification_path
 
     if context is not None:
         prompt = context.get("user_message", "")
@@ -121,6 +122,7 @@ async def jailbreak_detection_model(
             nim_url=nim_url,
             nim_port=nim_port,
             nim_auth_token=nim_auth_token,
+            nim_classification_path=nim_classification_path,
         )
     elif jailbreak_api_url:
         jailbreak = await jailbreak_detection_model_request(

--- a/nemoguardrails/library/jailbreak_detection/request.py
+++ b/nemoguardrails/library/jailbreak_detection/request.py
@@ -96,10 +96,9 @@ async def jailbreak_detection_model_request(
 
 
 async def jailbreak_nim_request(
-    prompt: str,
-    nim_url: str,
-    nim_port: int,
+    prompt: str, nim_url: str, nim_port: int, nim_auth_token: str
 ):
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
     payload = {
         "input": prompt,
     }
@@ -108,7 +107,11 @@ async def jailbreak_nim_request(
     try:
         async with aiohttp.ClientSession() as session:
             try:
-                async with session.post(endpoint, json=payload, timeout=30) as resp:
+                if nim_auth_token is not None:
+                    headers["Authorization: Bearer"] = nim_auth_token
+                async with session.post(
+                    endpoint, json=payload, headers=headers, timeout=30
+                ) as resp:
                     if resp.status != 200:
                         log.error(
                             f"NemoGuard JailbreakDetect NIM request failed with status {resp.status}"

--- a/nemoguardrails/library/jailbreak_detection/request.py
+++ b/nemoguardrails/library/jailbreak_detection/request.py
@@ -96,14 +96,18 @@ async def jailbreak_detection_model_request(
 
 
 async def jailbreak_nim_request(
-    prompt: str, nim_url: str, nim_port: int, nim_auth_token: str
+    prompt: str,
+    nim_url: str,
+    nim_port: int,
+    nim_auth_token: str,
+    nim_classification_path: str,
 ):
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
     payload = {
         "input": prompt,
     }
 
-    endpoint = f"http://{nim_url}:{nim_port}/v1/classify"
+    endpoint = f"http://{nim_url}:{nim_port}{nim_classification_path}"
     try:
         async with aiohttp.ClientSession() as session:
             try:

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -576,6 +576,9 @@ class JailbreakDetectionConfig(BaseModel):
         default=None,
         description="API key for JailbreakDetect NIM",
     )
+    nim_classification_path: Optional[str] = Field(
+        default="/v1/classify", description="Classification path uri"
+    )
     embedding: Optional[str] = Field(
         default="nvidia/nv-embedqa-e5-v5",
         description="DEPRECATED: Model to use for embedding-based detections. Use NIM instead.",

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -556,7 +556,7 @@ class JailbreakDetectionConfig(BaseModel):
 
     server_endpoint: Optional[str] = Field(
         default=None,
-        description="The endpoint for the jailbreak detection heuristics server.",
+        description="The endpoint for the jailbreak detection server.",
     )
     length_per_perplexity_threshold: float = Field(
         default=89.79, description="The length/perplexity threshold."
@@ -571,6 +571,10 @@ class JailbreakDetectionConfig(BaseModel):
     nim_port: int = Field(
         default=8000,
         description="Port the NemoGuard JailbreakDetect NIM is listening on.",
+    )
+    nim_auth_token: Optional[str] = Field(
+        default=None,
+        description="API key for JailbreakDetect NIM",
     )
     embedding: Optional[str] = Field(
         default="nvidia/nv-embedqa-e5-v5",


### PR DESCRIPTION
Update jailbreak detection compatibility for NIM to allow providing an API key.

Tagging @tgasser-nv for review

## Description
Allows the use of `integrate.nvidia.com` and other NIM deployments that require API key.

* Modified `config.JailbreakDetectionConfig` object to include `nim_auth_token` parameter with a default value of `None` and `nim_classification_path` with a default value of `"/v1/classify"`.
* Modified `jailbreak_detection.request.jailbreak_nim_request` to accept `nim_auth_token` and `nim_classification_path` parameters and add the `"Authorization: Bearer"` header if a key is provided.
* Modified `jailbreak_detection.actions.jailbreak_detection_model` to extract the `nim_auth_token` and `nim_classification_path` from the config and pass them to `jailbreak_nim_request`.

Tested with config values: 
* `nim_url = "https://ai.api.nvidia.com"`
* `nim_port=443`
* `nim_auth_token=my_token`
* `nim_classification_path="/v1/security/nvidia/nemoguard-jailbreak-detect"`


## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x ] I've updated the documentation if applicable.
- [ x] I've added tests if applicable.
- [ x] @mentions of the person or team responsible for reviewing proposed changes.
