### PR TITLE
docs(tracing): add OpenTelemetry span format guide

### DIFF
--- a/docs/user-guides/tracing/index.md
+++ b/docs/user-guides/tracing/index.md
@@ -67,7 +67,7 @@ The following are the key differences between the supported span formats.
 
 ### Migration Path
 
-Existing configurations will continue to work, but we strongly recommend migrating to the OpenTelemetry format:
+Existing configurations will continue to work. However, it is strongly recommended to migrate to the OpenTelemetry format. Migration steps are:
 
 1. Update your configuration to use `span_format: "opentelemetry"`
 2. Review your telemetry backends for compatibility with OpenTelemetry conventions


### PR DESCRIPTION
## Description

Add documentation describing the new OpenTelemetry-based span format for tracing, including configuration, key differences from the legacy format, migration steps, and important considerations around privacy and performance. Also add a test script to verify Jaeger integration with NeMo-Guardrails using OpenTelemetry, demonstrating trace export and event-span correlation.


