### PR TITLE
fix: remove stream_usage from text completion

### DIFF
--- a/nemoguardrails/llm/models/langchain_initializer.py
+++ b/nemoguardrails/llm/models/langchain_initializer.py
@@ -253,6 +253,9 @@ def _init_text_completion_model(
     if provider_cls is None:
         raise ValueError()
     kwargs = _update_model_kwargs(provider_cls, model_name, kwargs)
+    # remove stream_usage parameter as it's not supported by text completion APIs
+    # (e.g., OpenAI's AsyncCompletions.create() doesn't accept this parameter)
+    kwargs.pop("stream_usage", None)
     return provider_cls(**kwargs)
 
 


### PR DESCRIPTION
This pull request includes a small but important change to the `_init_text_completion_model` function in `langchain_initializer.py`. The change ensures compatibility with text completion APIs by removing the unsupported `stream_usage` parameter from the `kwargs` dictionary before initializing the provider class.


TODO:

ensure current implementation for token usage tracking does not break for other providers see #1264 