### PR TITLE
Fix: Resolve Content Safety Model Resolution Issue

### DIFF
--- a/nemoguardrails/llm/prompts.py
+++ b/nemoguardrails/llm/prompts.py
@@ -134,6 +134,17 @@ def get_task_model(config: RailsConfig, task: Union[str, Task]) -> Optional[Mode
     # Fetch current task parameters like name, models to use, and the prompting mode
     task_name = str(task.value) if isinstance(task, Task) else task
 
+    # Check if the task name contains a model specification (e.g., "content_safety_check_input $model=content_safety")
+    if "$model=" in task_name:
+        # Extract the model type from the task name
+        model_type = task_name.split("$model=")[-1].strip()
+        # Look for a model with this specific type
+        if config.models:
+            _models = [model for model in config.models if model.type == model_type]
+            if _models:
+                return _models[0]
+
+    # If no model specification or no matching model found, fall back to the original logic
     if config.models:
         _models = [model for model in config.models if model.type == task_name]
         if not _models:

--- a/tests/test_llm_task_manager.py
+++ b/tests/test_llm_task_manager.py
@@ -532,3 +532,37 @@ def test_get_task_model_fallback_to_main():
     result = get_task_model(config, "some_other_task")
     assert result is not None
     assert result.type == "main"
+
+
+def test_get_task_model_with_model_specification():
+    """Test that get_task_model correctly extracts model type from task names with $model= specification."""
+    config = RailsConfig.parse_object(
+        {
+            "models": [
+                {
+                    "type": "main",
+                    "engine": "openai",
+                    "model": "gpt-3.5-turbo",
+                },
+                {
+                    "type": "content_safety",
+                    "engine": "openai",
+                    "model": "gpt-4",
+                },
+            ]
+        }
+    )
+
+    # Test with a task name that contains $model= specification
+    result = get_task_model(config, "content_safety_check_input $model=content_safety")
+    assert result is not None
+    assert result.type == "content_safety"
+    assert result.engine == "openai"
+    assert result.model == "gpt-4"
+
+    # Test fallback to main model when specified model type doesn't exist
+    result = get_task_model(config, "unknown_task $model=nonexistent")
+    assert result is not None
+    assert result.type == "main"
+    assert result.engine == "openai"
+    assert result.model == "gpt-3.5-turbo"


### PR DESCRIPTION
## 🐛 Problem Description

The content safety actions were failing with the following error:

```
WARNING: Error while execution 'content_safety_check_input' with parameters '{...}': 
Could not find prompt for task content_safety_check_input $model=content_safety and model nimchat/nvidia/llama-3_3-nemotron-super-49b-v1_5
```

## 🔍 Root Cause Analysis

The issue occurred in the `get_task_model` function in `nemoguardrails/llm/prompts.py`. When content safety actions were called with task names like `content_safety_check_input $model=content_safety`, the system was:

1. **Incorrectly using the main model** (`nvidia/llama-3_3-nemotron-super-49b-v1_5`) instead of the specified content safety model
2. **Failing to parse** the `$model=content_safety` part of the task name
3. **Defaulting to the main model** for prompt resolution, causing the lookup to fail

## 🛠️ Solution

Updated the `get_task_model` function to properly handle task names with model specifications:

- **Added parsing** for task names containing `$model=` specifications
- **Extracts model type** from task names (e.g., `content_safety` from `content_safety_check_input $model=content_safety`)
- **Prioritizes specified models** over default fallbacks

## ✅ Changes Made

1. **Enhanced Model Resolution Logic** - Added parsing for $model= specifications
2. **Comprehensive Test Coverage** - Added new test case with positive and negative scenarios
3. **Backward Compatibility** - No breaking changes to existing functionality

## 🧪 Testing

- ✅ All existing tests continue to pass
- ✅ New test case validates the fix works correctly
- ✅ Content safety actions now work as expected
- ✅ Error messages no longer appear

## 🔧 Configuration Example

This fix enables proper functioning of configurations like:

```yaml
models:
  - type: content_safety
    engine: nim
    model: nvidia/llama-3.1-nemoguard-8b-content-safety

rails:
  input:
    flows:
      - content safety check input $model=content_safety
```

## 🚀 Impact

**Before**: Content safety actions failed with confusing error messages
**After**: Content safety actions work as expected with proper model resolution

This is a non-breaking bug fix that improves the user experience for content safety workflows.