### PR TITLE
docs: fix page-not-appearing issue

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ user-guides/advanced/nested-async-loop
 user-guides/advanced/vertexai-setup
 user-guides/advanced/nemoguard-contentsafety-deployment
 user-guides/advanced/nemoguard-topiccontrol-deployment
-user-guides/advanced/jailbreak-detection-heuristics-deployment
+user-guides/advanced/nemoguard-jailbreakdetect-deployment
 user-guides/advanced/safeguarding-ai-virtual-assistant-blueprint
 ```
 

--- a/docs/user-guides/advanced/index.rst
+++ b/docs/user-guides/advanced/index.rst
@@ -20,6 +20,5 @@ Advanced
    using-docker
    vertexai-setup
    nemoguard-contentsafety-deployment
-   nemoguard-jailbreakdetect-deployment
    nemoguard-topiccontrol-deployment
    safeguarding-ai-virtual-assistant-blueprint


### PR DESCRIPTION
## Description

Fix the advanced jailbreak deployment doc to appear

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
