### PR TITLE
fix: register main LLM as action parameter when initialized from config

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -388,6 +388,7 @@ class LLMRails:
                     mode="chat",
                     kwargs=main_model.parameters or {},
                 )
+                self.runtime.register_action_param("llm", self.llm)
             else:
                 log.warning(
                     "No main LLM specified in the config and no LLM provided via constructor."


### PR DESCRIPTION

### Problem
When the main LLM is initialized from configuration (without providing an LLM via constructor), it was not being registered as an action parameter. This caused actions that depend on the `llm` parameter to receive `None` instead of the actual LLM instance, leading to runtime errors.

**Error example:**
```
AttributeError: 'NoneType' object has no attribute 'agenerate_prompt'
```

This affected built in actions like `self_check_input` and any custom actions that require the `llm` parameter.

### Root Cause
In the `_init_llms()` method, when initializing the main LLM from config, the code was setting `self.llm` but missing the call to register it as an action parameter:

```python
# before fix it is missing registration
self.llm = init_llm_model(...)
# self.runtime.register_action_param("llm", self.llm)  # this was missing
```

### Solution
Added the missing `register_action_param("llm", self.llm)` call after initializing the main LLM from config
**Files Changed:**
- `nemoguardrails/rails/llm/llmrails.py`: Added missing LLM registration
- `tests/test_llmrails.py`: Added regression test


### Verification
✅ Original error scenario now works:
```bash
poetry run nemoguardrails chat --config="./examples/bots/abc"
```

✅ Test passes with fix and fails without it, proving regression coverage
