### PR TITLE
chore(types): Type-clean /actions_server (3 errors)

### DIFF
--- a/nemoguardrails/actions_server/actions_server.py
+++ b/nemoguardrails/actions_server/actions_server.py
@@ -16,7 +16,7 @@
 import logging
 from typing import Dict, Optional
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from pydantic import BaseModel, Field
 
 from nemoguardrails.actions.action_dispatcher import ActionDispatcher
@@ -34,7 +34,12 @@ app = FastAPI(
 
 
 # Create action dispatcher object to communicate with actions
-app.action_dispatcher = ActionDispatcher(load_all_actions=True)
+_action_dispatcher = ActionDispatcher(load_all_actions=True)
+
+
+def get_action_dispatcher() -> ActionDispatcher:
+    """Dependency to provide the action dispatcher instance."""
+    return _action_dispatcher
 
 
 class RequestBody(BaseModel):
@@ -58,22 +63,26 @@ class ResponseBody(BaseModel):
     summary="Execute action",
     response_model=ResponseBody,
 )
-async def run_action(body: RequestBody):
+async def run_action(
+    body: RequestBody,
+    action_dispatcher: ActionDispatcher = Depends(get_action_dispatcher),
+):
     """Execute the specified action and return the result.
 
     Args:
         body (RequestBody): The request body containing action_name and action_parameters.
+        action_dispatcher (ActionDispatcher): The action dispatcher dependency.
 
     Returns:
         dict: The response containing the execution status and result.
     """
 
-    log.info(f"Request body: {body}")
-    result, status = await app.action_dispatcher.execute_action(
+    log.info("Request body: %s", body)
+    result, status = await action_dispatcher.execute_action(
         body.action_name, body.action_parameters
     )
     resp = {"status": status, "result": result}
-    log.info(f"Response: {resp}")
+    log.info("Response: %s", resp)
     return resp
 
 
@@ -81,7 +90,9 @@ async def run_action(body: RequestBody):
     "/v1/actions/list",
     summary="List available actions",
 )
-async def get_actions_list():
+async def get_actions_list(
+    action_dispatcher: ActionDispatcher = Depends(get_action_dispatcher),
+):
     """Returns the list of available actions."""
 
-    return app.action_dispatcher.get_registered_actions()
+    return action_dispatcher.get_registered_actions()


### PR DESCRIPTION
## Description

Only a few type-cleaning steps to add the actions server as a FastAPI Dependency to inject it into endpoint methods, rather than an attribute on the Fast API server. Also some logging cleanups (%s, not f-strings)

## Test plan

### Type-checking

```bash
$ pyright nemoguardrails/actions_server
0 errors, 0 warnings, 0 informations
```

### Unit-tests
```bash
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/tgasser/projects/nemo_guardrails
configfile: pytest.ini
testpaths: tests, docs/colang-2/examples
plugins: cov-6.0.0, xdist-3.8.0, httpx-0.35.0, asyncio-0.25.3, anyio-4.8.0, profiling-1.8.1, langsmith-0.3.6
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function
collected 1440 items

tests/colang/parser/test_basic.py ...                                    [  0%]
tests/colang/parser/v2_x/test_ast.py .                                   [  0%]

.......

============================================ 1340 passed, 100 skipped in 103.86s (0:01:43) ============================================
```


### Action-server local test

**Server-side**

```bash
$ poetry run nemoguardrails actions-server
INFO:     Started server process [37991]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
INFO:     127.0.0.1:50940 - "GET /v1/actions/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:50941 - "GET /v1/actions/list HTTP/1.1" 200 OK
INFO:     127.0.0.1:50945 - "GET /v1/actions/list HTTP/1.1" 200 OK
```
 
**Client-side**

```bash
$  curl http://0.0.0.0:8001/v1/actions/list
["retrieve_relevant_chunks","create_event","wolfram alpha request","summarize_document","call_activefence_api","jailbreak_detection_heuristics","jailbreak_detection_model","protect_text","self_check_hallucination","GetAttentionPercentageAction","UpdateAttentionMaterializedViewAction","call cleanlab api","injection_detection","llama_guard_check_input","llama_guard_check_output","content_safety_check_input","content_safety_check_output","ClavataCheckAction","GetCurrentDateTimeAction","detect_sensitive_data","mask_sensitive_data","call gcpnlp api","topic_safety_check_input","validate_guardrails_ai_input","validate_guardrails_ai_output","call fiddler faithfulness","call fiddler safety on bot message","call fiddler safety on user message","pangea_ai_guard","autoalign_factcheck_output_api","autoalign_groundedness_output_api","autoalign_input_api","autoalign_output_api","alignscore_check_facts","alignscore request","self_check_facts","patronus_api_check_output","patronus_lynx_check_output_hallucination","self_check_input","self_check_output","detect_pii","mask_pii"]
```


## Related Issue(s)

Top-level PR to combine all type-fixes into a single merge-to-develop: https://github.com/NVIDIA/NeMo-Guardrails/pull/1367


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
