### PR TITLE
ci: run pre-commit in pr-tests only

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      run-pre-commit:
+        description: "Whether to run pre-commit checks"
+        required: false
+        default: false
+        type: boolean
 
 defaults:
   run:
@@ -90,6 +95,7 @@ jobs:
           fi
 
       - name: Run pre-commit hooks
+        if: inputs.run-pre-commit
         run: poetry run make pre_commit
 
       - name: Run pytest

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,17 +1,7 @@
 name: Full Tests
 
 on:
-  pull_request:
-    types: [review_requested, ready_for_review]
-    paths-ignore:
-      - "**/*.md"
-      - ".github/**"
   push:
-    branches:
-      - main
-      - develop
-    tags:
-      - "v*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,6 +23,7 @@ jobs:
       os: ${{ matrix.os }}
       image: ${{ matrix.image }}
       python-version: ${{ matrix.python-version }}
+      run-pre-commit: true
   pr-tests-summary:
     name: PR Tests Summary
     needs: pr-tests-matrix

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ docs:
 	poetry run sphinx-build -b html docs _build/docs
 
 pre_commit:
-	pre-commit install
-	pre-commit run --all-files
+	poetry run pre-commit install
+	poetry run pre-commit run --all-files
 
 
 # HELP


### PR DESCRIPTION
Fixes pre-commit execution in cross platform CI workflows

### Problem
The `full-tests.yml` workflow (Windows/macOS) was failing with the error:
```
poetry run make pre_commit
pre-commit install
make: *** [Makefile:28: pre_commit] Error 1
Error: Process completed with exit code 2.
```

While the `pr-tests.yml` workflow (ubuntu) was passing successfully.

### Root cause

still not clear, but it is related to Windows' github runner.