### PR TITLE
ci(release): install git-cliff manually for workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,17 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: Install git-cliff
-        uses: kenji-miyake/setup-git-cliff@v2
+        # not allowed by NVIDIA
+        # uses: kenji-miyake/setup-git-cliff@v2
+        run: |
+          # download and install git-cliff binary directly
+          CLIFF_VERSION="2.7.0"
+          wget -q https://github.com/orhun/git-cliff/releases/download/v${CLIFF_VERSION}/git-cliff-${CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf git-cliff-${CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv git-cliff-${CLIFF_VERSION}/git-cliff /usr/local/bin/
+          rm -rf git-cliff-${CLIFF_VERSION}*
+          # verify installation
+          git cliff --version
 
       - name: Determine version
         id: version


### PR DESCRIPTION
## Description

Install git cliff from source due to following issue:
```
kenji-miyake/setup-git-cliff@v2 is not allowed to be used in NVIDIA/NeMo-Guardrails. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: BSFishy/pip-action@v1, EndBug/add-and-commit@*, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@*, Jimver/cuda-toolkit@*, NVIDIA/blossom-action@*, NVIDIA/gitlab-answer-app/*, NVIDIA/spark-rapids-common@*, SonarSource/sonarqube-scan-action@*, TreTuna/sync-branches@1.4.0, Wandalen/wretry.action/post@*, abbbi/github-actions-tune@*, actions-cool/pr-approve@v0.0.1-beat, actions-ecosystem/action-add-assignees@v1, actions-ecosystem/action-add-labels@*, actions-ecosystem/action-regex-match@*, actions-ecosystem/action-remove-labels@*, actions/cache@*, actions/checkout@v3, actions/checkout@v4, actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e, actions/deploy-pages@*, actions/downl...
```
