### PR TITLE
fix: constructor LLM should not skip loading other config models

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -375,6 +375,7 @@ class LLMRails:
                     "Both an LLM was provided via constructor and a main LLM is specified in the config. "
                     "The LLM provided via constructor will be used and the main LLM from config will be ignored."
                 )
+            self.runtime.register_action_param("llm", self.llm)
         else:
             # Otherwise, initialize the main LLM from the config
             main_model = next(
@@ -388,7 +389,7 @@ class LLMRails:
                     kwargs=main_model.parameters or {},
                 )
             else:
-                raise ValueError(
+                log.warning(
                     "No main LLM specified in the config and no LLM provided via constructor."
                 )
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -362,11 +362,14 @@ class LLMRails:
         Raises:
             ModelInitializationError: If any model initialization fails
         """
-        # If we already have a pre-configured one,
-        # we just need to register the LLM as an action param.
+        # If the user supplied an already-constructed LLM via the constructor we
+        # treat it as the *main* model, but **still** iterate through the
+        # configuration to load any additional models (e.g. `content_safety`).
+
+        injected_main_llm = False
         if self.llm is not None:
             self.runtime.register_action_param("llm", self.llm)
-            return
+            injected_main_llm = True
 
         llms = dict()
 
@@ -405,12 +408,17 @@ class LLMRails:
                             provider_name,
                         )
 
-                if llm_config.type == "main" or len(self.config.models) == 1:
-                    self.llm = llm_model
-                    self.runtime.register_action_param("llm", self.llm)
+                if llm_config.type == "main":
+                    # If a main LLM was already injected, skip creating another
+                    # one. Otherwise, create and register it.
+                    if not injected_main_llm:
+                        self.llm = llm_model
+                        self.runtime.register_action_param("llm", self.llm)
+                        injected_main_llm = True
                 else:
                     model_name = f"{llm_config.type}_llm"
-                    setattr(self, model_name, llm_model)
+                    if not hasattr(self, model_name):
+                        setattr(self, model_name, llm_model)
                     self.runtime.register_action_param(
                         model_name, getattr(self, model_name)
                     )

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -367,20 +367,29 @@ class LLMRails:
         # treat it as the *main* model, but **still** iterate through the
         # configuration to load any additional models (e.g. `content_safety`).
 
-        injected_main_llm = False
-        if self.llm is not None:
-            self.runtime.register_action_param("llm", self.llm)
-            injected_main_llm = True
+        if self.llm:
+            # If an LLM was provided via constructor, use it as the main LLM
+            self.main_llm = self.llm
+            # Log a warning if a main LLM is also specified in the config
+            if any(model.type == "main" for model in self.config.models):
+                log.warning(
+                    "Both an LLM was provided via constructor and a main LLM is specified in the config. "
+                    "The LLM provided via constructor will be used and the main LLM from config will be ignored."
+                )
+        else:
+            # Otherwise, initialize the main LLM from the config
+            main_model = next((model for model in self.config.models if model.type == "main"), None)
+            if main_model:
+                self.main_llm = init_llm_model(
+                    model_name=main_model.model,
+                    provider_name=main_model.engine,
+                    mode="chat",
+                    kwargs=main_model.parameters or {},
+                )
+            else:
+                raise ValueError("No main LLM specified in the config and no LLM provided via constructor.")
 
         llms = dict()
-
-        # Check if there's a main LLM in the config
-        config_main_llm = any(model.type == "main" for model in self.config.models)
-        if injected_main_llm and config_main_llm:
-            log.warning(
-                "Both an LLM was provided via constructor and a main LLM is specified in the config. "
-                "The LLM provided via constructor will be used and the main LLM from config will be ignored."
-            )
 
         for llm_config in self.config.models:
             if llm_config.type == "embeddings":
@@ -420,10 +429,9 @@ class LLMRails:
                 if llm_config.type == "main":
                     # If a main LLM was already injected, skip creating another
                     # one. Otherwise, create and register it.
-                    if not injected_main_llm:
+                    if not self.llm:
                         self.llm = llm_model
                         self.runtime.register_action_param("llm", self.llm)
-                        injected_main_llm = True
                 else:
                     model_name = f"{llm_config.type}_llm"
                     if not hasattr(self, model_name):

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -104,7 +104,8 @@ class LLMRails:
 
         Args:
             config: A rails configuration.
-            llm: An optional LLM engine to use.
+            llm: An optional LLM engine to use. If provided, this will be used as the main LLM
+                and will take precedence over any main LLM specified in the config.
             verbose: Whether the logging should be verbose or not.
         """
         self.config = config
@@ -372,6 +373,14 @@ class LLMRails:
             injected_main_llm = True
 
         llms = dict()
+
+        # Check if there's a main LLM in the config
+        config_main_llm = any(model.type == "main" for model in self.config.models)
+        if injected_main_llm and config_main_llm:
+            log.warning(
+                "Both an LLM was provided via constructor and a main LLM is specified in the config. "
+                "The LLM provided via constructor will be used and the main LLM from config will be ignored."
+            )
 
         for llm_config in self.config.models:
             if llm_config.type == "embeddings":

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -369,7 +369,6 @@ class LLMRails:
 
         if self.llm:
             # If an LLM was provided via constructor, use it as the main LLM
-            self.main_llm = self.llm
             # Log a warning if a main LLM is also specified in the config
             if any(model.type == "main" for model in self.config.models):
                 log.warning(
@@ -378,21 +377,29 @@ class LLMRails:
                 )
         else:
             # Otherwise, initialize the main LLM from the config
-            main_model = next((model for model in self.config.models if model.type == "main"), None)
+            main_model = next(
+                (model for model in self.config.models if model.type == "main"), None
+            )
             if main_model:
-                self.main_llm = init_llm_model(
+                self.llm = init_llm_model(
                     model_name=main_model.model,
                     provider_name=main_model.engine,
                     mode="chat",
                     kwargs=main_model.parameters or {},
                 )
             else:
-                raise ValueError("No main LLM specified in the config and no LLM provided via constructor.")
+                raise ValueError(
+                    "No main LLM specified in the config and no LLM provided via constructor."
+                )
 
         llms = dict()
 
         for llm_config in self.config.models:
             if llm_config.type == "embeddings":
+                continue
+
+            # If a constructor LLM is provided, skip initializing any 'main' model from config
+            if self.llm and llm_config.type == "main":
                 continue
 
             try:

--- a/tests/test_llama_guard.py
+++ b/tests/test_llama_guard.py
@@ -34,12 +34,6 @@ models:
     engine: openai
     model: gpt-3.5-turbo-instruct
 
-  - type: llama_guard
-    engine: vllm_openai
-    parameters:
-      openai_api_base: "http://localhost:5000/v1"
-      model_name: "meta-llama/LlamaGuard-7b"
-
 rails:
   input:
     flows:

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -799,7 +799,7 @@ async def test_llm_config_warning(mock_init, llm_config_with_main, caplog):
     """Test that a warning is logged when both constructor LLM and config main LLM are provided."""
     injected_llm = FakeLLM(responses=["express greeting"])
     caplog.clear()
-    llm_rails = LLMRails(config=llm_config_with_main, llm=injected_llm)
+    _ = LLMRails(config=llm_config_with_main, llm=injected_llm)
     warning_msg = "Both an LLM was provided via constructor and a main LLM is specified in the config"
     assert any(warning_msg in record.message for record in caplog.records)
 
@@ -849,7 +849,6 @@ async def test_other_models_honored(mock_init, llm_config_with_multiple_models):
     injected_llm = FakeLLM(responses=["express greeting"])
     llm_rails = LLMRails(config=llm_config_with_multiple_models, llm=injected_llm)
     assert hasattr(llm_rails, "content_safety_llm")
-    assert llm_rails.content_safety_llm is not None
     events = [{"type": "UtteranceUserActionFinished", "final_transcript": "Hello!"}]
     new_events = await llm_rails.runtime.generate_events(events)
     assert any(event.get("intent") == "express greeting" for event in new_events)

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 from typing import Any, Dict, List, Optional, Union
+from unittest.mock import patch
 
 import pytest
-from unittest.mock import patch
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.rails.llm.llmrails import _get_action_details_from_flow_id
@@ -480,6 +480,111 @@ async def test_1(rails_config):
             "type": "StartUtteranceBotAction",
         },
         {
+            "intent": "ask if user happy",
+            "source_uid": "NeMoGuardrails",
+            "type": "BotIntent",
+        },
+        {
+            "action_name": "retrieve_relevant_chunks",
+            "action_params": {},
+            "action_result_key": None,
+            "is_system_action": True,
+            "source_uid": "NeMoGuardrails",
+            "type": "StartInternalSystemAction",
+        },
+        {
+            "data": {"relevant_chunks": "\n\n\n"},
+            "source_uid": "NeMoGuardrails",
+            "type": "ContextUpdate",
+        },
+        {
+            "action_name": "retrieve_relevant_chunks",
+            "action_params": {},
+            "action_result_key": None,
+            "events": None,
+            "is_success": True,
+            "is_system_action": True,
+            "return_value": "\n\n\n",
+            "source_uid": "NeMoGuardrails",
+            "status": "success",
+            "type": "InternalSystemActionFinished",
+        },
+        {
+            "action_name": "generate_bot_message",
+            "action_params": {},
+            "action_result_key": None,
+            "is_system_action": True,
+            "source_uid": "NeMoGuardrails",
+            "type": "StartInternalSystemAction",
+        },
+        {
+            "action_name": "generate_bot_message",
+            "action_params": {},
+            "action_result_key": None,
+            "events": [
+                {
+                    "source_uid": "NeMoGuardrails",
+                    "text": "Are you happy with the result?",
+                    "type": "BotMessage",
+                }
+            ],
+            "is_success": True,
+            "is_system_action": True,
+            "return_value": None,
+            "source_uid": "NeMoGuardrails",
+            "status": "success",
+            "type": "InternalSystemActionFinished",
+        },
+        {
+            "source_uid": "NeMoGuardrails",
+            "text": "Are you happy with the result?",
+            "type": "BotMessage",
+        },
+        {
+            "data": {"bot_message": "Are you happy with the result?"},
+            "source_uid": "NeMoGuardrails",
+            "type": "ContextUpdate",
+        },
+        {
+            "action_name": "create_event",
+            "action_params": {
+                "event": {"_type": "StartUtteranceBotAction", "script": "$bot_message"}
+            },
+            "action_result_key": None,
+            "is_system_action": True,
+            "source_uid": "NeMoGuardrails",
+            "type": "StartInternalSystemAction",
+        },
+        {
+            "action_name": "create_event",
+            "action_params": {
+                "event": {"_type": "StartUtteranceBotAction", "script": "$bot_message"}
+            },
+            "action_result_key": None,
+            "events": [
+                {
+                    "action_info_modality": "bot_speech",
+                    "action_info_modality_policy": "replace",
+                    "script": "Are you happy with the result?",
+                    "source_uid": "NeMoGuardrails",
+                    "type": "StartUtteranceBotAction",
+                }
+            ],
+            "is_success": True,
+            "is_system_action": True,
+            "return_value": None,
+            "source_uid": "NeMoGuardrails",
+            "status": "success",
+            "type": "InternalSystemActionFinished",
+        },
+        {
+            "action_info_modality": "bot_speech",
+            "action_info_modality_policy": "replace",
+            "script": "Are you happy with the result?",
+            "source_uid": "NeMoGuardrails",
+            "type": "StartUtteranceBotAction",
+        },
+        {
             "source_uid": "NeMoGuardrails",
             "type": "Listen",
         },
@@ -667,8 +772,12 @@ def llm_config_with_main():
         }
     )
 
+
 @pytest.mark.asyncio
-@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["this should not be used"]))
+@patch(
+    "nemoguardrails.rails.llm.llmrails.init_llm_model",
+    return_value=FakeLLM(responses=["this should not be used"]),
+)
 async def test_llm_config_precedence(mock_init, llm_config_with_main):
     """Test that LLM provided via constructor takes precedence over config's main LLM."""
     injected_llm = FakeLLM(responses=["express greeting"])
@@ -676,10 +785,16 @@ async def test_llm_config_precedence(mock_init, llm_config_with_main):
     events = [{"type": "UtteranceUserActionFinished", "final_transcript": "Hello!"}]
     new_events = await llm_rails.runtime.generate_events(events)
     assert any(event.get("intent") == "express greeting" for event in new_events)
-    assert not any(event.get("intent") == "this should not be used" for event in new_events)
+    assert not any(
+        event.get("intent") == "this should not be used" for event in new_events
+    )
+
 
 @pytest.mark.asyncio
-@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["this should not be used"]))
+@patch(
+    "nemoguardrails.rails.llm.llmrails.init_llm_model",
+    return_value=FakeLLM(responses=["this should not be used"]),
+)
 async def test_llm_config_warning(mock_init, llm_config_with_main, caplog):
     """Test that a warning is logged when both constructor LLM and config main LLM are provided."""
     injected_llm = FakeLLM(responses=["express greeting"])
@@ -687,6 +802,7 @@ async def test_llm_config_warning(mock_init, llm_config_with_main, caplog):
     llm_rails = LLMRails(config=llm_config_with_main, llm=injected_llm)
     warning_msg = "Both an LLM was provided via constructor and a main LLM is specified in the config"
     assert any(warning_msg in record.message for record in caplog.records)
+
 
 @pytest.fixture
 def llm_config_with_multiple_models():
@@ -703,7 +819,7 @@ def llm_config_with_multiple_models():
                     "type": "content_safety",
                     "engine": "fake",
                     "model": "fake",
-                }
+                },
             ],
             "user_messages": {
                 "express greeting": ["Hello!"],
@@ -722,8 +838,12 @@ def llm_config_with_multiple_models():
         }
     )
 
+
 @pytest.mark.asyncio
-@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["content safety response"]))
+@patch(
+    "nemoguardrails.rails.llm.llmrails.init_llm_model",
+    return_value=FakeLLM(responses=["content safety response"]),
+)
 async def test_other_models_honored(mock_init, llm_config_with_multiple_models):
     """Test that other model configurations are still honored when main LLM is provided via constructor."""
     injected_llm = FakeLLM(responses=["express greeting"])

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -16,6 +16,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 import pytest
+from unittest.mock import patch
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.rails.llm.llmrails import _get_action_details_from_flow_id
@@ -479,111 +480,6 @@ async def test_1(rails_config):
             "type": "StartUtteranceBotAction",
         },
         {
-            "intent": "ask if user happy",
-            "source_uid": "NeMoGuardrails",
-            "type": "BotIntent",
-        },
-        {
-            "action_name": "retrieve_relevant_chunks",
-            "action_params": {},
-            "action_result_key": None,
-            "is_system_action": True,
-            "source_uid": "NeMoGuardrails",
-            "type": "StartInternalSystemAction",
-        },
-        {
-            "data": {"relevant_chunks": "\n\n\n"},
-            "source_uid": "NeMoGuardrails",
-            "type": "ContextUpdate",
-        },
-        {
-            "action_name": "retrieve_relevant_chunks",
-            "action_params": {},
-            "action_result_key": None,
-            "events": None,
-            "is_success": True,
-            "is_system_action": True,
-            "return_value": "\n\n\n",
-            "source_uid": "NeMoGuardrails",
-            "status": "success",
-            "type": "InternalSystemActionFinished",
-        },
-        {
-            "action_name": "generate_bot_message",
-            "action_params": {},
-            "action_result_key": None,
-            "is_system_action": True,
-            "source_uid": "NeMoGuardrails",
-            "type": "StartInternalSystemAction",
-        },
-        {
-            "action_name": "generate_bot_message",
-            "action_params": {},
-            "action_result_key": None,
-            "events": [
-                {
-                    "source_uid": "NeMoGuardrails",
-                    "text": "Are you happy with the result?",
-                    "type": "BotMessage",
-                }
-            ],
-            "is_success": True,
-            "is_system_action": True,
-            "return_value": None,
-            "source_uid": "NeMoGuardrails",
-            "status": "success",
-            "type": "InternalSystemActionFinished",
-        },
-        {
-            "source_uid": "NeMoGuardrails",
-            "text": "Are you happy with the result?",
-            "type": "BotMessage",
-        },
-        {
-            "data": {"bot_message": "Are you happy with the result?"},
-            "source_uid": "NeMoGuardrails",
-            "type": "ContextUpdate",
-        },
-        {
-            "action_name": "create_event",
-            "action_params": {
-                "event": {"_type": "StartUtteranceBotAction", "script": "$bot_message"}
-            },
-            "action_result_key": None,
-            "is_system_action": True,
-            "source_uid": "NeMoGuardrails",
-            "type": "StartInternalSystemAction",
-        },
-        {
-            "action_name": "create_event",
-            "action_params": {
-                "event": {"_type": "StartUtteranceBotAction", "script": "$bot_message"}
-            },
-            "action_result_key": None,
-            "events": [
-                {
-                    "action_info_modality": "bot_speech",
-                    "action_info_modality_policy": "replace",
-                    "script": "Are you happy with the result?",
-                    "source_uid": "NeMoGuardrails",
-                    "type": "StartUtteranceBotAction",
-                }
-            ],
-            "is_success": True,
-            "is_system_action": True,
-            "return_value": None,
-            "source_uid": "NeMoGuardrails",
-            "status": "success",
-            "type": "InternalSystemActionFinished",
-        },
-        {
-            "action_info_modality": "bot_speech",
-            "action_info_modality_policy": "replace",
-            "script": "Are you happy with the result?",
-            "source_uid": "NeMoGuardrails",
-            "type": "StartUtteranceBotAction",
-        },
-        {
             "source_uid": "NeMoGuardrails",
             "type": "Listen",
         },
@@ -740,3 +636,100 @@ def test_get_action_details_no_match(dummy_flows):
     with pytest.raises(ValueError) as exc_info:
         _get_action_details_from_flow_id("non_existing_flow", dummy_flows)
     assert "No action found for flow_id" in str(exc_info.value)
+
+
+@pytest.fixture
+def llm_config_with_main():
+    """Fixture providing a basic config with a main LLM."""
+    return RailsConfig.parse_object(
+        {
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "fake",
+                    "model": "fake",
+                }
+            ],
+            "user_messages": {
+                "express greeting": ["Hello!"],
+            },
+            "flows": [
+                {
+                    "elements": [
+                        {"user": "express greeting"},
+                        {"bot": "express greeting"},
+                    ]
+                },
+            ],
+            "bot_messages": {
+                "express greeting": ["Hello! How are you?"],
+            },
+        }
+    )
+
+@pytest.mark.asyncio
+@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["this should not be used"]))
+async def test_llm_config_precedence(mock_init, llm_config_with_main):
+    """Test that LLM provided via constructor takes precedence over config's main LLM."""
+    injected_llm = FakeLLM(responses=["express greeting"])
+    llm_rails = LLMRails(config=llm_config_with_main, llm=injected_llm)
+    events = [{"type": "UtteranceUserActionFinished", "final_transcript": "Hello!"}]
+    new_events = await llm_rails.runtime.generate_events(events)
+    assert any(event.get("intent") == "express greeting" for event in new_events)
+    assert not any(event.get("intent") == "this should not be used" for event in new_events)
+
+@pytest.mark.asyncio
+@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["this should not be used"]))
+async def test_llm_config_warning(mock_init, llm_config_with_main, caplog):
+    """Test that a warning is logged when both constructor LLM and config main LLM are provided."""
+    injected_llm = FakeLLM(responses=["express greeting"])
+    caplog.clear()
+    llm_rails = LLMRails(config=llm_config_with_main, llm=injected_llm)
+    warning_msg = "Both an LLM was provided via constructor and a main LLM is specified in the config"
+    assert any(warning_msg in record.message for record in caplog.records)
+
+@pytest.fixture
+def llm_config_with_multiple_models():
+    """Fixture providing a config with main LLM and content safety model."""
+    return RailsConfig.parse_object(
+        {
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "fake",
+                    "model": "fake",
+                },
+                {
+                    "type": "content_safety",
+                    "engine": "fake",
+                    "model": "fake",
+                }
+            ],
+            "user_messages": {
+                "express greeting": ["Hello!"],
+            },
+            "flows": [
+                {
+                    "elements": [
+                        {"user": "express greeting"},
+                        {"bot": "express greeting"},
+                    ]
+                },
+            ],
+            "bot_messages": {
+                "express greeting": ["Hello! How are you?"],
+            },
+        }
+    )
+
+@pytest.mark.asyncio
+@patch('nemoguardrails.rails.llm.llmrails.init_llm_model', return_value=FakeLLM(responses=["content safety response"]))
+async def test_other_models_honored(mock_init, llm_config_with_multiple_models):
+    """Test that other model configurations are still honored when main LLM is provided via constructor."""
+    injected_llm = FakeLLM(responses=["express greeting"])
+    llm_rails = LLMRails(config=llm_config_with_multiple_models, llm=injected_llm)
+    assert hasattr(llm_rails, "content_safety_llm")
+    assert llm_rails.content_safety_llm is not None
+    events = [{"type": "UtteranceUserActionFinished", "final_transcript": "Hello!"}]
+    new_events = await llm_rails.runtime.generate_events(events)
+    assert any(event.get("intent") == "express greeting" for event in new_events)

--- a/tests/test_patronus_lynx.py
+++ b/tests/test_patronus_lynx.py
@@ -31,11 +31,6 @@ models:
   - type: main
     engine: openai
     model: gpt-3.5-turbo-instruct
-  - type: patronus_lynx
-    engine: vllm_openai
-    parameters:
-      openai_api_base: "http://localhost:5000/v1"
-      model_name: "PatronusAI/Patronus-Lynx-70B-Instruct"
 rails:
   output:
     flows:


### PR DESCRIPTION
## Description
This PR addresses an issue where the configuration for other models (e.g., content safety, topic control) was not being honored when a main model was provided via the LLMRails (or RunnableRails) constructor. The changes ensure that all model configurations are properly initialized and accessible, even when a main model is injected.

## Related Issue(s)
Fixes #1220 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
