### PR TITLE
Add Colang v2 example for sensitive data detection

### DIFF
--- a/examples/configs/sensitive_data_detection_v2/config.yml
+++ b/examples/configs/sensitive_data_detection_v2/config.yml
@@ -1,0 +1,29 @@
+colang_version: "2.x"
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  config:
+    sensitive_data_detection:
+      input:
+        score_threshold: 0.4
+        entities:
+          - PERSON
+          - EMAIL_ADDRESS
+          - PHONE_NUMBER
+          - CREDIT_CARD
+          - US_SSN
+          - LOCATION
+
+      output:
+        score_threshold: 0.4
+        entities:
+          - PERSON
+          - EMAIL_ADDRESS
+          - PHONE_NUMBER
+          - CREDIT_CARD
+          - US_SSN
+          - LOCATION

--- a/examples/configs/sensitive_data_detection_v2/flows.co
+++ b/examples/configs/sensitive_data_detection_v2/flows.co
@@ -1,0 +1,10 @@
+import guardrails
+import nemoguardrails.library.sensitive_data_detection
+
+flow input rails $input_text
+  """Check user utterances before they get further processed."""
+  await mask sensitive data on input
+
+flow output rails $output_text
+  """Check response before sending it to user."""
+  await mask sensitive data on output

--- a/examples/configs/sensitive_data_detection_v2/main.co
+++ b/examples/configs/sensitive_data_detection_v2/main.co
@@ -1,0 +1,5 @@
+import core
+import llm
+
+flow main
+  activate llm continuation

--- a/nemoguardrails/library/sensitive_data_detection/flows.co
+++ b/nemoguardrails/library/sensitive_data_detection/flows.co
@@ -11,6 +11,7 @@ flow detect sensitive data on input
 
 flow mask sensitive data on input
   """Mask any sensitive data found in the user input."""
+  global $user_message
   $user_message = await MaskSensitiveDataAction(source="input", text=$user_message)
 
 
@@ -28,10 +29,11 @@ flow detect sensitive data on output
 
 flow mask sensitive data on output
   """Mask any sensitive data found in the bot output."""
+  global $bot_message
   $bot_message = await MaskSensitiveDataAction(source="output", text=$bot_message)
 
 
-# RETRIVAL RAILS
+# RETRIEVAL RAILS
 
 
 flow detect sensitive data on retrieval
@@ -45,4 +47,5 @@ flow detect sensitive data on retrieval
 
 flow mask sensitive data on retrieval
   """Mask any sensitive data found in the relevant chunks from the knowledge base."""
+  global $relevant_chunks
   $relevant_chunks = await MaskSensitiveDataAction(source="retrieval", text=$relevant_chunks)


### PR DESCRIPTION
## Description

This PR adds a new example configuration for `sensitive_data_detection` using Colang v2 flows:  
`examples/configs/sensitive_data_detection_v2/`

It also adds the necessary `global` declarations to allow the rails to output redacted data (however, see the related issue below).

## Related Issue(s)

- Depends on: https://github.com/NVIDIA/NeMo-Guardrails/pull/1297

## Mentions

@drazvan — it looks like you’ve contributed to this package along with @prezakhani-nvidia. If you could take a look, that would be great!

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
