### PR TITLE
Fix import package declaration to new cleanlab-tlm name

### DIFF
--- a/docs/user-guides/community/cleanlab.md
+++ b/docs/user-guides/community/cleanlab.md
@@ -26,7 +26,7 @@ define bot response untrustworthy
 Install the Python client to use Cleanlab's trustworthiness score:
 
 ```
-pip install cleanlab-studio
+pip install --upgrade cleanlab-tlm
 ```
 
 You can get an API key for free by [creating a Cleanlab account](https://tlm.cleanlab.ai/) or experiment with the trustworthiness scores in the [playground](https://chat.cleanlab.ai/chat). Feel free to [email Cleanlab](mailto:suport@cleanlab.ai) with any questions.


### PR DESCRIPTION
## Description

using tlm via studio import is deprecated. updates with the correct import, see the [docs](https://help.cleanlab.ai/tlm/tutorials/tlm/).


## Checklist

- [ yes] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [n/a ] I've updated the documentation if applicable.
- [ n/a] I've added tests if applicable.
- [ @jwmueller ] @mentions of the person or team responsible for reviewing proposed changes.
