### PR TITLE
ci: enable codecov for all pull requests

### DIFF
--- a/.github/workflows/test-coverage-report.yml
+++ b/.github/workflows/test-coverage-report.yml
@@ -2,9 +2,9 @@ name: Coverage Report
 
 on:
   push:
-    branches: [develop]
+    branches: ["**"]
   pull_request:
-    branches: [develop]
+    branches: ["**"]
 
 jobs:
   test:


### PR DESCRIPTION
Remove branch restriction from pull_request trigger to allow codecov coverage reporting on PRs targeting any branch, not just develop.

