### PR TITLE
feat: support full URL and auth token for jailbreak detection NIM

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/actions.py
+++ b/nemoguardrails/library/jailbreak_detection/actions.py
@@ -96,32 +96,54 @@ async def jailbreak_detection_model(
     jailbreak_api_url = jailbreak_config.server_endpoint
     nim_url = jailbreak_config.nim_url
     nim_port = jailbreak_config.nim_port
+    nim_full_url = getattr(jailbreak_config, "nim_full_url", None)
+    nim_auth_token = getattr(jailbreak_config, "nim_auth_token", None)
+
+    log.info(f"NIM configuration: url={nim_url}, port={nim_port}, full_url={nim_full_url}")
+    log.info(f"API URL: {jailbreak_api_url}")
 
     if context is not None:
         prompt = context.get("user_message", "")
+        log.info(f"Checking jailbreak for message: {prompt}")
 
-    if not jailbreak_api_url and not nim_url:
+    # First check if we should use NIM
+    if nim_url or nim_full_url:
+        log.info("Using NIM-based approach")
+        jailbreak = await jailbreak_nim_request(
+            prompt=prompt,
+            nim_url=nim_url,
+            nim_port=nim_port,
+            nim_full_url=nim_full_url,
+            nim_auth_token=nim_auth_token,
+        )
+        log.info(f"NIM jailbreak detection result: {jailbreak}")
+    # Then check if we should use the API endpoint
+    elif jailbreak_api_url:
+        log.info("Using API endpoint approach")
+        jailbreak = await jailbreak_detection_model_request(
+            prompt=prompt, api_url=jailbreak_api_url
+        )
+        log.info(f"API jailbreak detection result: {jailbreak}")
+    # Only if neither NIM nor API endpoint is configured, fall back to local model
+    else:
+        log.info("Falling back to local model approach")
+        # Import these only if we need to use the local model
         from nemoguardrails.library.jailbreak_detection.model_based.checks import (
             check_jailbreak,
             initialize_model,
         )
-
         log.warning(
             "No jailbreak detection endpoint set. Running in-process, NOT RECOMMENDED FOR PRODUCTION."
         )
-        classifier = initialize_model()
-        jailbreak = check_jailbreak(prompt=prompt, classifier=classifier)
-
-        return jailbreak["jailbreak"]
-
-    if nim_url:
-        jailbreak = await jailbreak_nim_request(
-            prompt=prompt, nim_url=nim_url, nim_port=nim_port
-        )
-    elif jailbreak_api_url:
-        jailbreak = await jailbreak_detection_model_request(
-            prompt=prompt, api_url=jailbreak_api_url
-        )
+        try:
+            classifier = initialize_model()
+            jailbreak = check_jailbreak(prompt=prompt, classifier=classifier)
+            log.info(f"Local model jailbreak detection result: {jailbreak}")
+            return jailbreak["jailbreak"]
+        except ImportError as e:
+            log.error(f"Failed to import required dependencies for local model: {e}")
+            log.error("Please install scikit-learn and torch, or use NIM-based approach")
+            return False
 
     if jailbreak is None:
         log.warning("Jailbreak endpoint not set up properly.")

--- a/nemoguardrails/library/jailbreak_detection/request.py
+++ b/nemoguardrails/library/jailbreak_detection/request.py
@@ -99,27 +99,46 @@ async def jailbreak_nim_request(
     prompt: str,
     nim_url: str,
     nim_port: int,
+    nim_full_url: Optional[str] = None,
+    nim_auth_token: Optional[str] = None,
 ):
     payload = {
         "input": prompt,
     }
 
-    endpoint = f"http://{nim_url}:{nim_port}/v1/classify"
+    # Use full URL if provided, else construct from host/port
+    if nim_full_url:
+        endpoint = nim_full_url
+    else:
+        endpoint = f"http://{nim_url}:{nim_port}/v1/classify"
+
+    headers = {}
+    if nim_auth_token:
+        headers["Authorization"] = f"Bearer {nim_auth_token}"
+
+    log.info(f"Making NIM request to: {endpoint}")
+    log.info(f"Headers: {headers}")
+    log.info(f"Payload: {payload}")
+
     try:
         async with aiohttp.ClientSession() as session:
             try:
-                async with session.post(endpoint, json=payload, timeout=30) as resp:
+                async with session.post(endpoint, json=payload, headers=headers, timeout=30) as resp:
+                    log.info(f"Response status: {resp.status}")
                     if resp.status != 200:
+                        response_text = await resp.text()
                         log.error(
-                            f"NemoGuard JailbreakDetect NIM request failed with status {resp.status}"
+                            f"NemoGuard JailbreakDetect NIM request failed with status {resp.status}. Response: {response_text}"
                         )
                         return None
 
                     result = await resp.json()
+                    log.info(f"Raw NIM response: {result}")
 
                     log.info(f"Prompt jailbreak check: {result}.")
                     try:
                         result = result["jailbreak"]
+                        log.info(f"Extracted jailbreak value: {result}")
                     except KeyError:
                         log.exception("No jailbreak field in result.")
                         result = None

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -572,6 +572,14 @@ class JailbreakDetectionConfig(BaseModel):
         default=8000,
         description="Port the NemoGuard JailbreakDetect NIM is listening on.",
     )
+    nim_full_url: Optional[str] = Field(
+        default=None,
+        description="Full URL to the NIM endpoint, e.g. https://host/path. If set, overrides nim_url/nim_port.",
+    )
+    nim_auth_token: Optional[str] = Field(
+        default=None,
+        description="Bearer token for authenticating to the NIM endpoint.",
+    )
     embedding: Optional[str] = Field(
         default="nvidia/nv-embedqa-e5-v5",
         description="DEPRECATED: Model to use for embedding-based detections. Use NIM instead.",


### PR DESCRIPTION
## Description

This PR adds support for specifying a full URL and authentication token for the Jailbreak Detection NIM service in the configuration.
- Updates the JailbreakDetectionConfig to include `nim_full_url` and `nim_auth_token` fields.
- Improves clarity of field descriptions and docstrings.

## Related Issue(s)

This is an alternate implementation approach that solves the same issue as #1214 (that PR did not work for me).

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.

@cparisien @tgasser-nv 
