### PR TITLE
test: skip FastEmbed tests when not in live mode

### DIFF
--- a/tests/test_embeddings_fastembed.py
+++ b/tests/test_embeddings_fastembed.py
@@ -13,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 
 from nemoguardrails.embeddings.providers.fastembed import FastEmbedEmbeddingModel
 
+LIVE_TEST_MODE = os.environ.get("LIVE_TEST")
 
+
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
 def test_sync_embeddings():
     model = FastEmbedEmbeddingModel("all-MiniLM-L6-v2")
 
@@ -26,6 +31,7 @@ def test_sync_embeddings():
     assert len(result[0]) == 384
 
 
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
 def test_additional_params_with_fastembed():
     model = FastEmbedEmbeddingModel("all-MiniLM-L6-v2", max_length=512, lazy_load=True)
     result = model.encode(["test"])
@@ -33,6 +39,7 @@ def test_additional_params_with_fastembed():
     assert len(result[0]) == 384
 
 
+@pytest.mark.skipif(not LIVE_TEST_MODE, reason="Not in live mode.")
 @pytest.mark.asyncio
 async def test_async_embeddings():
     model = FastEmbedEmbeddingModel("all-MiniLM-L6-v2")


### PR DESCRIPTION
Skip FastEmbed embedding tests by default to prevent CI failures from external HuggingFace infrastructure issues. 

CI tests were intermittently failing due to HuggingFace's download service (CAS server) returning 500 errors when downloading the `all-MiniLM-L6-v2` model:
`RuntimeError: Data processing error: CAS service error : Reqwest Error: HTTP status server error (500 Internal Server Error)`

 **Failed CI run:** https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/18647268635/job/53157153037
