### PR TITLE
fix(logging): handle missing id and task in verbose logs

### DIFF
--- a/nemoguardrails/logging/verbose.py
+++ b/nemoguardrails/logging/verbose.py
@@ -54,7 +54,9 @@ class VerboseHandler(logging.StreamHandler):
                 skip_print = True
                 if verbose_llm_calls:
                     console.print("")
-                    console.print(f"[cyan]LLM {title} ({record.id[:5]}..)[/]")
+                    id_str = getattr(record, "id", None)
+                    id_display = f"({id_str[:5]}..)" if id_str else ""
+                    console.print(f"[cyan]LLM {title} {id_display}[/]")
                     for line in body.split("\n"):
                         text = Text(line, style="black on #006600", end="\n")
                         text.pad_right(console.width)
@@ -66,9 +68,10 @@ class VerboseHandler(logging.StreamHandler):
                 if verbose_llm_calls:
                     skip_print = True
                     console.print("")
-                    console.print(
-                        f"[cyan]LLM Prompt ({record.id[:5]}..) - {record.task}[/]"
-                    )
+                    id_str = getattr(record, "id", None)
+                    id_display = f"({id_str[:5]}..)" if id_str else ""
+                    task_str = getattr(record, "task", "unknown")
+                    console.print(f"[cyan]LLM Prompt {id_display} - {task_str}[/]")
 
                     for line in body.split("\n"):
                         if line.strip() == "[/]":


### PR DESCRIPTION
Update verbose logging to safely handle cases where log records may not have 'id' or 'task' attributes. Prevents potential `AttributeError` and improves robustness of LLM and prompt log output formatting.