### PR TITLE
fix: More heading levels so RNs resolve links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ exclude_patterns = [
 ]
 
 myst_linkify_fuzzy_links = False
-myst_heading_anchors = 3
+myst_heading_anchors = 4
 myst_enable_extensions = [
     "deflist",
     "dollarmath",


### PR DESCRIPTION
## Description

We need to increase the number of heading levels that are possible targets so that the RNs can link to the headings.

This fixes a goof in the [RNs](https://nvidia.github.io/NeMo-Guardrails/review/pr-1228/release-notes.html) where the "Added the rails.output.apply_to_reasoning_traces field" bullet did not end with a link _at all_.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
