### PR TITLE
fix: respect the user-provided log options regardless of tracing configuration

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -911,6 +911,7 @@ class LLMRails:
             await streaming_handler.push_chunk(END_OF_STREAM)
 
         # IF tracing is enabled we need to set GenerationLog attrs
+        original_log_options = None
         if self.config.tracing.enabled:
             if options is None:
                 options = GenerationOptions()
@@ -921,6 +922,7 @@ class LLMRails:
                 else:
                     # If options is a dict, convert it to GenerationOptions
                     options = GenerationOptions(**options)
+            original_log_options = options.log.model_copy(deep=True)
 
             # enable log options
             # it is aggressive, but these are required for tracing
@@ -1037,6 +1039,25 @@ class LLMRails:
                     input=messages, response=res, adapters=self._log_adapters
                 )
                 await tracer.export_async()
+
+                # respect original log specification, if tracing added information to the output
+                if original_log_options:
+                    if not any(
+                        (
+                            original_log_options.internal_events,
+                            original_log_options.activated_rails,
+                            original_log_options.llm_calls,
+                            original_log_options.colang_history,
+                        )
+                    ):
+                        res.log = None
+                    else:
+                        if not original_log_options.internal_events:
+                            res.log.internal_events = []
+                        if not original_log_options.activated_rails:
+                            res.log.activated_rails = []
+                        if not original_log_options.llm_calls:
+                            res.log.llm_calls = []
 
             return res
         else:


### PR DESCRIPTION
## Description
Using tracing overrides all user-provided logging configuration. While this is necessary to generate detailed logs, it should not require _returning_ that new log information back to the user if they did not request it. See https://github.com/NVIDIA/NeMo-Guardrails/issues/1316 for more detail.

Changes:
1) Ensures that regardless of tracing configuration, the returned response object respects the requested log options.
2) Modifies existing tracing unit test to account for new logging behavior
3) Adds new tracing unit test to check that ll permutations of logging options are respected if tracing is configured. 


## Related Issue(s)
  - Implements #1316 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
