### PR TITLE
feat(cache): add LLM metadata caching for model and provider information

### DIFF
--- a/nemoguardrails/llm/cache/utils.py
+++ b/nemoguardrails/llm/cache/utils.py
@@ -106,7 +106,7 @@ def create_normalized_cache_key(
 
 
 def restore_llm_stats_from_cache(
-    cached_stats: LLMStatsDict, cache_read_duration: float
+    cached_stats: LLMStatsDict, cache_read_duration_s: float
 ) -> None:
     llm_stats = llm_stats_var.get()
     if llm_stats is None:
@@ -114,19 +114,19 @@ def restore_llm_stats_from_cache(
         llm_stats_var.set(llm_stats)
 
     llm_stats.inc("total_calls")
-    llm_stats.inc("total_time", cache_read_duration)
+    llm_stats.inc("total_time", cache_read_duration_s)
     llm_stats.inc("total_tokens", cached_stats.get("total_tokens", 0))
     llm_stats.inc("total_prompt_tokens", cached_stats.get("prompt_tokens", 0))
     llm_stats.inc("total_completion_tokens", cached_stats.get("completion_tokens", 0))
 
     llm_call_info = llm_call_info_var.get()
     if llm_call_info:
-        llm_call_info.duration = cache_read_duration
+        llm_call_info.duration = cache_read_duration_s
         llm_call_info.total_tokens = cached_stats.get("total_tokens", 0)
         llm_call_info.prompt_tokens = cached_stats.get("prompt_tokens", 0)
         llm_call_info.completion_tokens = cached_stats.get("completion_tokens", 0)
         llm_call_info.from_cache = True
-        llm_call_info.started_at = time() - cache_read_duration
+        llm_call_info.started_at = time() - cache_read_duration_s
         llm_call_info.finished_at = time()
 
 
@@ -167,14 +167,14 @@ def get_from_cache_and_restore_stats(
     if cached_entry is None:
         return None
 
-    cache_read_start = time()
+    cache_read_start_s = time()
     final_result = cached_entry["result"]
     cached_stats = cached_entry.get("llm_stats")
     cached_metadata = cached_entry.get("llm_metadata")
-    cache_read_duration = time() - cache_read_start
+    cache_read_duration_s = time() - cache_read_start_s
 
     if cached_stats:
-        restore_llm_stats_from_cache(cached_stats, cache_read_duration)
+        restore_llm_stats_from_cache(cached_stats, cache_read_duration_s)
 
     if cached_metadata:
         restore_llm_metadata_from_cache(cached_metadata)

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -35,6 +35,12 @@ from nemoguardrails.logging.stats import LLMStats
 
 
 class TestCacheUtils:
+    @pytest.fixture(autouse=True)
+    def isolated_llm_call_info_var(self):
+        llm_call_info_var.set(None)
+        yield
+        llm_call_info_var.set(None)
+
     def test_create_normalized_cache_key_returns_sha256_hash(self):
         key = create_normalized_cache_key("Hello world")
         assert len(key) == 64
@@ -148,10 +154,9 @@ class TestCacheUtils:
             create_normalized_cache_key([123, 456])  # type: ignore
 
     def test_extract_llm_stats_for_cache_with_llm_call_info(self):
-        llm_call_info = LLMCallInfo(task="test_task")
-        llm_call_info.total_tokens = 100
-        llm_call_info.prompt_tokens = 50
-        llm_call_info.completion_tokens = 50
+        llm_call_info = LLMCallInfo(
+            task="test_task", total_tokens=100, prompt_tokens=50, completion_tokens=50
+        )
         llm_call_info_var.set(llm_call_info)
 
         stats = extract_llm_stats_for_cache()
@@ -171,10 +176,12 @@ class TestCacheUtils:
         assert stats is None
 
     def test_extract_llm_stats_for_cache_with_none_values(self):
-        llm_call_info = LLMCallInfo(task="test_task")
-        llm_call_info.total_tokens = None
-        llm_call_info.prompt_tokens = None
-        llm_call_info.completion_tokens = None
+        llm_call_info = LLMCallInfo(
+            task="test_task",
+            total_tokens=None,
+            prompt_tokens=None,
+            completion_tokens=None,
+        )
         llm_call_info_var.set(llm_call_info)
 
         stats = extract_llm_stats_for_cache()
@@ -196,7 +203,7 @@ class TestCacheUtils:
             "completion_tokens": 50,
         }
 
-        restore_llm_stats_from_cache(cached_stats, cache_read_duration=0.01)
+        restore_llm_stats_from_cache(cached_stats, cache_read_duration_s=0.01)
 
         llm_stats = llm_stats_var.get()
         assert llm_stats is not None
@@ -221,7 +228,7 @@ class TestCacheUtils:
             "completion_tokens": 50,
         }
 
-        restore_llm_stats_from_cache(cached_stats, cache_read_duration=0.5)
+        restore_llm_stats_from_cache(cached_stats, cache_read_duration_s=0.5)
 
         llm_stats = llm_stats_var.get()
         assert llm_stats is not None
@@ -242,7 +249,7 @@ class TestCacheUtils:
             "completion_tokens": 50,
         }
 
-        restore_llm_stats_from_cache(cached_stats, cache_read_duration=0.02)
+        restore_llm_stats_from_cache(cached_stats, cache_read_duration_s=0.02)
 
         updated_info = llm_call_info_var.get()
         assert updated_info is not None
@@ -387,9 +394,9 @@ class TestCacheUtils:
         llm_stats_var.set(None)
 
     def test_extract_llm_metadata_for_cache_with_model_info(self):
-        llm_call_info = LLMCallInfo(task="test_task")
-        llm_call_info.llm_model_name = "gpt-4"
-        llm_call_info.llm_provider_name = "openai"
+        llm_call_info = LLMCallInfo(
+            task="test_task", llm_model_name="gpt-4", llm_provider_name="openai"
+        )
         llm_call_info_var.set(llm_call_info)
 
         metadata = extract_llm_metadata_for_cache()


### PR DESCRIPTION
Extends the cache system to store and restore LLM metadata (model name and provider name) alongside cache entries. This allows cached results to maintain provenance information about which model and provider generated the original response.

## Changes
- Added `LLMMetadataDict` and `LLMCacheData` TypedDict definitions for type safety
- Extended `CacheEntry` to include optional `llm_metadata` field
- Implemented `extract_llm_metadata_for_cache()` to capture model and provider info from context
- Implemented `restore_llm_metadata_from_cache()` to restore metadata when retrieving cached results
- Updated `get_from_cache_and_restore_stats()` to handle metadata extraction and restoration
- Added comprehensive test coverage for metadata caching functionality

## Dependencies
- **Depends on:** PR #1455 

## Part of Stack
This is PR 2/5 in the NeMoGuards caching feature stack.
- ✅ PR 1: #1455
- ✅ **PR 2: LLM metadata caching** (this PR)
- ⬜ PR 3: #1457 
- ⬜ PR 4: #1458 
- ⬜ PR 5: #1459 
