### PR TITLE
feat: parallel rails execution

### DIFF
--- a/nemoguardrails/colang/runtime.py
+++ b/nemoguardrails/colang/runtime.py
@@ -43,6 +43,21 @@ class Runtime:
                 name="run_output_rails_in_parallel_streaming",
             )
 
+        if hasattr(self, "_run_flows_in_parallel"):
+            self.action_dispatcher.register_action(
+                self._run_flows_in_parallel, name="run_flows_in_parallel"
+            )
+
+        if hasattr(self, "_run_input_rails_in_parallel"):
+            self.action_dispatcher.register_action(
+                self._run_input_rails_in_parallel, name="run_input_rails_in_parallel"
+            )
+
+        if hasattr(self, "_run_output_rails_in_parallel"):
+            self.action_dispatcher.register_action(
+                self._run_output_rails_in_parallel, name="run_output_rails_in_parallel"
+            )
+
         # The list of additional parameters that can be passed to the actions.
         self.registered_action_params: dict = {}
 

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -293,12 +293,10 @@ class RuntimeV1_0(Runtime):
             post_events (List[dict], optional): Events to be added after finishing each flow.
         """
 
-        assert pre_events is None or len(pre_events) == len(
-            flows
-        ), "Number of pre-events must match number of flows."
-        assert post_events is None or len(post_events) == len(
-            flows
-        ), "Number of post-events must match number of flows."
+        if pre_events is not None and len(pre_events) != len(flows):
+            raise ValueError("Number of pre-events must match number of flows.")
+        if post_events is not None and len(post_events) != len(flows):
+            raise ValueError("Number of post-events must match number of flows.")
 
         unique_flow_ids = {}  # Keep track of unique flow IDs order
         task_results: Dict[str, List] = {}  # Store results keyed by flow_id

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -200,7 +200,7 @@ class RuntimeV1_0(Runtime):
                 break
 
             # As a safety measure, we stop the processing if we have too many events.
-            if len(new_events) > 100:
+            if len(new_events) > 300:
                 raise Exception("Too many events.")
 
         # Unpack and insert events in event history update event if available
@@ -686,15 +686,7 @@ class RuntimeV1_0(Runtime):
         next_steps = []
 
         if context_updates:
-            # We check if at least one key changed
-            changes = False
-            for k, v in context_updates.items():
-                if context.get(k) != v:
-                    changes = True
-                    break
-
-            if changes:
-                next_steps.append(new_event_dict("ContextUpdate", data=context_updates))
+            next_steps.append(new_event_dict("ContextUpdate", data=context_updates))
 
         next_steps.append(
             new_event_dict(

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -24,6 +24,7 @@ import aiohttp
 from langchain.chains.base import Chain
 
 from nemoguardrails.actions.actions import ActionResult
+from nemoguardrails.actions.core import create_event
 from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.colang import parse_colang_file
 from nemoguardrails.colang.runtime import Runtime
@@ -169,7 +170,7 @@ class RuntimeV1_0(Runtime):
                 next_events = await self._process_start_action(events)
 
             # If we need to start a flow, we parse the content and register it.
-            elif last_event["type"] == "start_flow":
+            elif last_event["type"] == "start_flow" and last_event.get("flow_body"):
                 next_events = await self._process_start_flow(
                     events, processing_log=processing_log
                 )
@@ -200,6 +201,17 @@ class RuntimeV1_0(Runtime):
             # As a safety measure, we stop the processing if we have too many events.
             if len(new_events) > 100:
                 raise Exception("Too many events.")
+
+        # Unpack and insert events in event history update event if available
+        temp_events = []
+        for event in new_events:
+            if event["type"] == "EventHistoryUpdate":
+                temp_events.extend(
+                    [e for e in event["data"]["events"] if e["type"] != "Listen"]
+                )
+            else:
+                temp_events.append(event)
+        new_events = temp_events
 
         return new_events
 
@@ -259,6 +271,193 @@ class RuntimeV1_0(Runtime):
                 # We also want to hide this from now from the history moving forward
                 {"type": "hide_prev_turn"},
             ]
+        )
+
+    async def _run_flows_in_parallel(
+        self,
+        flows: List[str],
+        events: List[dict],
+        pre_events: Optional[List[dict]] = None,
+        post_events: Optional[List[dict]] = None,
+    ) -> ActionResult:
+        """
+        Run flows in parallel.
+
+        Running flows in parallel is done by triggering a separate event loop with a `start_flow` event for each flow, in the context of the current event loop.
+
+        Args:
+            flows (List[str]): The list of flow names to run in parallel.
+            events (List[dict]): The current events.
+            pre_events (List[dict], optional): Events to be added before starting each flow.
+            post_events (List[dict], optional): Events to be added after finishing each flow.
+        """
+
+        assert pre_events is None or len(pre_events) == len(
+            flows
+        ), "Number of pre-events must match number of flows."
+        assert post_events is None or len(post_events) == len(
+            flows
+        ), "Number of post-events must match number of flows."
+
+        unique_flow_ids = {}  # Keep track of unique flow IDs order
+        task_results: Dict[str, List] = {}  # Store results keyed by flow_id
+        task_processing_logs: dict = {}  # Store resulting processing logs for each flow
+        finished_task_results: List[dict] = []  # Collect all results in order
+        new_events: Optional[List[dict]] = None
+
+        # Wrapper function to help reverse map the task result to the flow ID
+        async def task_call_helper(flow_uid, final_event, func, *args, **kwargs):
+            result = await func(*args, **kwargs)
+            if final_event:
+                result.append(final_event)
+            return flow_uid, result
+
+        # Create a task for each flow but don't await them yet
+        tasks = []
+        for index, flow_name in enumerate(flows):
+            # Copy the events to avoid modifying the original list
+            _events = events.copy()
+
+            flow_params = _get_flow_params(flow_name)
+            flow_id = _normalize_flow_id(flow_name)
+
+            if flow_params:
+                _events.append(
+                    {"type": "start_flow", "flow_id": flow_id, "params": flow_params}
+                )
+            else:
+                _events.append({"type": "start_flow", "flow_id": flow_id})
+
+            # Generate a unique flow ID
+            flow_uid = f"{flow_id}:{str(uuid.uuid4())}"
+
+            # Initialize task results
+            task_results[flow_uid] = []
+
+            # Add pre-event if provided
+            if pre_events:
+                task_results[flow_uid].append(pre_events[index])
+
+            task_processing_logs[flow_uid] = []
+            task = asyncio.create_task(
+                task_call_helper(
+                    flow_uid,
+                    post_events[index] if post_events else None,
+                    self.generate_events,
+                    _events,
+                    task_processing_logs[flow_uid],
+                )
+            )
+            tasks.append(task)
+            unique_flow_ids[flow_uid] = task
+
+        # Process tasks as they complete using as_completed
+        try:
+            for future in asyncio.as_completed(tasks):
+                try:
+                    (flow_id, result) = await future
+
+                    # Check if this rail requested to stop
+                    has_stop = any(
+                        event["type"] == "BotIntent" and event["intent"] == "stop"
+                        for event in result
+                    )
+
+                    # If this flow had a stop event
+                    if has_stop:
+                        # Add result of failed task that includes stop event
+                        new_events = result
+                        # Cancel all remaining tasks
+                        for pending_task in tasks:
+                            if (
+                                pending_task != unique_flow_ids[flow_id]
+                                and not pending_task.done()
+                            ):
+                                pending_task.cancel()
+                    else:
+                        # Store the result for this specific flow
+                        task_results[flow_id].extend(result)
+
+                except asyncio.exceptions.CancelledError:
+                    pass
+
+        except Exception as e:
+            log.error(f"Error in parallel rail execution: {str(e)}")
+            raise
+
+        context_updates: dict = {}
+        processing_log = processing_log_var.get()
+
+        # Compose results in original flow order
+        for flow_id in unique_flow_ids:
+            # Skip if this flow has not finished
+            if flow_id not in task_results:
+                continue
+
+            result = task_results[flow_id]
+
+            # Extract context updates
+            for event in result:
+                if event["type"] == "ContextUpdate":
+                    context_updates = {**context_updates, **event["data"]}
+
+            finished_task_results.extend(result)
+            if processing_log:
+                processing_log.extend(task_processing_logs[flow_id])
+
+        # We pack all events into a single event to add it to the event history.
+        history_events = new_event_dict(
+            "EventHistoryUpdate",
+            data={"events": finished_task_results},
+        )
+        if new_events:
+            new_events.insert(0, history_events)
+        else:
+            new_events = [history_events]
+
+        return ActionResult(
+            events=new_events,
+            context_updates=context_updates,
+        )
+
+    async def _run_input_rails_in_parallel(
+        self, flows: List[str], events: List[dict]
+    ) -> ActionResult:
+        """Run the input rails in parallel."""
+        pre_events = [
+            (await create_event({"_type": "StartInputRail", "flow_id": flow})).events[0]
+            for flow in flows
+        ]
+        post_events = [
+            (
+                await create_event({"_type": "InputRailFinished", "flow_id": flow})
+            ).events[0]
+            for flow in flows
+        ]
+
+        return await self._run_flows_in_parallel(
+            flows=flows, events=events, pre_events=pre_events, post_events=post_events
+        )
+
+    async def _run_output_rails_in_parallel(
+        self, flows: List[str], events: List[dict]
+    ) -> ActionResult:
+        """Run the output rails in parallel."""
+        pre_events = [
+            (await create_event({"_type": "StartOutputRail", "flow_id": flow})).events[
+                0
+            ]
+            for flow in flows
+        ]
+        post_events = [
+            (
+                await create_event({"_type": "OutputRailFinished", "flow_id": flow})
+            ).events[0]
+            for flow in flows
+        ]
+
+        return await self._run_flows_in_parallel(
+            flows=flows, events=events, pre_events=pre_events, post_events=post_events
         )
 
     async def _run_output_rails_in_parallel_streaming(

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -15,6 +15,7 @@
 import asyncio
 import inspect
 import logging
+import uuid
 from textwrap import indent
 from time import time
 from typing import Any, Dict, List, Optional, Tuple

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -190,9 +190,10 @@ class RuntimeV1_0(Runtime):
             new_events.extend(next_events)
 
             for event in next_events:
-                processing_log.append(
-                    {"type": "event", "timestamp": time(), "data": event}
-                )
+                if event["type"] != "EventHistoryUpdate":
+                    processing_log.append(
+                        {"type": "event", "timestamp": time(), "data": event}
+                    )
 
             # If the next event is a listen, we stop the processing.
             if next_events[-1]["type"] == "Listen":
@@ -302,14 +303,15 @@ class RuntimeV1_0(Runtime):
         unique_flow_ids = {}  # Keep track of unique flow IDs order
         task_results: Dict[str, List] = {}  # Store results keyed by flow_id
         task_processing_logs: dict = {}  # Store resulting processing logs for each flow
-        finished_task_results: List[dict] = []  # Collect all results in order
-        new_events: Optional[List[dict]] = None
 
         # Wrapper function to help reverse map the task result to the flow ID
-        async def task_call_helper(flow_uid, final_event, func, *args, **kwargs):
+        async def task_call_helper(flow_uid, post_event, func, *args, **kwargs):
             result = await func(*args, **kwargs)
-            if final_event:
-                result.append(final_event)
+            if post_event:
+                result.append(post_event)
+                args[1].append(
+                    {"type": "event", "timestamp": time(), "data": post_event}
+                )
             return flow_uid, result
 
         # Create a task for each flow but don't await them yet
@@ -331,14 +333,17 @@ class RuntimeV1_0(Runtime):
             # Generate a unique flow ID
             flow_uid = f"{flow_id}:{str(uuid.uuid4())}"
 
-            # Initialize task results
+            # Initialize task results and processing logs for this flow
             task_results[flow_uid] = []
+            task_processing_logs[flow_uid] = []
 
             # Add pre-event if provided
             if pre_events:
                 task_results[flow_uid].append(pre_events[index])
+                task_processing_logs[flow_uid].append(
+                    {"type": "event", "timestamp": time(), "data": pre_events[index]}
+                )
 
-            task_processing_logs[flow_uid] = []
             task = asyncio.create_task(
                 task_call_helper(
                     flow_uid,
@@ -350,6 +355,8 @@ class RuntimeV1_0(Runtime):
             )
             tasks.append(task)
             unique_flow_ids[flow_uid] = task
+
+        stopped_task_results: List[dict] = []
 
         # Process tasks as they complete using as_completed
         try:
@@ -365,15 +372,21 @@ class RuntimeV1_0(Runtime):
 
                     # If this flow had a stop event
                     if has_stop:
-                        # Add result of failed task that includes stop event
-                        new_events = result
+                        stopped_task_results = task_results[flow_id] + result
+
+                        del unique_flow_ids[flow_id]
                         # Cancel all remaining tasks
                         for pending_task in tasks:
+                            # Don't include results and processing logs for cancelled or stopped tasks
                             if (
-                                pending_task != unique_flow_ids[flow_id]
+                                flow_id in unique_flow_ids
+                                and pending_task != unique_flow_ids[flow_id]
                                 and not pending_task.done()
                             ):
+                                # Cancel the task if it is not done
                                 pending_task.cancel()
+                                del unique_flow_ids[flow_id]
+                        break
                     else:
                         # Store the result for this specific flow
                         task_results[flow_id].extend(result)
@@ -388,12 +401,11 @@ class RuntimeV1_0(Runtime):
         context_updates: dict = {}
         processing_log = processing_log_var.get()
 
-        # Compose results in original flow order
-        for flow_id in unique_flow_ids:
-            # Skip if this flow has not finished
-            if flow_id not in task_results:
-                continue
+        finished_task_processing_logs: List[dict] = []  # Collect all results in order
+        finished_task_results: List[dict] = []  # Collect all results in order
 
+        # Compose results in original flow order of all completed tasks
+        for flow_id in unique_flow_ids:
             result = task_results[flow_id]
 
             # Extract context updates
@@ -402,21 +414,26 @@ class RuntimeV1_0(Runtime):
                     context_updates = {**context_updates, **event["data"]}
 
             finished_task_results.extend(result)
-            if processing_log:
-                processing_log.extend(task_processing_logs[flow_id])
+            finished_task_processing_logs.extend(task_processing_logs[flow_id])
+
+        if processing_log:
+            for plog in finished_task_processing_logs:
+                # Filter out "Listen" and "start_flow" events from task processing log
+                if plog["type"] == "event" and (
+                    plog["data"]["type"] == "Listen"
+                    or plog["data"]["type"] == "start_flow"
+                ):
+                    continue
+                processing_log.append(plog)
 
         # We pack all events into a single event to add it to the event history.
         history_events = new_event_dict(
             "EventHistoryUpdate",
             data={"events": finished_task_results},
         )
-        if new_events:
-            new_events.insert(0, history_events)
-        else:
-            new_events = [history_events]
 
         return ActionResult(
-            events=new_events,
+            events=[history_events] + stopped_task_results,
             context_updates=context_updates,
         )
 

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -372,18 +372,21 @@ class RuntimeV1_0(Runtime):
                     if has_stop:
                         stopped_task_results = task_results[flow_id] + result
 
-                        del unique_flow_ids[flow_id]
                         # Cancel all remaining tasks
                         for pending_task in tasks:
                             # Don't include results and processing logs for cancelled or stopped tasks
                             if (
-                                flow_id in unique_flow_ids
-                                and pending_task != unique_flow_ids[flow_id]
+                                pending_task != unique_flow_ids[flow_id]
                                 and not pending_task.done()
                             ):
                                 # Cancel the task if it is not done
                                 pending_task.cancel()
-                                del unique_flow_ids[flow_id]
+                                # Find the flow_uid for this task and remove it from the dict
+                                for k, v in list(unique_flow_ids.items()):
+                                    if v == pending_task:
+                                        del unique_flow_ids[k]
+                                        break
+                        del unique_flow_ids[flow_id]
                         break
                     else:
                         # Store the result for this specific flow

--- a/nemoguardrails/logging/processing_log.py
+++ b/nemoguardrails/logging/processing_log.py
@@ -40,6 +40,7 @@ def compute_generation_log(processing_log: List[dict]) -> GenerationLog:
         "create_event",
         "run_input_rails_in_parallel",
         "run_output_rails_in_parallel",
+        "run_flows_in_parallel",
     ]
     ignored_flows = [
         "process user input",

--- a/nemoguardrails/logging/processing_log.py
+++ b/nemoguardrails/logging/processing_log.py
@@ -36,7 +36,11 @@ def compute_generation_log(processing_log: List[dict]) -> GenerationLog:
     generation_log = GenerationLog()
 
     # The list of actions to ignore during the processing.
-    ignored_actions = ["create_event"]
+    ignored_actions = [
+        "create_event",
+        "run_input_rails_in_parallel",
+        "run_output_rails_in_parallel",
+    ]
     ignored_flows = [
         "process user input",
         "run input rails",

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -425,6 +425,11 @@ class CoreConfig(BaseModel):
 class InputRails(BaseModel):
     """Configuration of input rails."""
 
+    parallel: Optional[bool] = Field(
+        default=False,
+        description="If True, the input rails are executed in parallel.",
+    )
+
     flows: List[str] = Field(
         default_factory=list,
         description="The names of all the flows that implement input rails.",

--- a/nemoguardrails/rails/llm/llm_flows.co
+++ b/nemoguardrails/rails/llm/llm_flows.co
@@ -46,23 +46,27 @@ define subflow generate user intent
 
 define subflow run input rails
   """Runs all the input rails in a sequential order. """
-  $i = 0
   $input_flows = $config.rails.input.flows
-  while $i < len($input_flows)
-    # We set the current rail as being triggered.
-    $triggered_input_rail = $input_flows[$i]
 
-    create event StartInputRail(flow_id=$triggered_input_rail)
-    event StartInputRail
+  if $config.rails.input.parallel
+    execute run_input_rails_in_parallel(flows=$input_flows)
+  else
+    $i = 0
+    while $i < len($input_flows)
+      # We set the current rail as being triggered.
+      $triggered_input_rail = $input_flows[$i]
 
-    do $input_flows[$i]
-    $i = $i + 1
+      create event StartInputRail(flow_id=$triggered_input_rail)
+      event StartInputRail
 
-    create event InputRailFinished(flow_id=$triggered_input_rail)
-    event InputRailFinished
+      do $input_flows[$i]
+      $i = $i + 1
 
-    # If all went smooth, we remove it.
-    $triggered_input_rail = None
+      create event InputRailFinished(flow_id=$triggered_input_rail)
+      event InputRailFinished
+
+      # If all went smooth, we remove it.
+      $triggered_input_rail = None
 
 
 
@@ -130,23 +134,27 @@ define parallel extension flow process bot message
 
 define subflow run output rails
   """Runs all the output rails in a sequential order. """
-  $i = 0
   $output_flows = $config.rails.output.flows
-  while $i < len($output_flows)
-    # We set the current rail as being triggered.
-    $triggered_output_rail = $output_flows[$i]
 
-    create event StartOutputRail(flow_id=$triggered_output_rail)
-    event StartOutputRail
+  if $config.rails.input.parallel
+    execute run_output_rails_in_parallel(flows=$output_flows)
+  else
+    $i = 0
+    while $i < len($output_flows)
+      # We set the current rail as being triggered.
+      $triggered_output_rail = $output_flows[$i]
 
-    do $output_flows[$i]
-    $i = $i + 1
+      create event StartOutputRail(flow_id=$triggered_output_rail)
+      event StartOutputRail
 
-    create event OutputRailFinished(flow_id=$triggered_output_rail)
-    event OutputRailFinished
+      do $output_flows[$i]
+      $i = $i + 1
 
-    # If all went smooth, we remove it.
-    $triggered_output_rail = None
+      create event OutputRailFinished(flow_id=$triggered_output_rail)
+      event OutputRailFinished
+
+      # If all went smooth, we remove it.
+      $triggered_output_rail = None
 
 
 define subflow run retrieval rails

--- a/nemoguardrails/rails/llm/llm_flows.co
+++ b/nemoguardrails/rails/llm/llm_flows.co
@@ -136,7 +136,7 @@ define subflow run output rails
   """Runs all the output rails in a sequential order. """
   $output_flows = $config.rails.output.flows
 
-  if $config.rails.input.parallel
+  if $config.rails.output.parallel
     execute run_output_rails_in_parallel(flows=$output_flows)
   else
     $i = 0

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -37,7 +37,7 @@ from nemoguardrails.actions.llm.utils import (
 from nemoguardrails.actions.output_mapping import is_output_blocked
 from nemoguardrails.actions.v2_x.generation import LLMGenerationActionsV2dotx
 from nemoguardrails.colang import parse_colang_file
-from nemoguardrails.colang.v1_0.runtime.flows import compute_context
+from nemoguardrails.colang.v1_0.runtime.flows import _normalize_flow_id, compute_context
 from nemoguardrails.colang.v1_0.runtime.runtime import Runtime, RuntimeV1_0
 from nemoguardrails.colang.v2_x.runtime.flows import Action, State
 from nemoguardrails.colang.v2_x.runtime.runtime import RuntimeV2_x
@@ -301,20 +301,14 @@ class LLMRails:
 
         for flow_name in self.config.rails.input.flows:
             # content safety check input/output flows are special as they have parameters
-            if flow_name.startswith("content safety check") or flow_name.startswith(
-                "topic safety check"
-            ):
-                continue
+            flow_name = _normalize_flow_id(flow_name)
             if flow_name not in existing_flows_names:
                 raise ValueError(
                     f"The provided input rail flow `{flow_name}` does not exist"
                 )
 
         for flow_name in self.config.rails.output.flows:
-            if flow_name.startswith("content safety check") or flow_name.startswith(
-                "topic safety check"
-            ):
-                continue
+            flow_name = _normalize_flow_id(flow_name)
             if flow_name not in existing_flows_names:
                 raise ValueError(
                     f"The provided output rail flow `{flow_name}` does not exist"

--- a/tests/test_configs/parallel_rails/actions.py
+++ b/tests/test_configs/parallel_rails/actions.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from typing import Optional
+
+from nemoguardrails.actions import action
+
+
+@action(is_system_action=True)
+async def check_blocked_input_terms(context: Optional[dict] = None):
+    user_message = context.get("user_message")
+
+    # A quick hard-coded list of proprietary terms. You can also read this from a file.
+    proprietary_terms = ["blocked term"]
+
+    # Wait for 1 seconds to simulate a delay in processing
+    await asyncio.sleep(1)
+
+    for term in proprietary_terms:
+        if term.lower() in user_message.lower():
+            return True
+
+    return False
+
+
+@action(is_system_action=True)
+async def check_blocked_output_terms(context: Optional[dict] = None):
+    bot_response = context.get("bot_message")
+
+    # A quick hard-coded list of proprietary terms. You can also read this from a file.
+    proprietary_terms = ["blocked term"]
+
+    # Wait for 1 seconds to simulate a delay in processing
+    await asyncio.sleep(1)
+
+    for term in proprietary_terms:
+        if term.lower() in bot_response.lower():
+            return True
+
+    return False

--- a/tests/test_configs/parallel_rails/actions.py
+++ b/tests/test_configs/parallel_rails/actions.py
@@ -20,14 +20,18 @@ from nemoguardrails.actions import action
 
 
 @action(is_system_action=True)
-async def check_blocked_input_terms(context: Optional[dict] = None):
+async def check_blocked_input_terms(
+    duration: float = 0.0, context: Optional[dict] = None
+):
     user_message = context.get("user_message")
 
     # A quick hard-coded list of proprietary terms. You can also read this from a file.
     proprietary_terms = ["blocked term"]
 
-    # Wait for 1 seconds to simulate a delay in processing
-    await asyncio.sleep(1)
+    # Wait to simulate a delay in processing
+    if isinstance(duration, str):
+        duration = float(duration)
+    await asyncio.sleep(duration)
 
     for term in proprietary_terms:
         if term.lower() in user_message.lower():
@@ -37,14 +41,18 @@ async def check_blocked_input_terms(context: Optional[dict] = None):
 
 
 @action(is_system_action=True)
-async def check_blocked_output_terms(context: Optional[dict] = None):
+async def check_blocked_output_terms(
+    duration: float = 0.0, context: Optional[dict] = None
+):
     bot_response = context.get("bot_message")
 
     # A quick hard-coded list of proprietary terms. You can also read this from a file.
     proprietary_terms = ["blocked term"]
 
-    # Wait for 1 seconds to simulate a delay in processing
-    await asyncio.sleep(1)
+    # Wait to simulate a delay in processing
+    if isinstance(duration, str):
+        duration = float(duration)
+    await asyncio.sleep(duration)
 
     for term in proprietary_terms:
         if term.lower() in bot_response.lower():

--- a/tests/test_configs/parallel_rails/config.yml
+++ b/tests/test_configs/parallel_rails/config.yml
@@ -26,15 +26,15 @@ rails:
     parallel: True
     flows:
       - self check input
-      - check blocked input terms
-      - check blocked input terms
+      - check blocked input terms $duration=1.0
+      - check blocked input terms $duration=1.0
 
   output:
     parallel: True
     flows:
       - self check output
-      - check blocked output terms
-      - check blocked output terms
+      - check blocked output terms $duration=1.0
+      - check blocked output terms $duration=1.0
 
   dialog:
     single_call:

--- a/tests/test_configs/parallel_rails/config.yml
+++ b/tests/test_configs/parallel_rails/config.yml
@@ -1,0 +1,41 @@
+instructions:
+  - type: general
+    content: |
+      Below is a conversation between a user and a bot called the ABC Bot.
+      The bot is designed to answer employee questions about the ABC Company.
+      The bot is knowledgeable about the employee handbook and company policies.
+      If the bot does not know the answer to a question, it truthfully says it does not know.
+
+sample_conversation: |
+  user "Hi there. Can you help me with some questions I have about the company?"
+    express greeting and ask for assistance
+  bot express greeting and confirm and offer assistance
+    "Hi there! I'm here to help answer any questions you may have about the ABC Company. What would you like to know?"
+  user "What's the company policy on paid time off?"
+    ask question about benefits
+  bot respond to question about benefits
+    "The ABC Company provides eligible employees with up to two weeks of paid vacation time per year, as well as five paid sick days per year. Please refer to the employee handbook for more information."
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o
+
+rails:
+  input:
+    parallel: True
+    flows:
+      - self check input
+      - check blocked input terms
+      - check blocked input terms
+
+  output:
+    parallel: True
+    flows:
+      - self check output
+      - check blocked output terms
+      - check blocked output terms
+
+  dialog:
+    single_call:
+      enabled: False

--- a/tests/test_configs/parallel_rails/prompts.yml
+++ b/tests/test_configs/parallel_rails/prompts.yml
@@ -1,0 +1,25 @@
+prompts:
+  - task: self_check_input
+    content: |
+      Your task is to check if the user message below complies with the company policy for talking with the company bot.
+
+      Company policy for the user messages:
+      - should not contain the expression "unicorn"
+      - Anything else is allowed
+
+      User message: "{{ user_input }}"
+
+      Question: Should the user message be blocked (Yes or No)?
+      Answer:
+  - task: self_check_output
+    content: |
+      Your task is to check if the bot message below complies with the company policy.
+
+      Company policy for the user messages:
+      - should not contain the expression "unicorn"
+      - Anything else is allowed
+
+      Bot message: "{{ bot_response }}"
+
+      Question: Should the message be blocked (Yes or No)?
+      Answer:

--- a/tests/test_configs/parallel_rails/rails/blocked_terms.co
+++ b/tests/test_configs/parallel_rails/rails/blocked_terms.co
@@ -1,0 +1,19 @@
+define bot inform about blocked user term
+  "I cannot process a term in the user message."
+
+define bot inform about blocked bot term
+  "I cannot express a term in the bot answer."
+
+define subflow check blocked input terms
+  $is_blocked = execute check_blocked_input_terms
+
+  if $is_blocked
+    bot inform about blocked user term
+    stop
+
+define subflow check blocked output terms
+  $is_blocked = execute check_blocked_output_terms
+
+  if $is_blocked
+    bot inform about blocked bot term
+    stop

--- a/tests/test_configs/parallel_rails/rails/blocked_terms.co
+++ b/tests/test_configs/parallel_rails/rails/blocked_terms.co
@@ -5,14 +5,14 @@ define bot inform about blocked bot term
   "I cannot express a term in the bot answer."
 
 define subflow check blocked input terms
-  $is_blocked = execute check_blocked_input_terms
+  $is_blocked = execute check_blocked_input_terms(duration=$duration)
 
   if $is_blocked
     bot inform about blocked user term
     stop
 
 define subflow check blocked output terms
-  $is_blocked = execute check_blocked_output_terms
+  $is_blocked = execute check_blocked_output_terms(duration=$duration)
 
   if $is_blocked
     bot inform about blocked bot term

--- a/tests/test_parallel_rails.py
+++ b/tests/test_parallel_rails.py
@@ -64,7 +64,6 @@ async def test_parallel_rails_success():
     assert (
         result.log.activated_rails[2].name == "check blocked input terms $duration=1.0"
     )
-    # assert len(result.log.activated_rails[1].executed_actions) == 2
     assert result.log.activated_rails[3].name == "generate user intent"
     assert result.log.activated_rails[4].name == "self check output"
     assert (
@@ -73,7 +72,6 @@ async def test_parallel_rails_success():
     assert (
         result.log.activated_rails[6].name == "check blocked output terms $duration=1.0"
     )
-    # assert len(result.log.activated_rails[4].executed_actions) == 2
 
     # Time should be close to 2 seconds due to parallel processing:
     # check blocked input terms: 1s

--- a/tests/test_parallel_rails.py
+++ b/tests/test_parallel_rails.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.rails.llm.options import GenerationOptions
+from tests.utils import TestChat
+
+CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), ".", "test_configs")
+
+OPTIONS = GenerationOptions(
+    log={
+        "activated_rails": True,
+        "llm_calls": True,
+        "internal_events": True,
+        "colang_history": False,
+    }
+)
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_success():
+    # Test 1 - All input/output rails pass
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "parallel_rails"))
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "No",
+            "Hi there! How can I assist you with questions about the ABC Company today?",
+            "No",
+        ],
+    )
+
+    chat >> "hi"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    # Assert the response is correct
+    assert (
+        result
+        and result.response[0]["content"]
+        == "Hi there! How can I assist you with questions about the ABC Company today?"
+    )
+
+    # Check that all rails were executed
+    assert result.log.activated_rails[0].name == "self check input"
+    assert result.log.activated_rails[1].name == "check blocked input terms"
+    assert len(result.log.activated_rails[1].executed_actions) == 2
+    assert result.log.activated_rails[2].name == "generate user intent"
+    assert result.log.activated_rails[3].name == "self check output"
+    assert result.log.activated_rails[4].name == "check blocked output terms"
+    assert len(result.log.activated_rails[4].executed_actions) == 2
+
+    # Time should be close to 2 seconds due to parallel processing:
+    # check blocked input terms: 1s
+    # check blocked output terms: 1s
+    assert (
+        result.log.stats.input_rails_duration < 1.5
+        and result.log.stats.output_rails_duration < 1.5
+    ), "Rails processing took too long, parallelization seems to be not working."
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_input_fail_1():
+    # Test 2 - First input rail fails
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "parallel_rails"))
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "Yes",
+            "Hi there! How can I assist you with questions about the ABC Company today?",
+            "No",
+        ],
+    )
+    chat >> "hi, I am a unicorn!"
+    await chat.bot_async("I'm sorry, I can't respond to that.")
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_input_fail_2():
+    # Test 3 - Second input rail fails due to blocked term
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "parallel_rails"))
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "No",
+            "Hi there! How can I assist you with questions about the ABC Company today?",
+            "No",
+        ],
+    )
+
+    chat >> "hi, this is a blocked term."
+    await chat.bot_async("I cannot process a term in the user message.")
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_output_fail_1():
+    # Test 4 - First output rail fails
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "parallel_rails"))
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "No",
+            "Hi there! I am a unicorn!",
+            "Yes",
+        ],
+    )
+
+    chat >> "hi!"
+    await chat.bot_async("I'm sorry, I can't respond to that.")
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_output_fail_2():
+    # Test 4 - Second output rail fails due to blocked term
+    config = RailsConfig.from_path(os.path.join(CONFIGS_FOLDER, "parallel_rails"))
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "No",
+            "Hi there! This is a blocked term!",
+            "No",
+        ],
+    )
+
+    chat >> "hi!"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+    assert (
+        result
+        and result.response[0]["content"]
+        == "I cannot express a term in the bot answer."
+    )

--- a/tests/test_parallel_rails.py
+++ b/tests/test_parallel_rails.py
@@ -58,12 +58,22 @@ async def test_parallel_rails_success():
 
     # Check that all rails were executed
     assert result.log.activated_rails[0].name == "self check input"
-    assert result.log.activated_rails[1].name == "check blocked input terms"
-    assert len(result.log.activated_rails[1].executed_actions) == 2
-    assert result.log.activated_rails[2].name == "generate user intent"
-    assert result.log.activated_rails[3].name == "self check output"
-    assert result.log.activated_rails[4].name == "check blocked output terms"
-    assert len(result.log.activated_rails[4].executed_actions) == 2
+    assert (
+        result.log.activated_rails[1].name == "check blocked input terms $duration=1.0"
+    )
+    assert (
+        result.log.activated_rails[2].name == "check blocked input terms $duration=1.0"
+    )
+    # assert len(result.log.activated_rails[1].executed_actions) == 2
+    assert result.log.activated_rails[3].name == "generate user intent"
+    assert result.log.activated_rails[4].name == "self check output"
+    assert (
+        result.log.activated_rails[5].name == "check blocked output terms $duration=1.0"
+    )
+    assert (
+        result.log.activated_rails[6].name == "check blocked output terms $duration=1.0"
+    )
+    # assert len(result.log.activated_rails[4].executed_actions) == 2
 
     # Time should be close to 2 seconds due to parallel processing:
     # check blocked input terms: 1s


### PR DESCRIPTION
## Description

This MR enables parallel input/output rail execution (in Colang 1) through a new action called 'run_flows_in_parallel'.

- Input and output rails can be configured to run in parallel through a new field in the bot config (parallel: True).
- Two additional actions are added (`run_input_rails_in_parallel`, `run_output_rails_in_parallel`) to simplify the parallel rails calling and to create the necessary tracing events: `StartInputRail`, `InputRailFinished`, `StartOutputRail`, `OutputRailFinished`.
- The parallel rail execution tries to mimic the sequential processing as much as possible. Therefore, the resulting event history, processing log and flow context will be almost the same and appear in sequential order, even if the event timestamps reveal the concurrent execution of the rails.

## Related Issue(s)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
