### PR TITLE
chore(library): remove unused vllm requirements.txt files

### DIFF
--- a/nemoguardrails/library/llama_guard/requirements.txt
+++ b/nemoguardrails/library/llama_guard/requirements.txt
@@ -1,2 +1,0 @@
-# The minimal set of requirements for the Llama Guard server to run.
-vllm==0.10.1.1

--- a/nemoguardrails/library/patronusai/requirements.txt
+++ b/nemoguardrails/library/patronusai/requirements.txt
@@ -1,2 +1,0 @@
-# The minimal set of requirements to run Patronus Lynx on vLLM.
-vllm==0.10.1.1


### PR DESCRIPTION
## Summary
Removes unused requirements.txt files from patronusai and llama_guard library directories that pinned vllm==0.10.1.1 (which has known security vulnerabilities).

we won't get any of these in future:

https://github.com/NVIDIA-NeMo/Guardrails/security/dependabot/130
https://github.com/NVIDIA-NeMo/Guardrails/security/dependabot/129
https://github.com/NVIDIA-NeMo/Guardrails/security/dependabot/125
https://github.com/NVIDIA-NeMo/Guardrails/security/dependabot/124

## Context
- These requirements.txt files were not referenced or used by any code in the codebase
- The Python code in both libraries does not import vllm
- vllm is only needed for users who choose to self-host the models, which is already documented in the deployment guides
- Removing these files eliminates the pinned vulnerable vllm version from the repository
