### PR TITLE
feat(llmrails): isolate LLMs only for configured actions

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -73,7 +73,10 @@ from nemoguardrails.rails.llm.options import (
     GenerationOptions,
     GenerationResponse,
 )
-from nemoguardrails.rails.llm.utils import get_history_cache_key
+from nemoguardrails.rails.llm.utils import (
+    get_action_details_from_flow_id,
+    get_history_cache_key,
+)
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 from nemoguardrails.utils import (
     extract_error_json,
@@ -1590,7 +1593,7 @@ class LLMRails:
         output_rails_flows_id = self.config.rails.output.flows
         stream_first = stream_first or output_rails_streaming_config.stream_first
         get_action_details = partial(
-            _get_action_details_from_flow_id, flows=self.config.flows
+            get_action_details_from_flow_id, flows=self.config.flows
         )
 
         parallel_mode = getattr(self.config.rails.output, "parallel", False)
@@ -1746,58 +1749,3 @@ class LLMRails:
                 # yield the individual chunks directly from the buffer strategy
                 for chunk in user_output_chunks:
                     yield chunk
-
-
-def _get_action_details_from_flow_id(
-    flow_id: str,
-    flows: List[Union[Dict, Any]],
-    prefixes: Optional[List[str]] = None,
-) -> Tuple[str, Any]:
-    """Get the action name and parameters from the flow id.
-
-    First, try to find an exact match.
-    If not found, then if the provided flow_id starts with one of the special prefixes,
-    return the first flow whose id starts with that same prefix.
-    """
-
-    supported_prefixes = [
-        "content safety check output",
-        "topic safety check output",
-    ]
-    if prefixes:
-        supported_prefixes.extend(prefixes)
-
-    candidate_flow = None
-
-    for flow in flows:
-        # If exact match, use it
-        if flow["id"] == flow_id:
-            candidate_flow = flow
-            break
-
-        # If no exact match, check if both the provided flow_id and this flow's id share a special prefix
-        for prefix in supported_prefixes:
-            if flow_id.startswith(prefix) and flow["id"].startswith(prefix):
-                candidate_flow = flow
-                # We don't break immediately here because an exact match would have been preferred,
-                # but since we're in the else branch it's fine to choose the first matching candidate.
-                # TODO:we should avoid having multiple matchin prefixes
-                break
-
-        if candidate_flow is not None:
-            break
-
-    if candidate_flow is None:
-        raise ValueError(f"No action found for flow_id: {flow_id}")
-
-    # we have identified a candidate, look for the run_action element.
-    for element in candidate_flow["elements"]:
-        if (
-            element["_type"] == "run_action"
-            and element["_source_mapping"]["filename"].endswith(".co")
-            and "execute" in element["_source_mapping"]["line_text"]
-            and "action_name" in element
-        ):
-            return element["action_name"], element["action_params"]
-
-    raise ValueError(f"No run_action element found for flow_id: {flow_id}")

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -523,7 +523,7 @@ class LLMRails:
             )
 
             created_count = 0
-            # out of flows defined in rails config we get the actions
+            # Get the actions from flows defined in rails config
             get_action_details = partial(
                 get_action_details_from_flow_id, flows=self.config.flows
             )

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -523,7 +523,21 @@ class LLMRails:
             )
 
             created_count = 0
-            for action_name in actions_needing_llms:
+            # out of flows defined in rails config we get the actions
+            get_action_details = partial(
+                get_action_details_from_flow_id, flows=self.config.flows
+            )
+            configured_actions_names = []
+            for flow_id in self.config.rails.input.flows:
+                action_name, _ = get_action_details(flow_id)
+                configured_actions_names.append(action_name)
+            for flow_id in self.config.rails.output.flows:
+                action_name, _ = get_action_details(flow_id)
+                configured_actions_names.append(action_name)
+
+            for action_name in configured_actions_names:
+                if action_name not in actions_needing_llms:
+                    continue
                 if f"{action_name}_llm" not in self.runtime.registered_action_params:
                     isolated_llm = self._create_action_llm_copy(self.llm, action_name)
                     if isolated_llm:

--- a/tests/test_llm_isolation.py
+++ b/tests/test_llm_isolation.py
@@ -256,25 +256,45 @@ class TestLLMIsolation:
         """Test the full isolated LLM creation process."""
         rails = rails_with_mock_llm
 
+        # Mock rails configuration with flows
+        rails.config.rails = Mock()
+        rails.config.rails.input = Mock()
+        rails.config.rails.output = Mock()
+        rails.config.rails.input.flows = ["input_flow_1", "input_flow_2"]
+        rails.config.rails.output.flows = ["output_flow_1"]
+
         rails.runtime = Mock()
         rails.runtime.action_dispatcher = MockActionDispatcher()
         rails.runtime.registered_action_params = {}
         rails.runtime.register_action_param = Mock()
 
-        rails._create_isolated_llms_for_actions()
+        # Mock get_action_details_from_flow_id to return actions that need LLMs
+        def mock_get_action_details(flow_id, flows):
+            mapping = {
+                "input_flow_1": ("action_with_llm", {}),
+                "input_flow_2": ("generate_user_intent", {}),
+                "output_flow_1": ("self_check_output", {}),
+            }
+            return mapping.get(flow_id, ("unknown_action", {}))
 
-        expected_calls = [
+        with patch(
+            "nemoguardrails.rails.llm.llmrails.get_action_details_from_flow_id",
+            side_effect=mock_get_action_details,
+        ):
+            rails._create_isolated_llms_for_actions()
+
+        expected_llm_params = [
             "action_with_llm_llm",
             "generate_user_intent_llm",
             "self_check_output_llm",
         ]
 
-        actual_calls = [
+        registered_llm_params = [
             call[0][0] for call in rails.runtime.register_action_param.call_args_list
         ]
 
-        for expected_call in expected_calls:
-            assert expected_call in actual_calls
+        for expected_param in expected_llm_params:
+            assert expected_param in registered_llm_params
 
     def test_create_isolated_llms_skips_existing_specialized_llms(
         self, rails_with_mock_llm
@@ -282,22 +302,43 @@ class TestLLMIsolation:
         """Test that existing specialized LLMs are not overridden."""
         rails = rails_with_mock_llm
 
+        # Mock rails configuration with flows
+        rails.config.rails = Mock()
+        rails.config.rails.input = Mock()
+        rails.config.rails.output = Mock()
+        rails.config.rails.input.flows = ["input_flow_1", "input_flow_2"]
+        rails.config.rails.output.flows = ["output_flow_1"]
+
         rails.runtime = Mock()
         rails.runtime.action_dispatcher = MockActionDispatcher()
         rails.runtime.registered_action_params = {"self_check_output_llm": Mock()}
         rails.runtime.register_action_param = Mock()
 
-        rails._create_isolated_llms_for_actions()
+        # Mock get_action_details_from_flow_id to return actions that need LLMs
+        def mock_get_action_details(flow_id, flows):
+            mapping = {
+                "input_flow_1": ("action_with_llm", {}),
+                "input_flow_2": ("generate_user_intent", {}),
+                "output_flow_1": (
+                    "self_check_output",
+                    {},
+                ),  # This one already has an LLM
+            }
+            return mapping.get(flow_id, ("unknown_action", {}))
 
-        # verify self_check_output_llm was NOT re-registered
-        actual_calls = [
+        with patch(
+            "nemoguardrails.rails.llm.llmrails.get_action_details_from_flow_id",
+            side_effect=mock_get_action_details,
+        ):
+            rails._create_isolated_llms_for_actions()
+
+        registered_llm_params = [
             call[0][0] for call in rails.runtime.register_action_param.call_args_list
         ]
-        assert "self_check_output_llm" not in actual_calls
 
-        # but other actions should still get isolated LLMs
-        assert "action_with_llm_llm" in actual_calls
-        assert "generate_user_intent_llm" in actual_calls
+        assert "self_check_output_llm" not in registered_llm_params
+        assert "action_with_llm_llm" in registered_llm_params
+        assert "generate_user_intent_llm" in registered_llm_params
 
     def test_create_isolated_llms_handles_no_main_llm(self, mock_config):
         """Test graceful handling when no main LLM is available."""
@@ -412,3 +453,87 @@ class TestLLMIsolationEdgeCases:
             assert action_name in actions_needing_llms
         else:
             assert action_name not in actions_needing_llms
+
+    def test_create_isolated_llms_for_configured_actions_only(
+        self, rails_with_mock_llm
+    ):
+        """Test that isolated LLMs are created only for actions configured in rails flows."""
+        rails = rails_with_mock_llm
+
+        rails.config.rails = Mock()
+        rails.config.rails.input = Mock()
+        rails.config.rails.output = Mock()
+        rails.config.rails.input.flows = [
+            "input_flow_1",
+            "input_flow_2",
+            "input_flow_3",
+        ]
+        rails.config.rails.output.flows = ["output_flow_1", "output_flow_2"]
+
+        rails.runtime = Mock()
+        rails.runtime.action_dispatcher = MockActionDispatcher()
+        rails.runtime.registered_action_params = {}
+        rails.runtime.register_action_param = Mock()
+
+        def mock_get_action_details(flow_id, flows):
+            mapping = {
+                "input_flow_1": ("action_with_llm", {}),
+                "input_flow_2": ("action_without_llm", {}),
+                "input_flow_3": ("self_check_output", {}),
+                "output_flow_1": ("generate_user_intent", {}),
+                "output_flow_2": ("non_configured_action", {}),
+            }
+            return mapping.get(flow_id, ("unknown_action", {}))
+
+        with patch(
+            "nemoguardrails.rails.llm.llmrails.get_action_details_from_flow_id",
+            side_effect=mock_get_action_details,
+        ):
+            rails._create_isolated_llms_for_actions()
+
+        registered_llm_params = [
+            call[0][0] for call in rails.runtime.register_action_param.call_args_list
+        ]
+
+        expected_isolated_llm_params = [
+            "action_with_llm_llm",
+            "generate_user_intent_llm",
+            "self_check_output_llm",
+        ]
+
+        for expected_param in expected_isolated_llm_params:
+            assert (
+                expected_param in registered_llm_params
+            ), f"Expected {expected_param} to be registered as action param"
+
+        assert "action_without_llm_llm" not in registered_llm_params
+        assert "non_configured_action_llm" not in registered_llm_params
+
+        assert len(registered_llm_params) == 3, (
+            f"Should only create isolated LLMs for actions from config flows that need LLMs. "
+            f"Got {registered_llm_params}"
+        )
+
+    def test_create_isolated_llms_handles_empty_rails_config(self, rails_with_mock_llm):
+        """Test that the method handles empty rails configuration gracefully."""
+        rails = rails_with_mock_llm
+
+        rails.config.rails = Mock()
+        rails.config.rails.input = Mock()
+        rails.config.rails.output = Mock()
+        rails.config.rails.input.flows = []
+        rails.config.rails.output.flows = []
+
+        rails.runtime = Mock()
+        rails.runtime.action_dispatcher = MockActionDispatcher()
+        rails.runtime.registered_action_params = {}
+        rails.runtime.register_action_param = Mock()
+
+        with patch(
+            "nemoguardrails.rails.llm.llmrails.get_action_details_from_flow_id"
+        ) as mock_get_action:
+            rails._create_isolated_llms_for_actions()
+
+        mock_get_action.assert_not_called()
+
+        rails.runtime.register_action_param.assert_not_called()

--- a/tests/test_llm_isolation_e2e.py
+++ b/tests/test_llm_isolation_e2e.py
@@ -474,6 +474,10 @@ async def run_parameter_contamination_test():
         )
 
 
+@pytest.mark.skipif(
+    not TEST_LIVE_MODE,
+    reason="This test requires TEST_LIVE_MODE environment variable to be set for live testing",
+)
 class TestLLMIsolationConfiguredActionsOnly:
     """Test that isolated LLMs are created only for actions configured in rails flows."""
 

--- a/tests/test_llm_isolation_e2e.py
+++ b/tests/test_llm_isolation_e2e.py
@@ -25,7 +25,7 @@ import pytest
 from nemoguardrails import LLMRails
 from nemoguardrails.rails.llm.config import RailsConfig
 
-TEST_LIVE_MODE = os.environ.get("TEST_LIVE_MODE")
+LIVE_TEST_MODE = os.environ.get("TEST_LIVE_MODE")
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ def test_config_path(test_config_content):
 
 
 @pytest.mark.skipif(
-    not TEST_LIVE_MODE,
+    not LIVE_TEST_MODE,
     reason="This test requires TEST_LIVE_MODE environment variable to be set for live testing",
 )
 class TestLLMIsolationE2E:
@@ -383,7 +383,7 @@ class TestLLMIsolationE2E:
 
 
 @pytest.mark.skipif(
-    not TEST_LIVE_MODE,
+    not LIVE_TEST_MODE,
     reason="This test requires TEST_LIVE_MODE environment variable to be set for live testing",
 )
 class TestLLMIsolationErrorHandling:
@@ -475,7 +475,7 @@ async def run_parameter_contamination_test():
 
 
 @pytest.mark.skipif(
-    not TEST_LIVE_MODE,
+    not LIVE_TEST_MODE,
     reason="This test requires TEST_LIVE_MODE environment variable to be set for live testing",
 )
 class TestLLMIsolationConfiguredActionsOnly:

--- a/tests/test_llm_isolation_e2e.py
+++ b/tests/test_llm_isolation_e2e.py
@@ -474,5 +474,131 @@ async def run_parameter_contamination_test():
         )
 
 
+class TestLLMIsolationConfiguredActionsOnly:
+    """Test that isolated LLMs are created only for actions configured in rails flows."""
+
+    @staticmethod
+    def _create_rails_with_config(config_content: str) -> LLMRails:
+        """Helper to create LLMRails instance from config content."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.yml"
+            config_path.write_text(config_content)
+            config = RailsConfig.from_path(str(temp_dir))
+            return LLMRails(config, verbose=False)
+
+    @staticmethod
+    def _get_isolated_llm_params(
+        rails: LLMRails, exclude_specialized: bool = False
+    ) -> list:
+        """Helper to get isolated LLM parameters from rails instance."""
+        registered_params = rails.runtime.registered_action_params
+        isolated_llm_params = [
+            key
+            for key in registered_params.keys()
+            if key.endswith("_llm") and key != "llm" and key != "llms"
+        ]
+
+        if exclude_specialized:
+            specialized_llms = ["content_safety_llm", "topic_safety_llm"]
+            isolated_llm_params = [
+                param for param in isolated_llm_params if param not in specialized_llms
+            ]
+
+        return isolated_llm_params
+
+    def test_only_configured__rail_actions_get_isolated_llms(self):
+        """Test that only actions from output rails flows get isolated LLMs."""
+        config_content = """
+        models:
+          - type: main
+            engine: openai
+            model: gpt-4o-mini
+
+        rails:
+          output:
+            flows:
+              - self check output
+              - self check input
+
+        prompts:
+          - task: self_check_output
+            content: |
+              Check if output is safe.
+              Output: {{ bot_message }}
+              Safe? (Yes/No):
+          - task: self_check_input
+            content: |
+              Check if input is safe.
+              Input: {{ user_input }}
+              Safe? (Yes/No):
+        """
+
+        rails = self._create_rails_with_config(config_content)
+        isolated_llm_params = self._get_isolated_llm_params(rails)
+
+        assert "self_check_output_llm" in isolated_llm_params
+        assert "self_check_input_llm" in isolated_llm_params
+        assert "self_check_facts_llm" not in isolated_llm_params
+
+    def test_no_isolated_llms_when_no_rails_configured(self):
+        """Test that no isolated LLMs are created when no rails are configured."""
+        config_content = """
+        models:
+          - type: main
+            engine: openai
+            model: gpt-4o-mini
+        """
+
+        rails = self._create_rails_with_config(config_content)
+        isolated_llm_params = self._get_isolated_llm_params(
+            rails, exclude_specialized=True
+        )
+
+        assert (
+            len(isolated_llm_params) == 0
+        ), f"Unexpected isolated LLMs created: {isolated_llm_params}"
+
+    def test_empty_rails_flows_creates_no_isolated_llms(self):
+        """Test that empty rails flows list creates no isolated LLMs."""
+        config_content = """
+        models:
+          - type: main
+            engine: openai
+            model: gpt-4o-mini
+
+        rails:
+          input:
+            flows: []
+          output:
+            flows: []
+        """
+
+        rails = self._create_rails_with_config(config_content)
+        isolated_llm_params = self._get_isolated_llm_params(
+            rails, exclude_specialized=True
+        )
+
+        assert (
+            len(isolated_llm_params) == 0
+        ), f"Unexpected isolated LLMs created: {isolated_llm_params}"
+
+    def test_non_llm_requiring_actions_dont_get_isolated_llms(self):
+        """Test that even valid flows don't get isolated LLMs if actions don't require LLMs."""
+        config_content = """
+        models:
+          - type: main
+            engine: openai
+            model: gpt-4o-mini
+        """
+
+        rails = self._create_rails_with_config(config_content)
+
+        # retrieve_relevant_chunks action exists but doesn't require LLM
+        # so it should never get an isolated LLM even if it were configured
+        assert (
+            "retrieve_relevant_chunks_llm" not in rails.runtime.registered_action_params
+        )
+
+
 if __name__ == "__main__":
     asyncio.run(run_parameter_contamination_test())

--- a/tests/test_llmrails_reasoning.py
+++ b/tests/test_llmrails_reasoning.py
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Optional
 
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
-from nemoguardrails.rails.llm.llmrails import _get_action_details_from_flow_id
-from tests.utils import FakeLLM, clean_events, event_sequence_conforms
+from tests.utils import FakeLLM
 
 
 @pytest.fixture

--- a/tests/test_rails_llm_utils.py
+++ b/tests/test_rails_llm_utils.py
@@ -13,7 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemoguardrails.rails.llm.utils import get_history_cache_key
+from typing import Any, Dict, List, Union
+
+import pytest
+
+from nemoguardrails.rails.llm.utils import (
+    get_action_details_from_flow_id,
+    get_history_cache_key,
+)
 
 
 def test_basic():
@@ -55,3 +62,378 @@ def test_with_context():
         )
         == '{"user_name": "John"}:hi:Hello!:How are you?'
     )
+
+
+def test_multimodal_content():
+    """Test get_history_cache_key with multimodal content (list-based content)."""
+    multimodal_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,..."},
+                },
+            ],
+        }
+    ]
+    assert get_history_cache_key(multimodal_messages) == "What's in this image?"
+
+    multi_text_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "First part"},
+                {"type": "text", "text": "Second part"},
+            ],
+        }
+    ]
+    assert get_history_cache_key(multi_text_messages) == "First part Second part"
+
+    mixed_content_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,..."},
+                },
+                {"type": "text", "text": "World"},
+            ],
+        }
+    ]
+    assert get_history_cache_key(mixed_content_messages) == "Hello World"
+
+    empty_text_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": ""},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,..."},
+                },
+            ],
+        }
+    ]
+    assert get_history_cache_key(empty_text_messages) == ""
+
+
+def test_get_action_details_from_flow_id_exact_match():
+    """Test get_action_details_from_flow_id with exact flow ID match."""
+    flows = [
+        {
+            "id": "test_flow",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "test.co",
+                        "line_text": "execute action_name",
+                    },
+                    "action_name": "test_action",
+                    "action_params": {"param1": "value1"},
+                }
+            ],
+        }
+    ]
+
+    action_name, action_params = get_action_details_from_flow_id("test_flow", flows)
+    assert action_name == "test_action"
+    assert action_params == {"param1": "value1"}
+
+
+def test_get_action_details_from_flow_id_prefix_match():
+    """Test get_action_details_from_flow_id with prefix matching."""
+    flows = [
+        {
+            "id": "content safety check output with model gpt-4",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "safety.co",
+                        "line_text": "execute content_safety_check",
+                    },
+                    "action_name": "content_safety_check",
+                    "action_params": {"model": "gpt-4"},
+                }
+            ],
+        }
+    ]
+
+    action_name, action_params = get_action_details_from_flow_id(
+        "content safety check output", flows
+    )
+    assert action_name == "content_safety_check"
+    assert action_params == {"model": "gpt-4"}
+
+
+def test_get_action_details_from_flow_id_topic_safety_prefix():
+    """Test get_action_details_from_flow_id with topic safety prefix."""
+    flows = [
+        {
+            "id": "topic safety check output with model claude",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "topic.co",
+                        "line_text": "execute topic_safety_check",
+                    },
+                    "action_name": "topic_safety_check",
+                    "action_params": {"model": "claude"},
+                }
+            ],
+        }
+    ]
+
+    action_name, action_params = get_action_details_from_flow_id(
+        "topic safety check output", flows
+    )
+    assert action_name == "topic_safety_check"
+    assert action_params == {"model": "claude"}
+
+
+def test_get_action_details_from_flow_id_custom_prefixes():
+    """Test get_action_details_from_flow_id with custom prefixes."""
+    flows = [
+        {
+            "id": "custom prefix flow with params",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "custom.co",
+                        "line_text": "execute custom_action",
+                    },
+                    "action_name": "custom_action",
+                    "action_params": {"custom": "value"},
+                }
+            ],
+        }
+    ]
+
+    action_name, action_params = get_action_details_from_flow_id(
+        "custom prefix flow", flows, prefixes=["custom prefix"]
+    )
+    assert action_name == "custom_action"
+    assert action_params == {"custom": "value"}
+
+
+def test_get_action_details_from_flow_id_no_match():
+    """Test get_action_details_from_flow_id when no flow matches."""
+    flows = [
+        {
+            "id": "different_flow",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "test.co",
+                        "line_text": "execute test_action",
+                    },
+                    "action_name": "test_action",
+                    "action_params": {},
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(
+        ValueError, match="No action found for flow_id: nonexistent_flow"
+    ):
+        get_action_details_from_flow_id("nonexistent_flow", flows)
+
+
+def test_get_action_details_from_flow_id_no_run_action():
+    """Test get_action_details_from_flow_id when flow has no run_action element."""
+    flows = [
+        {
+            "id": "test_flow",
+            "elements": [{"_type": "other_element", "some_data": "value"}],
+        }
+    ]
+
+    with pytest.raises(
+        ValueError, match="No run_action element found for flow_id: test_flow"
+    ):
+        get_action_details_from_flow_id("test_flow", flows)
+
+
+def test_get_action_details_from_flow_id_invalid_run_action():
+    """Test get_action_details_from_flow_id when run_action element is invalid."""
+    flows = [
+        {
+            "id": "test_flow",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "test.py",
+                        "line_text": "execute test_action",
+                    },
+                    "action_name": "test_action",
+                    "action_params": {},
+                }
+            ],
+        }
+    ]
+
+    with pytest.raises(
+        ValueError, match="No run_action element found for flow_id: test_flow"
+    ):
+        get_action_details_from_flow_id("test_flow", flows)
+
+
+def test_get_action_details_from_flow_id_multiple_run_actions():
+    """Test get_action_details_from_flow_id with multiple run_action elements."""
+    flows = [
+        {
+            "id": "multi_action_flow",
+            "elements": [
+                {"_type": "other_element", "data": "ignore"},
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "multi.co",
+                        "line_text": "execute first_action",
+                    },
+                    "action_name": "first_action",
+                    "action_params": {"order": "first"},
+                },
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "multi.co",
+                        "line_text": "execute second_action",
+                    },
+                    "action_name": "second_action",
+                    "action_params": {"order": "second"},
+                },
+            ],
+        }
+    ]
+
+    # Should return the first valid run_action element
+    action_name, action_params = get_action_details_from_flow_id(
+        "multi_action_flow", flows
+    )
+    assert action_name == "first_action"
+    assert action_params == {"order": "first"}
+
+
+@pytest.fixture
+def dummy_flows() -> List[Union[Dict, Any]]:
+    return [
+        {
+            "id": "test_flow",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "flows.v1.co",
+                        "line_text": "execute something",
+                    },
+                    "action_name": "test_action",
+                    "action_params": {"param1": "value1"},
+                }
+            ],
+        },
+        {
+            "id": "other_flow is prefix",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "flows.v1.co",
+                        "line_text": "execute something else",
+                    },
+                    "action_name": "other_action",
+                    "action_params": {"param2": "value2"},
+                }
+            ],
+        },
+        {
+            "id": "test_rails_co",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "rails.co",
+                        "line_text": "execute something",
+                    },
+                    "action_name": "test_action_supported",
+                    "action_params": {"param1": "value1"},
+                }
+            ],
+        },
+        {
+            "id": "test_rails_co_v2",
+            "elements": [
+                {
+                    "_type": "run_action",
+                    "_source_mapping": {
+                        "filename": "rails.co",
+                        "line_text": "await something",
+                    },
+                    "action_name": "test_action_not_supported",
+                    "action_params": {"param1": "value1"},
+                }
+            ],
+        },
+    ]
+
+
+def test_get_action_details_exact_match(dummy_flows):
+    action_name, action_params = get_action_details_from_flow_id(
+        "test_flow", dummy_flows
+    )
+    assert action_name == "test_action"
+    assert action_params == {"param1": "value1"}
+
+
+def test_get_action_details_exact_match_any_co_file(dummy_flows):
+    action_name, action_params = get_action_details_from_flow_id(
+        "test_rails_co", dummy_flows
+    )
+    assert action_name == "test_action_supported"
+    assert action_params == {"param1": "value1"}
+
+
+def test_get_action_details_exact_match_not_colang_2(dummy_flows):
+    with pytest.raises(ValueError) as exc_info:
+        get_action_details_from_flow_id("test_rails_co_v2", dummy_flows)
+
+    assert "No run_action element found for flow_id" in str(exc_info.value)
+
+
+def test_get_action_details_prefix_match(dummy_flows):
+    # For a flow_id that starts with the prefix "other_flow",
+    # we expect to retrieve the action details from the flow whose id starts with that prefix.
+    # we expect a result since we are passing the prefixes argument.
+    action_name, action_params = get_action_details_from_flow_id(
+        "other_flow", dummy_flows, prefixes=["other_flow"]
+    )
+    assert action_name == "other_action"
+    assert action_params == {"param2": "value2"}
+
+
+def test_get_action_details_prefix_match_unsupported_prefix(dummy_flows):
+    # For a flow_id that starts with the prefix "other_flow",
+    # we expect to retrieve the action details from the flow whose id starts with that prefix.
+    # but as the prefix is not supported, we expect a ValueError.
+
+    with pytest.raises(ValueError) as exc_info:
+        get_action_details_from_flow_id("other_flow", dummy_flows)
+
+    assert "No action found for flow_id" in str(exc_info.value)
+
+
+def test_get_action_details_no_match(dummy_flows):
+    # Tests that a non matching flow_id raises a ValueError
+    with pytest.raises(ValueError) as exc_info:
+        get_action_details_from_flow_id("non_existing_flow", dummy_flows)
+    assert "No action found for flow_id" in str(exc_info.value)


### PR DESCRIPTION
Update isolated LLM creation to only target actions defined in rails config flows. This ensures that LLMs are not unnecessarily created for actions not present in the configuration. Adds comprehensive tests to verify correct behavior, including handling of empty configs and skipping already-registered LLMs.