### PR TITLE
feat(streaming): support external async token generators

### DIFF
--- a/docs/user-guides/advanced/streaming.md
+++ b/docs/user-guides/advanced/streaming.md
@@ -78,7 +78,7 @@ You can also provide your own async generator that yields tokens, which is usefu
 - You want to use a different LLM provider that has its own streaming API
 - You have pre-generated responses that you want to stream through guardrails
 - You want to implement custom token generation logic
-- You want to test your output rails or its config in streaming mode wihtout relying on an LLM which generates stochastic outputs.
+- You want to test your output rails or its config in streaming mode on predefined responses without actually relying on an actual LLM generation.
 
 To use an external generator, pass it to the `generator` parameter of `stream_async`:
 
@@ -89,14 +89,16 @@ from typing import AsyncIterator
 app = LLMRails(config)
 
 async def my_token_generator() -> AsyncIterator[str]:
-    # this could be from OpenAI, Anthropic, or any other source
+    # This could be from OpenAI API, Anthropic API, or any other LLM API that already has a streaming token generator. Mocking the stream here, for a simple example.
     tokens = ["Hello", " ", "world", "!"]
     for token in tokens:
         yield token
 
+messages = [{"role": "user", "content": "The most famous program ever written is"}]"}]
+
 # use the external generator with guardrails
 async for chunk in app.stream_async(
-    messages=history,
+    messages=messages,
     generator=my_token_generator()
 ):
     print(f"CHUNK: {chunk}")
@@ -105,7 +107,7 @@ async for chunk in app.stream_async(
 When using an external generator:
 
 - The internal LLM generation is completely bypassed
-- Output rails are still applied if configured
+- Output rails are still applied to the LLM responses returned by the external generator, if configured
 - The generator should yield string tokens
 
 Example with a real LLM API:

--- a/docs/user-guides/advanced/streaming.md
+++ b/docs/user-guides/advanced/streaming.md
@@ -71,7 +71,73 @@ result = await app.generate_async(
 print(result)
 ```
 
-For the complete working example, check out this [demo script](https://github.com/NVIDIA/NeMo-Guardrails/tree/develop/examples/scripts/demo_streaming.py).
+### Using External Token Generators
+
+You can also provide your own async generator that yields tokens, which is useful when:
+
+- You want to use a different LLM provider that has its own streaming API
+- You have pre-generated responses that you want to stream through guardrails
+- You want to implement custom token generation logic
+- You want to test your output rails or its config in streaming mode wihtout relying on an LLM which generates stochastic outputs.
+
+To use an external generator, pass it to the `generator` parameter of `stream_async`:
+
+```python
+from nemoguardrails import LLMRails
+from typing import AsyncIterator
+
+app = LLMRails(config)
+
+async def my_token_generator() -> AsyncIterator[str]:
+    # this could be from OpenAI, Anthropic, or any other source
+    tokens = ["Hello", " ", "world", "!"]
+    for token in tokens:
+        yield token
+
+# use the external generator with guardrails
+async for chunk in app.stream_async(
+    messages=history,
+    generator=my_token_generator()
+):
+    print(f"CHUNK: {chunk}")
+```
+
+When using an external generator:
+
+- The internal LLM generation is completely bypassed
+- Output rails are still applied if configured
+- The generator should yield string tokens
+
+Example with a real LLM API:
+
+```python
+async def openai_streaming_generator(messages) -> AsyncIterator[str]:
+    """Example using OpenAI's streaming API."""
+    import openai
+
+    stream = await openai.ChatCompletion.create(
+        model="gpt-4o",
+        messages=messages,
+        stream=True
+    )
+
+    # Yield tokens as they arrive
+    async for chunk in stream:
+        if chunk.choices[0].delta.content:
+            yield chunk.choices[0].delta.content
+
+config = RailsConfig.from_path("config/with_output_rails")
+app = LLMRails(config)
+
+async for chunk in app.stream_async(
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    generator=openai_streaming_generator(messages)
+):
+    # output rails will be applied to these chunks
+    print(chunk, end="", flush=True)
+```
+
+This feature enables seamless integration of NeMo Guardrails with any streaming LLM or token source while maintaining all the safety features of output rails.
 
 ### Server API
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1053,8 +1053,21 @@ class LLMRails:
         options: Optional[Union[dict, GenerationOptions]] = None,
         state: Optional[Union[dict, State]] = None,
         include_generation_metadata: Optional[bool] = False,
+        generator: Optional[AsyncIterator[str]] = None,
     ) -> AsyncIterator[str]:
         """Simplified interface for getting directly the streamed tokens from the LLM."""
+
+        # if an external generator is provided, use it directly
+        if generator:
+            if self.config.rails.output.streaming.enabled:
+                return self._run_output_rails_in_streaming(
+                    streaming_handler=generator,
+                    messages=messages,
+                    prompt=prompt,
+                )
+            else:
+                return generator
+
         self.explain_info = self._ensure_explain_info()
 
         streaming_handler = StreamingHandler(


### PR DESCRIPTION
Add ability to pass custom async token generators to `stream_async`, enabling integration with external LLMs or custom streaming sources. Update docs and add tests for output rails interaction and edge cases with external generators.

Note:
* This is equivalent to output rails only option in streaming mode. 
* Useful for testing streaming with output rails feature

