### PR TITLE
fix(jailbreak): pin numpy==1.23.5 for scikit-learn compatibility

### DIFF
--- a/nemoguardrails/library/jailbreak_detection/requirements.txt
+++ b/nemoguardrails/library/jailbreak_detection/requirements.txt
@@ -7,5 +7,6 @@ uvicorn>=0.23.2
 transformers>=4.32.1
 torch>=2.1.1
 nemoguardrails>=0.7.0
+numpy==1.23.5
 scikit-learn==1.2.2
 einops>=0.7.0


### PR DESCRIPTION
### Problem
The Docker build for the jailbreak detection heuristics server was failing with a binary incompatibility error:

```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

This error occurred during the step that pre downloads the GPT-2 model, when the transformers library tried to import scikit-learn, which had been compiled against a different version of numpy than what was present at runtime.

### Root Cause
- The `requirements.txt` had `scikit-learn==1.2.2` pinned but no explicit numpy version constraint
- during Docker build transformers and other deps pulled in a newer version of numpy
- scikit-learn 1.2.2 was compiled against numpy 1.23.x series, but a newer numpy version was installed
- this created a binary incompatibility between scikit-learn's C extensions and the runtime numpy version

