### PR TITLE
fix(models): suppress langchain_nvidia_ai_endpoints warnings

### DIFF
--- a/nemoguardrails/llm/models/langchain_initializer.py
+++ b/nemoguardrails/llm/models/langchain_initializer.py
@@ -38,6 +38,7 @@ log = logging.getLogger(__name__)
 # Suppress specific LangChain warnings
 warnings.filterwarnings("ignore", category=LangChainDeprecationWarning)
 warnings.filterwarnings("ignore", category=LangChainBetaWarning)
+warnings.filterwarnings("ignore", module="langchain_nvidia_ai_endpoints._common")
 
 
 class ModelInitializationError(Exception):


### PR DESCRIPTION
suppress langchain_nvidia_ai_endpoints warnings

```sh
irtualenvs/nemoguardrails-O6aG79rF-py3.12/lib/python3.12/site-packages/langchain_nvidia_ai_endpoints/_common.py:212: UserWarning: Found nvidia/llama-3.1-nemoguard-8b-content-safety in available_models, but type is unknown and inference may fail.
  warnings.warn(
/Users/prezakhani/Library/Caches/pypoetry/virtualenvs/nemoguardrails-O6aG79rF-py3.12/lib/python3.12/site-packages/langchain_nvidia_ai_endpoints/_common.py:212: UserWarning: Found nvidia/llama-3.1-nemoguard-8b-topic-control in available_models, but type is unknown and inference may fail.
  warnings.warn(

```