### PR TITLE
chore: update pre-commit-hooks to v5.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer


### PR DESCRIPTION
## Summary
Updates pre-commit-hooks from v4.4.0 to v5.0.0 to resolve deprecated stage names warning.

## Changes
- Bumped `pre-commit-hooks` version to v5.0.0 in `.pre-commit-config.yaml`

Fixes the warning:
> repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version