### PR TITLE
feat(tracing)!: update tracing to use otel api

### DIFF
--- a/examples/configs/tracing/README.md
+++ b/examples/configs/tracing/README.md
@@ -133,7 +133,7 @@ pip install nemoguardrails[tracing] opentelemetry-sdk
 pip install nemoguardrails[tracing]
 
 # install SDK and your preferred exporter
-# for TLP
+# for OTLP
 pip install opentelemetry-sdk opentelemetry-exporter-otlp
 # OR for Jaeger
 pip install opentelemetry-sdk opentelemetry-exporter-jaeger

--- a/examples/configs/tracing/README.md
+++ b/examples/configs/tracing/README.md
@@ -337,6 +337,36 @@ config = RailsConfig.from_content(
 )
 ```
 
+### Deprecated Features
+
+#### register_otel_exporter Function
+
+The `register_otel_exporter` function is deprecated and will be removed in version 0.16.0:
+
+```python
+#  DEPRECATED - will be removed in 0.16.0
+from nemoguardrails.tracing.adapters.opentelemetry import register_otel_exporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+register_otel_exporter("my-otlp", OTLPSpanExporter)
+```
+
+Instead, configure exporters directly in your application:
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+tracer_provider = TracerProvider()
+trace.set_tracer_provider(tracer_provider)
+
+otlp_exporter = OTLPSpanExporter(endpoint="http://localhost:4318")
+span_processor = BatchSpanProcessor(otlp_exporter)
+tracer_provider.add_span_processor(span_processor)
+```
+
 ### Why the Change?
 
 This change follows OpenTelemetry best practices:

--- a/examples/configs/tracing/README.md
+++ b/examples/configs/tracing/README.md
@@ -18,6 +18,7 @@ Tracing helps you understand what happens inside your guardrails:
 The fastest way to see tracing in action:
 
 ```bash
+# Install tracing support with SDK (needed for examples)
 pip install nemoguardrails[tracing] opentelemetry-sdk
 
 cd examples/configs/tracing/
@@ -109,11 +110,35 @@ This means you must configure OpenTelemetry in your application code.
 
 ### Installation
 
+#### For Tracing Support (API only)
+
 ```bash
+# minimum requirement for NeMo Guardrails tracing features
+pip install nemoguardrails[tracing]
+```
+
+This installs only the OpenTelemetry API, which is sufficient if your application already configures OpenTelemetry.
+
+#### For Running Examples and Development
+
+```bash
+# includes OpenTelemetry SDK for configuring exporters
+pip install nemoguardrails[tracing] opentelemetry-sdk
+```
+
+#### For Production Deployments
+
+```bash
+# install tracing support
 pip install nemoguardrails[tracing]
 
-# install OpenTelemetry SDK and exporters (required for your application)
-pip install opentelemetry-sdk
+# install SDK and your preferred exporter
+# for TLP
+pip install opentelemetry-sdk opentelemetry-exporter-otlp
+# OR for Jaeger
+pip install opentelemetry-sdk opentelemetry-exporter-jaeger
+# OR for Zipkin
+pip install opentelemetry-sdk opentelemetry-exporter-zipkin
 ```
 
 ### Configuration Examples

--- a/examples/configs/tracing/README.md
+++ b/examples/configs/tracing/README.md
@@ -1,35 +1,354 @@
-# README
+# NeMo Guardrails Tracing
 
-We encourage you to implement a log adapter for the production environment based on your specific requirements.
+This guide explains how to set up tracing with NeMo Guardrails to monitor and debug your guardrails interactions.
 
-To use the `FileSystem` and `OpenTelemetry` adapters, please install the following dependencies:
+## What is Tracing?
+
+Tracing helps you understand what happens inside your guardrails:
+
+- Track which rails are activated
+- Monitor LLM calls and responses
+- Debug performance issues
+- Analyze conversation flows
+
+## Quick Start
+
+### 1. Try the Working Example
+
+The fastest way to see tracing in action:
 
 ```bash
-pip install opentelemetry-api opentelemetry-sdk aiofiles
+pip install nemoguardrails[tracing] opentelemetry-sdk
+
+cd examples/configs/tracing/
+python working_example.py
 ```
 
-If you want to use Zipkin as a backend, you can use the following command to start a Zipkin server:
+This will show traces printed to your console immediately.
 
-1. Install the Zipkin exporter for OpenTelemetry:
+### 2. Basic Configuration
 
-    ```sh
-    pip install opentelemetry-exporter-zipkin
-    ```
+Enable tracing in your `config.yml`:
 
-2. Run the `Zipkin` server using Docker:
+```yaml
+tracing:
+  enabled: true
+  adapters:
+    - name: FileSystem
+```
 
-    ```sh
-    docker run -d -p 9411:9411 openzipkin/zipkin
-    ```
+Or use OpenTelemetry (requires additional setup):
 
-3. Update the `config.yml` to set the exporter to Zipkin:
+```yaml
+tracing:
+  enabled: true
+  adapters:
+    - name: OpenTelemetry
+```
 
-    ```yaml
-    tracing:
-      enabled: true
-      adapters:
-        - name: OpenTelemetry
-          service_name: "nemo_guardrails_service"
-          exporter: "zipkin"
-          resource_attributes:
-            env: "production"
+## Available Tracing Adapters
+
+### FileSystem Adapter (Easiest)
+
+Logs traces to local JSON files which is a good option for development and debugging:
+
+```yaml
+tracing:
+  enabled: true
+  adapters:
+    - name: FileSystem
+      filepath: "./logs/traces.jsonl"
+```
+
+**When to use**: Development, debugging, simple logging needs.
+
+### OpenTelemetry Adapter
+
+```yaml
+tracing:
+  enabled: true
+  adapters:
+    - name: OpenTelemetry
+```
+
+**When to use**: Production environments, integration with monitoring systems, distributed applications.
+
+## OpenTelemetry Ecosystem Compatibility
+
+**NeMo Guardrails is compatible with the entire OpenTelemetry ecosystem.** The examples below show common configurations, but you can use any OpenTelemetry compatible:
+
+- **Exporters**: Jaeger, Zipkin, Prometheus, New Relic, Datadog, AWS X-Ray, Google Cloud Trace, and many more
+- **Collectors**: OpenTelemetry Collector, Jaeger Collector, custom collectors
+- **Backends**: Any system that accepts OpenTelemetry traces
+
+For the complete list of supported exporters, see the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/).
+
+### Custom Adapter
+
+Implement your own adapter for specific requirements:
+
+```python
+from nemoguardrails.tracing.adapters.base import InteractionLogAdapter
+
+class MyCustomAdapter(InteractionLogAdapter):
+    name = "MyCustomAdapter"
+
+    def transform(self, interaction_log):
+        # your custom logic here
+        pass
+```
+
+## OpenTelemetry Setup
+
+### Understanding the Architecture
+
+- **NeMo Guardrails**: Uses only the OpenTelemetry API (doesn't configure anything)
+- **Your Application**: Configures the OpenTelemetry SDK and exporters
+
+This means you must configure OpenTelemetry in your application code.
+
+### Installation
+
+```bash
+pip install nemoguardrails[tracing]
+
+# install OpenTelemetry SDK and exporters (required for your application)
+pip install opentelemetry-sdk
+```
+
+### Configuration Examples
+
+#### Common Examples
+
+**Console Output** (Development/Testing):
+
+Suitable for development which prints traces to your terminal:
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+# configure OpenTelemetry (do this before using NeMo Guardrails)
+resource = Resource.create({
+    "service.name": "my-guardrails-app",
+    "service.version": "1.0.0",
+}, schema_url="https://opentelemetry.io/schemas/1.26.0")
+
+tracer_provider = TracerProvider(resource=resource)
+trace.set_tracer_provider(tracer_provider)
+
+# use console exporter (prints to terminal)
+console_exporter = ConsoleSpanExporter()
+span_processor = BatchSpanProcessor(console_exporter)
+tracer_provider.add_span_processor(span_processor)
+
+# now configure NeMo Guardrails
+from nemoguardrails import LLMRails, RailsConfig
+
+config = RailsConfig.from_content(
+    config={
+        "models": [{"type": "main", "engine": "openai", "model": "gpt-3.5-turbo-instruct"}],
+        "tracing": {
+            "enabled": True,
+            "adapters": [{"name": "OpenTelemetry"}]
+        }
+    }
+)
+
+rails = LLMRails(config)
+response = rails.generate(messages=[{"role": "user", "content": "Hello!"}])
+```
+
+**OTLP Exporter** (Production-ready):
+
+For production use with observability platforms:
+
+```bash
+# install OTLP exporter
+pip install opentelemetry-exporter-otlp
+```
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+# configure OpenTelemetry
+resource = Resource.create({
+    "service.name": "my-guardrails-app",
+    "service.version": "1.0.0",
+}, schema_url="https://opentelemetry.io/schemas/1.26.0")
+
+tracer_provider = TracerProvider(resource=resource)
+trace.set_tracer_provider(tracer_provider)
+
+# configure OTLP exporter
+otlp_exporter = OTLPSpanExporter(
+    endpoint="http://localhost:4317",  # Your OTLP collector endpoint
+    insecure=True
+)
+
+span_processor = BatchSpanProcessor(otlp_exporter)
+tracer_provider.add_span_processor(span_processor)
+
+# use with NeMo Guardrails (same as console example)
+```
+
+> **Note**: These examples show popular configurations, but OpenTelemetry supports many more exporters and backends. You can integrate with any OpenTelemetry-compatible observability platform by installing the appropriate exporter package and configuring it in your application code.
+
+## Additional Integration Examples
+
+These are just a few examples of the many OpenTelemetry integrations available:
+
+### Zipkin Integration
+
+1. Start Zipkin server:
+
+```bash
+docker run -d -p 9411:9411 openzipkin/zipkin
+```
+
+2. Install Zipkin exporter:
+
+```bash
+pip install opentelemetry-exporter-zipkin
+```
+
+3. Configure in your application:
+
+```python
+from opentelemetry.exporter.zipkin.proto.http import ZipkinExporter
+
+zipkin_exporter = ZipkinExporter(
+    endpoint="http://localhost:9411/api/v2/spans",
+)
+span_processor = BatchSpanProcessor(zipkin_exporter)
+tracer_provider.add_span_processor(span_processor)
+```
+
+### OpenTelemetry Collector
+
+Create a collector configuration file:
+
+```yaml
+# otel-config.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  logging:
+    loglevel: debug
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]
+```
+
+Run the collector:
+
+```bash
+docker run -p 4317:4317 -p 4318:4318 \
+  -v $(pwd)/otel-config.yaml:/etc/otel-collector-config.yaml \
+  otel/opentelemetry-collector:latest \
+  --config=/etc/otel-collector-config.yaml
+```
+
+## Migration Guide
+
+### From Previous Versions
+
+If you were using the old OpenTelemetry configuration:
+
+**❌ no longer supported:**
+
+```yaml
+tracing:
+  enabled: true
+  adapters:
+    - name: OpenTelemetry
+      service_name: "my-service"
+      exporter: "console"
+      resource_attributes:
+        env: "production"
+```
+
+**✅ supported:**
+
+```python
+# configure OpenTelemetry in your application code
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+tracer_provider = TracerProvider()
+trace.set_tracer_provider(tracer_provider)
+
+console_exporter = ConsoleSpanExporter()
+span_processor = BatchSpanProcessor(console_exporter)
+tracer_provider.add_span_processor(span_processor)
+
+config = RailsConfig.from_content(
+    config={
+        "tracing": {
+            "enabled": True,
+            "adapters": [{"name": "OpenTelemetry"}]
+        }
+    }
+)
+```
+
+### Why the Change?
+
+This change follows OpenTelemetry best practices:
+
+1. **Libraries use only the API**: No configuration conflicts
+2. **Applications control observability**: You decide where traces go
+3. **Better compatibility**: Works with any OpenTelemetry setup
+
+## Troubleshooting
+
+### Common Issues
+
+**No traces appear:**
+
+- Ensure OpenTelemetry is configured in your application (not just NeMo Guardrails config)
+- Check that your exporter is working (try `ConsoleSpanExporter` first)
+- Verify tracing is enabled in your config
+
+**Connection errors with OTLP:**
+
+```
+WARNING: Transient error StatusCode.UNAVAILABLE encountered while exporting traces to localhost:4317
+```
+
+- Make sure your collector/endpoint is running
+- Use `ConsoleSpanExporter` for testing without external dependencies
+
+**Import errors:**
+
+```
+ImportError: No module named 'opentelemetry'
+```
+
+- Install the tracing dependencies: `pip install nemoguardrails[tracing]`
+- For exporters: `pip install opentelemetry-exporter-otlp`
+
+**Wrong service name in traces:**
+
+- Configure the `Resource` with `SERVICE_NAME` in your application code
+- The old `service_name` parameter is no longer used

--- a/examples/configs/tracing/working_example.py
+++ b/examples/configs/tracing/working_example.py
@@ -88,6 +88,18 @@ def create_guardrails_config():
                 }
             ],
             "tracing": {"enabled": True, "adapters": [{"name": "OpenTelemetry"}]},
+            # Note: The following old-style configuration is deprecated and will be ignored:
+            # "tracing": {
+            #     "enabled": True,
+            #     "adapters": [{
+            #         "name": "OpenTelemetry",
+            #         "service_name": "my-service",      # DEPRECATED - configure in Resource
+            #         "exporter": "console",             # DEPRECATED - configure SDK
+            #         "resource_attributes": {           # DEPRECATED - configure in Resource
+            #             "env": "production"
+            #         }
+            #     }]
+            # }
         },
     )
 

--- a/examples/configs/tracing/working_example.py
+++ b/examples/configs/tracing/working_example.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Complete working example of NeMo Guardrails with OpenTelemetry tracing.
+
+This example uses the ConsoleSpanExporter so you can see traces immediately
+without needing to set up any external infrastructure.
+
+Usage:
+    pip install nemoguardrails[tracing] opentelemetry-sdk
+    python working_example.py
+"""
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+from nemoguardrails import LLMRails, RailsConfig
+
+
+def setup_opentelemetry():
+    """Configure OpenTelemetry SDK with console output."""
+
+    print("Setting up OpenTelemetry...")
+
+    # configure resource (metadata about your service)
+    resource = Resource.create(
+        {
+            "service.name": "nemo-guardrails-example",
+            "service.version": "1.0.0",
+            "deployment.environment": "development",
+        },
+        schema_url="https://opentelemetry.io/schemas/1.26.0",
+    )
+
+    # set up the tracer provider
+    tracer_provider = TracerProvider(resource=resource)
+    trace.set_tracer_provider(tracer_provider)
+
+    # configure console exporter (prints traces to stdout)
+    console_exporter = ConsoleSpanExporter()
+    span_processor = BatchSpanProcessor(console_exporter)
+    tracer_provider.add_span_processor(span_processor)
+
+    print(" OpenTelemetry configured with ConsoleSpanExporter")
+    print(" Traces will be printed to the console below\n")
+
+
+def create_guardrails_config():
+    """Create a simple guardrails configuration with tracing enabled."""
+
+    return RailsConfig.from_content(
+        colang_content="""
+        define user express greeting
+            "hello"
+            "hi"
+            "hey"
+
+        define flow
+            user express greeting
+            bot express greeting
+
+        define bot express greeting
+            "Hello! I'm a guardrails-enabled assistant."
+            "Hi there! How can I help you today?"
+        """,
+        config={
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "openai",
+                    "model": "gpt-4o",
+                }
+            ],
+            "tracing": {"enabled": True, "adapters": [{"name": "OpenTelemetry"}]},
+        },
+    )
+
+
+def main():
+    """Main function demonstrating NeMo Guardrails with OpenTelemetry."""
+    print(" NeMo Guardrails + OpenTelemetry Example")
+    print("=" * 50)
+
+    # step 1: configure OpenTelemetry (APPLICATION'S RESPONSIBILITY)
+    setup_opentelemetry()
+
+    # step 2: create guardrails configuration
+    print(" Creating guardrails configuration...")
+    config = create_guardrails_config()
+    rails = LLMRails(config)
+    print(" Guardrails configured with tracing enabled\n")
+
+    # step 3: test the guardrails with tracing
+    print(" Testing guardrails (traces will appear below)...")
+    print("-" * 50)
+
+    # this will create spans that get exported to the console
+    response = rails.generate(
+        messages=[{"role": "user", "content": "What can you do?"}]
+    )
+
+    print(f"User: What can you do?")
+    print(f"Bot: {response.response}")
+    print("-" * 50)
+
+    # force export any remaining spans
+    print("\n Flushing remaining traces...")
+    trace.get_tracer_provider().force_flush(1000)
+
+    print("\n Example completed!")
+    print("\n Tips:")
+    print("   - Traces were printed above (look for JSON output)")
+    print("   - In production, replace ConsoleSpanExporter with OTLP/Jaeger")
+    print("   - The spans show the internal flow of guardrails processing")
+
+
+if __name__ == "__main__":
+    main()

--- a/nemoguardrails/tracing/adapters/opentelemetry.py
+++ b/nemoguardrails/tracing/adapters/opentelemetry.py
@@ -13,78 +13,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+OpenTelemetry Adapter for NeMo Guardrails
+
+This adapter follows OpenTelemetry best practices for libraries:
+- Uses only the OpenTelemetry API (not SDK)
+- Does not modify global state
+- Relies on the application to configure the SDK
+
+Usage:
+    Applications using NeMo Guardrails with OpenTelemetry should configure
+    the OpenTelemetry SDK before using this adapter:
+
+    ```python
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+    # application configures the SDK
+    trace.set_tracer_provider(TracerProvider())
+    tracer_provider = trace.get_tracer_provider()
+
+    exporter = OTLPSpanExporter(endpoint="http://localhost:4317")
+    span_processor = BatchSpanProcessor(exporter)
+    tracer_provider.add_span_processor(span_processor)
+
+    # now NeMo Guardrails can use the configured tracer
+    config = RailsConfig.from_content(
+        config={
+            "tracing": {
+                "enabled": True,
+                "adapters": [{"name": "OpenTelemetry"}]
+            }
+        }
+    )
+    ```
+"""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Type
-
-from opentelemetry.sdk.trace.export import SpanExporter
+from importlib.metadata import version
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from nemoguardrails.tracing import InteractionLog
 try:
     from opentelemetry import trace
-    from opentelemetry.sdk.resources import Attributes, Resource
-    from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 
 except ImportError:
     raise ImportError(
-        "opentelemetry is not installed. Please install it using `pip install opentelemetry-api opentelemetry-sdk`."
+        "OpenTelemetry API is not installed. Please install NeMo Guardrails with tracing support: "
+        "`pip install nemoguardrails[tracing]` or install the API directly: `pip install opentelemetry-api`."
     )
 
 from nemoguardrails.tracing.adapters.base import InteractionLogAdapter
 
-# Global dictionary to store registered exporters
-_exporter_name_cls_map: Dict[str, Type[SpanExporter]] = {
-    "console": ConsoleSpanExporter,
-}
-
-
-def register_otel_exporter(name: str, exporter_cls: Type[SpanExporter]):
-    """Register a new exporter."""
-    _exporter_name_cls_map[name] = exporter_cls
-
 
 class OpenTelemetryAdapter(InteractionLogAdapter):
+    """
+    OpenTelemetry adapter that follows library best practices.
+
+    This adapter uses only the OpenTelemetry API and relies on the application
+    to configure the SDK. It does not modify global state or create its own
+    tracer provider.
+    """
+
     name = "OpenTelemetry"
 
     def __init__(
         self,
-        service_name="nemo_guardrails_service",
-        span_processor: Optional[SpanProcessor] = None,
-        exporter: Optional[str] = None,
-        exporter_cls: Optional[SpanExporter] = None,
-        resource_attributes: Optional[Attributes] = None,
+        service_name: str = "nemo_guardrails",
         **kwargs,
     ):
-        resource_attributes = resource_attributes or {}
-        resource = Resource.create(
-            {"service.name": service_name, **resource_attributes}
+        """
+        Initialize the OpenTelemetry adapter.
+
+        Args:
+            service_name: Service name for instrumentation scope (not used for resource)
+            **kwargs: Additional arguments (for backward compatibility)
+
+        Note:
+            Applications must configure the OpenTelemetry SDK before using this adapter.
+            The adapter will use the globally configured tracer provider.
+        """
+        self.tracer = trace.get_tracer(
+            service_name,
+            instrumenting_library_version=version("nemoguardrails"),
+            schema_url="https://opentelemetry.io/schemas/1.26.0",
         )
-
-        if exporter_cls and exporter:
-            raise ValueError(
-                "Only one of 'exporter' or 'exporter_name' should be provided"
-            )
-        # Set up the tracer provider
-        provider = TracerProvider(resource=resource)
-
-        # Init the span processor and exporter
-        exporter_cls = None
-        if exporter:
-            exporter_cls = self.get_exporter(exporter, **kwargs)
-
-        if exporter_cls is None:
-            exporter_cls = ConsoleSpanExporter()
-
-        if span_processor is None:
-            span_processor = BatchSpanProcessor(exporter_cls)
-
-        provider.add_span_processor(span_processor)
-        trace.set_tracer_provider(provider)
-
-        self.tracer_provider = provider
-        self.tracer = trace.get_tracer(__name__)
 
     def transform(self, interaction_log: "InteractionLog"):
         """Transforms the InteractionLog into OpenTelemetry spans."""
@@ -139,20 +156,3 @@ class OpenTelemetryAdapter(InteractionLogAdapter):
             span.set_attribute("duration", span_data.duration)
 
             spans[span_data.span_id] = span
-
-    @staticmethod
-    def get_exporter(exporter: str, **kwargs) -> SpanExporter:
-        if exporter == "zipkin":
-            try:
-                from opentelemetry.exporter.zipkin.json import ZipkinExporter
-
-                _exporter_name_cls_map["zipkin"] = ZipkinExporter
-            except ImportError:
-                raise ImportError(
-                    "The opentelemetry-exporter-zipkin package is not installed. Please install it using 'pip install opentelemetry-exporter-zipkin'."
-                )
-
-        exporter_cls = _exporter_name_cls_map.get(exporter)
-        if not exporter_cls:
-            raise ValueError(f"Unknown exporter: {exporter}")
-        return exporter_cls(**kwargs)

--- a/nemoguardrails/tracing/adapters/opentelemetry.py
+++ b/nemoguardrails/tracing/adapters/opentelemetry.py
@@ -53,13 +53,15 @@ Usage:
 
 from __future__ import annotations
 
+import warnings
 from importlib.metadata import version
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nemoguardrails.tracing import InteractionLog
 try:
     from opentelemetry import trace
+    from opentelemetry.trace import NoOpTracerProvider
 
 except ImportError:
     raise ImportError(
@@ -97,6 +99,37 @@ class OpenTelemetryAdapter(InteractionLogAdapter):
             Applications must configure the OpenTelemetry SDK before using this adapter.
             The adapter will use the globally configured tracer provider.
         """
+        # check for deprecated parameters and warn users
+        deprecated_params = [
+            "exporter",
+            "exporter_cls",
+            "resource_attributes",
+            "span_processor",
+        ]
+        used_deprecated = [param for param in deprecated_params if param in kwargs]
+
+        if used_deprecated:
+            warnings.warn(
+                f"OpenTelemetry configuration parameters {used_deprecated} in YAML/config are deprecated "
+                "and will be ignored. Please configure OpenTelemetry in your application code. "
+                "See the migration guide at: "
+                "https://github.com/NVIDIA/NeMo-Guardrails/blob/main/examples/configs/tracing/README.md#migration-guide",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        # validate that OpenTelemetry is properly configured
+        provider = trace.get_tracer_provider()
+        if provider is None or isinstance(provider, NoOpTracerProvider):
+            warnings.warn(
+                "No OpenTelemetry TracerProvider configured. Traces will not be exported. "
+                "Please configure OpenTelemetry in your application code before using NeMo Guardrails. "
+                "See setup guide at: "
+                "https://github.com/NVIDIA/NeMo-Guardrails/blob/main/examples/configs/tracing/README.md#opentelemetry-setup",
+                UserWarning,
+                stacklevel=2,
+            )
+
         self.tracer = trace.get_tracer(
             service_name,
             instrumenting_library_version=version("nemoguardrails"),

--- a/nemoguardrails/tracing/adapters/opentelemetry.py
+++ b/nemoguardrails/tracing/adapters/opentelemetry.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 
 import warnings
 from importlib.metadata import version
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Type
 
 if TYPE_CHECKING:
     from nemoguardrails.tracing import InteractionLog
@@ -70,6 +70,34 @@ except ImportError:
     )
 
 from nemoguardrails.tracing.adapters.base import InteractionLogAdapter
+
+# DEPRECATED: global dictionary to store registered exporters
+# will be removed in  v0.16.0
+_exporter_name_cls_map: dict[str, Type] = {}
+
+
+def register_otel_exporter(name: str, exporter_cls: Type):
+    """Register a new exporter.
+
+    Args:
+        name: The name to register the exporter under.
+        exporter_cls: The exporter class to register.
+
+    Deprecated:
+        This function is deprecated and will be removed in version 0.16.0.
+        Please configure OpenTelemetry exporters directly in your application code.
+        See the migration guide at:
+        https://github.com/NVIDIA/NeMo-Guardrails/blob/main/examples/configs/tracing/README.md#migration-guide
+    """
+    warnings.warn(
+        "register_otel_exporter is deprecated and will be removed in version 0.16.0. "
+        "Please configure OpenTelemetry exporters directly in your application code. "
+        "See the migration guide at: "
+        "https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/examples/configs/tracing/README.md#migration-guide",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    _exporter_name_cls_map[name] = exporter_cls
 
 
 class OpenTelemetryAdapter(InteractionLogAdapter):

--- a/poetry.lock
+++ b/poetry.lock
@@ -903,23 +903,6 @@ marshmallow = ">=3.18.0,<4.0.0"
 typing-inspect = ">=0.4.0,<1"
 
 [[package]]
-name = "deprecated"
-version = "1.2.18"
-description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
-optional = true
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-files = [
-    {file = "Deprecated-1.2.18-py2.py3-none-any.whl", hash = "sha256:bd5011788200372a32418f888e326a09ff80d0214bd961147cfed01b5c018eec"},
-    {file = "deprecated-1.2.18.tar.gz", hash = "sha256:422b6f6d859da6f2ef57857761bfb392480502a64c3028ca9bbe86085d72115d"},
-]
-
-[package.dependencies]
-wrapt = ">=1.10,<2"
-
-[package.extras]
-dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "setuptools", "tox"]
-
-[[package]]
 name = "dill"
 version = "0.3.9"
 description = "serialize all of Python"
@@ -2961,49 +2944,49 @@ realtime = ["websockets (>=13,<15)"]
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.30.0"
+version = "1.34.1"
 description = "OpenTelemetry Python API"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.9"
 files = [
-    {file = "opentelemetry_api-1.30.0-py3-none-any.whl", hash = "sha256:d5f5284890d73fdf47f843dda3210edf37a38d66f44f2b5aedc1e89ed455dc09"},
-    {file = "opentelemetry_api-1.30.0.tar.gz", hash = "sha256:375893400c1435bf623f7dfb3bcd44825fe6b56c34d0667c542ea8257b1a1240"},
+    {file = "opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c"},
+    {file = "opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
-importlib-metadata = ">=6.0,<=8.5.0"
+importlib-metadata = ">=6.0,<8.8.0"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.30.0"
+version = "1.34.1"
 description = "OpenTelemetry Python SDK"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.9"
 files = [
-    {file = "opentelemetry_sdk-1.30.0-py3-none-any.whl", hash = "sha256:14fe7afc090caad881addb6926cec967129bd9260c4d33ae6a217359f6b61091"},
-    {file = "opentelemetry_sdk-1.30.0.tar.gz", hash = "sha256:c9287a9e4a7614b9946e933a67168450b9ab35f08797eb9bc77d998fa480fa18"},
+    {file = "opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e"},
+    {file = "opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d"},
 ]
 
 [package.dependencies]
-opentelemetry-api = "1.30.0"
-opentelemetry-semantic-conventions = "0.51b0"
-typing-extensions = ">=3.7.4"
+opentelemetry-api = "1.34.1"
+opentelemetry-semantic-conventions = "0.55b1"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.51b0"
+version = "0.55b1"
 description = "OpenTelemetry Semantic Conventions"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.9"
 files = [
-    {file = "opentelemetry_semantic_conventions-0.51b0-py3-none-any.whl", hash = "sha256:fdc777359418e8d06c86012c3dc92c88a6453ba662e941593adb062e48c2eeae"},
-    {file = "opentelemetry_semantic_conventions-0.51b0.tar.gz", hash = "sha256:3fabf47f35d1fd9aebcdca7e6802d86bd5ebc3bc3408b7e3248dde6e87a18c47"},
+    {file = "opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed"},
+    {file = "opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3"},
 ]
 
 [package.dependencies]
-deprecated = ">=1.2.6"
-opentelemetry-api = "1.30.0"
+opentelemetry-api = "1.34.1"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "orjson"
@@ -6195,16 +6178,16 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 cffi = ["cffi (>=1.11)"]
 
 [extras]
-all = ["aiofiles", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "opentelemetry-api", "opentelemetry-sdk", "presidio-analyzer", "presidio-anonymizer", "streamlit", "tqdm", "yara-python"]
+all = ["aiofiles", "google-cloud-language", "langchain-nvidia-ai-endpoints", "langchain-openai", "numpy", "numpy", "numpy", "numpy", "opentelemetry-api", "presidio-analyzer", "presidio-anonymizer", "streamlit", "tqdm", "yara-python"]
 eval = ["numpy", "numpy", "numpy", "numpy", "streamlit", "tornado", "tqdm"]
 gcp = ["google-cloud-language"]
 jailbreak = ["yara-python"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 openai = ["langchain-openai"]
 sdd = ["presidio-analyzer", "presidio-anonymizer"]
-tracing = ["aiofiles", "opentelemetry-api", "opentelemetry-sdk"]
+tracing = ["aiofiles", "opentelemetry-api"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,!=3.9.7,<3.14"
-content-hash = "87f68af4fed89e29bd905dc11b10d1d4324087677e4d4ed4d5962c38ba647ef0"
+content-hash = "874f6720f0e92fe01142dfd8f8ca19d875a1b1e08d53b47b11374c7b3461eec1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6190,4 +6190,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,!=3.9.7,<3.14"
-content-hash = "874f6720f0e92fe01142dfd8f8ca19d875a1b1e08d53b47b11374c7b3461eec1"
+content-hash = "8f64239df194716cbdedfafd861add0998b1473d744933c5573b37eb90e05a61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ watchdog = ">=3.0.0,"
 
 # tracing
 opentelemetry-api = { version = ">=1.27.0,<2.0.0", optional = true }
-opentelemetry-sdk = { version = ">=1.27.0,<2.0.0", optional = true }
 aiofiles = { version = ">=24.1.0", optional = true }
 
 # openai
@@ -107,7 +106,7 @@ sdd = ["presidio-analyzer", "presidio-anonymizer"]
 eval = ["tqdm", "numpy", "streamlit", "tornado"]
 openai = ["langchain-openai"]
 gcp = ["google-cloud-language"]
-tracing = ["opentelemetry-api", "opentelemetry-sdk", "aiofiles"]
+tracing = ["opentelemetry-api", "aiofiles"]
 nvidia = ["langchain-nvidia-ai-endpoints"]
 jailbreak = ["yara-python"]
 # Poetry does not support recursive dependencies, so we need to add all the dependencies here.
@@ -122,7 +121,6 @@ all = [
   "langchain-openai",
   "google-cloud-language",
   "opentelemetry-api",
-  "opentelemetry-sdk",
   "aiofiles",
   "langchain-nvidia-ai-endpoints",
   "yara-python",
@@ -146,6 +144,8 @@ streamlit = ">=1.37.0"
 tox = "^4.23.2"
 pytest-profiling = "^1.7.0"
 yara-python = "^4.5.1"
+opentelemetry-api = "^1.34.1"
+opentelemetry-sdk = "^1.34.1"
 
 
 [tool.poetry.group.docs]

--- a/tests/test_tracing_adapters_opentelemetry.py
+++ b/tests/test_tracing_adapters_opentelemetry.py
@@ -332,7 +332,6 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
 
     def test_no_warnings_with_proper_configuration(self):
         """Test that no warnings are issued when properly configured."""
-
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
 
@@ -341,3 +340,25 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
 
             # no warnings is issued
             self.assertEqual(len(w), 0)
+
+    def test_register_otel_exporter_deprecation(self):
+        """Test that register_otel_exporter shows deprecation warning."""
+        from nemoguardrails.tracing.adapters.opentelemetry import register_otel_exporter
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            mock_exporter_cls = MagicMock()
+
+            register_otel_exporter("test-exporter", mock_exporter_cls)
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("register_otel_exporter is deprecated", str(w[0].message))
+            self.assertIn("0.16.0", str(w[0].message))
+
+            from nemoguardrails.tracing.adapters.opentelemetry import (
+                _exporter_name_cls_map,
+            )
+
+            self.assertEqual(_exporter_name_cls_map["test-exporter"], mock_exporter_cls)

--- a/tests/test_tracing_adapters_opentelemetry.py
+++ b/tests/test_tracing_adapters_opentelemetry.py
@@ -15,14 +15,15 @@
 
 import asyncio
 import unittest
+import warnings
 from importlib.metadata import version
 from unittest.mock import MagicMock, patch
 
 # TODO: check to see if we can add it as a dependency
 # but now we try to import opentelemetry and set a flag if it's not available
 try:
-    from opentelemetry import trace
     from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.trace import NoOpTracerProvider
 
     from nemoguardrails.tracing.adapters.opentelemetry import OpenTelemetryAdapter
 
@@ -288,3 +289,55 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
         # Should still create the adapter successfully
         self.assertIsInstance(adapter, OpenTelemetryAdapter)
         self.assertEqual(adapter.tracer, self.mock_tracer)
+
+    def test_deprecation_warning_for_old_parameters(self):
+        """Test that deprecation warnings are raised for old configuration parameters."""
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # adapter with deprecated parameters
+            _adapter = OpenTelemetryAdapter(
+                service_name="test_service",
+                exporter="console",
+                resource_attributes={"test": "value"},
+                span_processor=MagicMock(),
+            )
+
+            # deprecation warning is issued
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn("deprecated", str(w[0].message))
+            self.assertIn("exporter", str(w[0].message))
+            self.assertIn("resource_attributes", str(w[0].message))
+            self.assertIn("span_processor", str(w[0].message))
+
+    def test_no_op_tracer_provider_warning(self):
+        """Test that a warning is issued when NoOpTracerProvider is detected."""
+
+        with patch("opentelemetry.trace.get_tracer_provider") as mock_get_provider:
+            mock_get_provider.return_value = NoOpTracerProvider()
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+
+                _adapter = OpenTelemetryAdapter()
+
+                self.assertEqual(len(w), 1)
+                self.assertTrue(issubclass(w[0].category, UserWarning))
+                self.assertIn(
+                    "No OpenTelemetry TracerProvider configured", str(w[0].message)
+                )
+                self.assertIn("Traces will not be exported", str(w[0].message))
+
+    def test_no_warnings_with_proper_configuration(self):
+        """Test that no warnings are issued when properly configured."""
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            # adapter without deprecated parameters
+            _adapter = OpenTelemetryAdapter(service_name="test_service")
+
+            # no warnings is issued
+            self.assertEqual(len(w), 0)

--- a/tests/test_tracing_adapters_opentelemetry.py
+++ b/tests/test_tracing_adapters_opentelemetry.py
@@ -15,12 +15,14 @@
 
 import asyncio
 import unittest
+from importlib.metadata import version
 from unittest.mock import MagicMock, patch
 
 # TODO: check to see if we can add it as a dependency
 # but now we try to import opentelemetry and set a flag if it's not available
 try:
-    from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
 
     from nemoguardrails.tracing.adapters.opentelemetry import OpenTelemetryAdapter
 
@@ -35,44 +37,42 @@ from nemoguardrails.tracing import InteractionLog
 @unittest.skipIf(not OPENTELEMETRY_AVAILABLE, "opentelemetry is not available")
 class TestOpenTelemetryAdapter(unittest.TestCase):
     def setUp(self):
+        # Set up a mock tracer provider for testing
+        self.mock_tracer_provider = MagicMock(spec=TracerProvider)
+        self.mock_tracer = MagicMock()
+        self.mock_tracer_provider.get_tracer.return_value = self.mock_tracer
+
+        # Patch the global tracer provider
+        patcher_get_tracer_provider = patch("opentelemetry.trace.get_tracer_provider")
+        self.mock_get_tracer_provider = patcher_get_tracer_provider.start()
+        self.mock_get_tracer_provider.return_value = self.mock_tracer_provider
+        self.addCleanup(patcher_get_tracer_provider.stop)
+
+        # Patch get_tracer to return our mock
         patcher_get_tracer = patch("opentelemetry.trace.get_tracer")
         self.mock_get_tracer = patcher_get_tracer.start()
+        self.mock_get_tracer.return_value = self.mock_tracer
         self.addCleanup(patcher_get_tracer.stop)
 
-        # Create a mock tracer
-        self.mock_tracer = MagicMock()
-        self.mock_get_tracer.return_value = self.mock_tracer
+        # Get the actual version for testing
+        self.actual_version = version("nemoguardrails")
 
-        patcher_console_exporter = patch(
-            "opentelemetry.sdk.trace.export.ConsoleSpanExporter"
-        )
-        self.mock_console_exporter_cls = patcher_console_exporter.start()
-        self.addCleanup(patcher_console_exporter.stop)
-
-        patcher_batch_span_processor = patch(
-            "opentelemetry.sdk.trace.export.BatchSpanProcessor"
-        )
-        self.mock_batch_span_processor_cls = patcher_batch_span_processor.start()
-        self.addCleanup(patcher_batch_span_processor.stop)
-
-        patcher_add_span_processor = patch(
-            "opentelemetry.sdk.trace.TracerProvider.add_span_processor"
-        )
-        self.mock_add_span_processor = patcher_add_span_processor.start()
-        self.addCleanup(patcher_add_span_processor.stop)
-
-        self.adapter = OpenTelemetryAdapter(
-            span_processor=self.mock_batch_span_processor_cls,
-            exporter_cls=self.mock_console_exporter_cls,
-        )
+        # Create the adapter - it should now use the global tracer
+        self.adapter = OpenTelemetryAdapter()
 
     def test_initialization(self):
-        self.assertIsInstance(self.adapter.tracer_provider, SDKTracerProvider)
-        self.mock_add_span_processor.assert_called_once_with(
-            self.mock_batch_span_processor_cls
+        """Test that the adapter initializes correctly using the global tracer."""
+
+        self.mock_get_tracer.assert_called_once_with(
+            "nemo_guardrails",
+            instrumenting_library_version=self.actual_version,
+            schema_url="https://opentelemetry.io/schemas/1.26.0",
         )
+        # Verify that the adapter has the mock tracer
+        self.assertEqual(self.adapter.tracer, self.mock_tracer)
 
     def test_transform(self):
+        """Test that transform creates spans correctly."""
         interaction_log = InteractionLog(
             id="test_id",
             activated_rails=[],
@@ -110,6 +110,7 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
         span_instance.set_attribute.assert_any_call("duration", 1.0)
 
     def test_transform_span_attributes_various_types(self):
+        """Test that different attribute types are handled correctly."""
         interaction_log = InteractionLog(
             id="test_id",
             activated_rails=[],
@@ -149,6 +150,7 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
         span_instance.set_attribute.assert_any_call("duration", 1.0)
 
     def test_transform_with_empty_trace(self):
+        """Test transform with empty trace."""
         interaction_log = InteractionLog(
             id="test_id",
             activated_rails=[],
@@ -160,10 +162,9 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
 
         self.mock_tracer.start_as_current_span.assert_not_called()
 
-    def test_transform_with_exporter_failure(self):
-        self.mock_tracer.start_as_current_span.side_effect = Exception(
-            "Exporter failure"
-        )
+    def test_transform_with_tracer_failure(self):
+        """Test transform when tracer fails."""
+        self.mock_tracer.start_as_current_span.side_effect = Exception("Tracer failure")
 
         interaction_log = InteractionLog(
             id="test_id",
@@ -185,9 +186,11 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             self.adapter.transform(interaction_log)
 
-        self.assertIn("Exporter failure", str(context.exception))
+        self.assertIn("Tracer failure", str(context.exception))
 
     def test_transform_async(self):
+        """Test async transform functionality."""
+
         async def run_test():
             interaction_log = InteractionLog(
                 id="test_id",
@@ -228,6 +231,8 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
         asyncio.run(run_test())
 
     def test_transform_async_with_empty_trace(self):
+        """Test async transform with empty trace."""
+
         async def run_test():
             interaction_log = InteractionLog(
                 id="test_id",
@@ -242,10 +247,9 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
 
         asyncio.run(run_test())
 
-    def test_transform_async_with_exporter_failure(self):
-        self.mock_tracer.start_as_current_span.side_effect = Exception(
-            "Exporter failure"
-        )
+    def test_transform_async_with_tracer_failure(self):
+        """Test async transform when tracer fails."""
+        self.mock_tracer.start_as_current_span.side_effect = Exception("Tracer failure")
 
         async def run_test():
             interaction_log = InteractionLog(
@@ -268,6 +272,19 @@ class TestOpenTelemetryAdapter(unittest.TestCase):
             with self.assertRaises(Exception) as context:
                 await self.adapter.transform_async(interaction_log)
 
-            self.assertIn("Exporter failure", str(context.exception))
+            self.assertIn("Tracer failure", str(context.exception))
 
         asyncio.run(run_test())
+
+    def test_backward_compatibility_with_old_config(self):
+        """Test that old configuration parameters are still accepted."""
+        # This should not fail even if old parameters are passed
+        adapter = OpenTelemetryAdapter(
+            service_name="test_service",
+            exporter="console",  # this should be ignored gracefully
+            resource_attributes={"test": "value"},  # this should be ignored gracefully
+        )
+
+        # Should still create the adapter successfully
+        self.assertIsInstance(adapter, OpenTelemetryAdapter)
+        self.assertEqual(adapter.tracer, self.mock_tracer)


### PR DESCRIPTION
## Description
This PR refactors the OpenTelemetry integration to follow OpenTelemetry best practices by removing the SDK dependency and relying only on the OpenTelemetry API. We should not configure observability; that's the application's responsibility.

## Changes
- **Breaking**: Removed `opentelemetry-sdk` from `[tracing]` extra dependencies
- **Breaking**: OpenTelemetry adapter no longer configures SDK/exporters via YAML config
- Added deprecation warnings for old configuration parameters (`exporter`, `resource_attributes`, etc.)
- Added validation to warn users when OpenTelemetry is not properly configured
- Kept `register_otel_exporter` function with deprecation warning (will be removed in v0.16.0)



## Fixes
Resolves #1094

