### PR TITLE
style(cache): replace pass with ellipsis in abstract methods

### DIFF
--- a/nemoguardrails/llm/cache/interface.py
+++ b/nemoguardrails/llm/cache/interface.py
@@ -44,7 +44,7 @@ class CacheInterface(ABC):
         Returns:
             The value associated with the key, or default if not found.
         """
-        pass
+        ...
 
     @abstractmethod
     def put(self, key: Any, value: Any) -> None:
@@ -58,7 +58,7 @@ class CacheInterface(ABC):
             key: The key to store.
             value: The value to associate with the key.
         """
-        pass
+        ...
 
     @abstractmethod
     def size(self) -> int:
@@ -68,7 +68,7 @@ class CacheInterface(ABC):
         Returns:
             The number of items currently stored in the cache.
         """
-        pass
+        ...
 
     @abstractmethod
     def is_empty(self) -> bool:
@@ -78,7 +78,7 @@ class CacheInterface(ABC):
         Returns:
             True if the cache contains no items, False otherwise.
         """
-        pass
+        ...
 
     @abstractmethod
     def clear(self) -> None:
@@ -87,7 +87,7 @@ class CacheInterface(ABC):
 
         After calling this method, the cache should be empty.
         """
-        pass
+        ...
 
     def contains(self, key: Any) -> bool:
         """
@@ -115,7 +115,7 @@ class CacheInterface(ABC):
         Returns:
             The maximum number of items the cache can hold.
         """
-        pass
+        ...
 
     def get_stats(self) -> dict:
         """


### PR DESCRIPTION
Updates abstract method implementations in CacheInterface to use ellipsis (...) instead of pass, following modern Python conventions for abstract method stubs.

## Part of Stack
This is PR 1/5 in the NeMoGuards caching feature stack.
- ✅ **PR 1: Cache interface cleanup** (this PR)
- ⬜ PR 2: #1456 
- ⬜ PR 3: #1457 
- ⬜ PR 4: #1458 
- ⬜ PR 5: #1459
