### PR TITLE
lazy load jailbreak detection dependencies

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/model_based/checks.py
+++ b/nemoguardrails/library/jailbreak_detection/model_based/checks.py
@@ -14,29 +14,17 @@
 # limitations under the License.
 
 import os
-import pickle
 from functools import lru_cache
 from pathlib import Path
 from typing import Tuple, Union
 
 import numpy as np
-from sklearn.ensemble import RandomForestClassifier
-
-from nemoguardrails.library.jailbreak_detection.model_based.models import (
-    JailbreakClassifier,
-)
 
 models_path = os.environ.get("EMBEDDING_CLASSIFIER_PATH")
 
-# When we add NIM support, will need to remove this check.
-if models_path is None:
-    raise EnvironmentError(
-        "Please set the EMBEDDING_CLASSIFIER_PATH environment variable to point to the Classifier model_based folder"
-    )
-
 
 @lru_cache()
-def initialize_model(classifier_path: str = models_path) -> JailbreakClassifier:
+def initialize_model(classifier_path: str = models_path):
     """
     Initialize the global classifier model according to the configuration provided.
     Args
@@ -44,6 +32,14 @@ def initialize_model(classifier_path: str = models_path) -> JailbreakClassifier:
     Returns
         jailbreak_classifier: JailbreakClassifier object combining embedding model and NemoGuard JailbreakDetect RF
     """
+    if classifier_path is None:
+        raise EnvironmentError(
+            "Please set the EMBEDDING_CLASSIFIER_PATH environment variable to point to the Classifier model_based folder"
+        )
+
+    from nemoguardrails.library.jailbreak_detection.model_based.models import (
+        JailbreakClassifier,
+    )
 
     jailbreak_classifier = JailbreakClassifier(
         str(Path(classifier_path).joinpath("snowflake.pkl"))
@@ -54,7 +50,7 @@ def initialize_model(classifier_path: str = models_path) -> JailbreakClassifier:
 
 def check_jailbreak(
     prompt: str,
-    classifier: JailbreakClassifier = None,
+    classifier = None,
 ) -> dict:
     """
     Use embedding-based jailbreak detection model to check for the presence of a jailbreak

--- a/nemoguardrails/library/jailbreak_detection/model_based/models.py
+++ b/nemoguardrails/library/jailbreak_detection/model_based/models.py
@@ -18,12 +18,13 @@ import pickle
 from typing import Tuple
 
 import numpy as np
-import torch
-from transformers import AutoModel, AutoTokenizer
 
 
 class SnowflakeEmbed:
     def __init__(self):
+        import torch
+        from transformers import AutoModel, AutoTokenizer
+
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
         self.tokenizer = AutoTokenizer.from_pretrained(
             "snowflake/snowflake-arctic-embed-m-long"
@@ -38,6 +39,7 @@ class SnowflakeEmbed:
         self.model.eval()
 
     def __call__(self, text: str):
+        import torch
         tokens = self.tokenizer(
             [text], padding=True, truncation=True, return_tensors="pt", max_length=2048
         )
@@ -71,6 +73,7 @@ class NvEmbedE5:
 
 class JailbreakClassifier:
     def __init__(self, random_forest_path: str):
+        from sklearn.ensemble import RandomForestClassifier
         self.embed = SnowflakeEmbed()
         with open(random_forest_path, "rb") as fd:
             self.classifier = pickle.load(fd)


### PR DESCRIPTION
## Description

Fixes #1222 by making jailbreak detection dependencies lazy-loaded. This means torch, transformers, and sklearn are only imported when using the local model-based approach, not when using the NIM-based approach.

## Related Issue(s)

Fixes #1222 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
