### PR TITLE
docs: update LLM reasoning traces config guidance

### DIFF
--- a/docs/user-guides/configuration-guide/llm-configuration.md
+++ b/docs/user-guides/configuration-guide/llm-configuration.md
@@ -59,85 +59,127 @@ For more details about the command and its usage, see the [CLI documentation](..
 
 ### Using LLMs with Reasoning Traces
 
-```{warning}
-**Breaking Change in v0.18.0**: The `reasoning_config` field and its options (`remove_reasoning_traces`, `start_token`, `end_token`) have been removed. The `rails.output.apply_to_reasoning_traces` field has also been removed. Use output rails to guardrail reasoning traces instead.
+```{deprecated} 0.18.0
+The `reasoning_config` field and its options `remove_reasoning_traces`, `start_token`, and `end_token` are deprecated. The `rails.output.apply_to_reasoning_traces` field has also been deprecated. Instead, use output rails to guardrail reasoning traces, as introduced in this section.
 ```
 
-Reasoning-capable LLMs such as [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) and [NVIDIA Llama 3.1 Nemotron Ultra 253B V1](https://build.nvidia.com/nvidia/llama-3_1-nemotron-ultra-253b-v1) include reasoning traces in their responses, typically wrapped in tokens like `<think>` and `</think>`. NeMo Guardrails automatically extracts these traces and makes them available throughout your guardrails configuration via the `$bot_thinking` variable in Colang flows and `bot_thinking` in Python contexts.
+Reasoning-capable LLMs such as [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) and [NVIDIA Llama 3.1 Nemotron Ultra 253B V1](https://build.nvidia.com/nvidia/llama-3_1-nemotron-ultra-253b-v1) include reasoning traces in their responses, typically wrapped in tokens such as `<think>` and `</think>`.
+
+The NeMo Guardrails toolkit automatically extracts these traces and makes them available to set up in your guardrails configuration through the following variables:
+
+- In Colang flows, use the `$bot_thinking` variable.
+- In Python contexts, use the `bot_thinking` variable.
 
 #### Guardrailing Reasoning Traces with Output Rails
 
-The primary approach is to use output rails to inspect and control reasoning traces. This allows you to:
+Use output rails to inspect and control reasoning traces. This allows you to:
 
-- Block responses based on problematic reasoning patterns
-- Enhance moderation decisions with reasoning context
-- Monitor and filter sensitive information in reasoning
+- Block responses based on problematic reasoning patterns.
+- Enhance moderation decisions with reasoning context.
+- Monitor and filter sensitive information in reasoning.
 
-Here's a minimal example:
+##### Prepare Configuration Files
 
-```yaml
-models:
-  - type: main
-    engine: nim
-    model: nvidia/llama-3.1-nemotron-ultra-253b-v1
-  - type: self_check_output
-    model: <your_moderation_model>
-    engine: <your_engine>
+The following configuration files show a minimal configuration for guardrailing reasoning traces with output rails.
 
-rails:
-  output:
-    flows:
-      - self check output
-```
+1. Configure output rails in `config.yml`:
 
-**prompts.yml**:
+    ```yaml
+    models:
+      - type: main
+        engine: nim
+        model: nvidia/llama-3.1-nemotron-ultra-253b-v1
+      - type: self_check_output
+        model: <your_moderation_model>
+        engine: <your_engine>
 
-```yaml
-prompts:
-  - task: self_check_output
-    content: |
-      Your task is to check if the bot message complies with company policy.
+    rails:
+      output:
+        flows:
+          - self check output
+    ```
 
-      Bot message: "{{ bot_response }}"
+1. Configure the prompt to access the reasoning traces in `prompts.yml`:
 
-      {% if bot_thinking %}
-      Bot reasoning: "{{ bot_thinking }}"
-      {% endif %}
+    ```yaml
+    prompts:
+      - task: self_check_output
+        content: |
+          Your task is to check if the bot message complies with company policy.
 
-      Should this be blocked (Yes or No)?
-      Answer:
-```
+          Bot message: "{{ bot_response }}"
 
-For more detailed examples of guardrailing reasoning traces, see [Guardrailing Bot Reasoning Content](../../advanced/bot-thinking-guardrails.md).
+          {% if bot_thinking %}
+          Bot reasoning: "{{ bot_thinking }}"
+          {% endif %}
+
+          Should this be blocked (Yes or No)?
+          Answer:
+    ```
+
+For more detailed examples of guardrailing reasoning traces, refer to [Guardrailing Bot Reasoning Content](../../advanced/bot-thinking-guardrails.md).
 
 #### Accessing Reasoning Traces in API Responses
 
-##### With GenerationOptions (Structured Access)
+There are two ways to access reasoning traces in API responses: with generation options and without generation options.
 
-When you pass `GenerationOptions` to the API, the function returns a `GenerationResponse` object with structured fields, including `reasoning_content` for accessing reasoning traces separately from the main response:
+Read the option **With GenerationOptions** when you:
+
+- Need structured access to reasoning and response separately.
+- Are building a new application.
+- Need access to other structured fields such as state, output_data, or llm_metadata.
+
+Read the option **Without GenerationOptions** when you:
+
+- Need backward compatibility with existing code.
+- Want the raw response with inline reasoning tags.
+- Are integrating with systems that expect tagged strings.
+
+##### With GenerationOptions for Structured Access
+
+When you pass `GenerationOptions` to the API, the function returns a `GenerationResponse` object with structured fields. This approach provides clean separation between the reasoning traces and the final response content, making it easier to process each component independently.
+
+The `reasoning_content` field contains the extracted reasoning traces, while `response` contains the main LLM response. This structured access pattern is recommended for new applications as it provides type safety and clear access to all response metadata.
+
+The following example demonstrates how to use `GenerationOptions` in an guardrails async generation call `rails.generate_async` to access reasoning traces.
 
 ```python
 from nemoguardrails import RailsConfig, LLMRails
 from nemoguardrails.rails.llm.options import GenerationOptions
 
+# Load the guardrails configuration
 config = RailsConfig.from_path("./config")
 rails = LLMRails(config)
 
+# Create a GenerationOptions object to enable structured responses
 options = GenerationOptions()
+
+# Make an async call with GenerationOptions
 result = await rails.generate_async(
     messages=[{"role": "user", "content": "What is 2+2?"}],
     options=options
 )
 
+# Access reasoning traces separately from the response
 if result.reasoning_content:
     print("Reasoning:", result.reasoning_content)
 
+# Access the main response content
 print("Response:", result.response[0]["content"])
 ```
 
-##### Without GenerationOptions (Tagged String)
+The following example output shows the reasoning traces and the main response content from the guardrailed generation result.
 
-When calling without `GenerationOptions` (e.g., via dict/string response), reasoning is wrapped in `<think>` tags:
+```
+Reasoning: Let me calculate: 2 plus 2 equals 4.
+Response: The answer is 4.
+```
+
+##### Without GenerationOptions for Tagged String
+
+When calling without `GenerationOptions`, such as by using a dict or string response, reasoning is wrapped in `<think>` tags.
+
+The following example demonstrates how to access reasoning traces without using `GenerationOptions`.
 
 ```python
 response = rails.generate(
@@ -147,24 +189,12 @@ response = rails.generate(
 print(response["content"])
 ```
 
-Output:
+The response is wrapped in `<think>` tags as shown in the following example output.
 
 ```
 <think>Let me calculate: 2 plus 2 equals 4.</think>
 The answer is 4.
 ```
-
-**Which pattern should you use?**
-
-Use **Pattern 1 (With GenerationOptions)** when:
-- You need structured access to reasoning and response separately
-- You're building a new application
-- You need access to other structured fields (state, output_data, llm_metadata, etc.)
-
-Use **Pattern 2 (Without GenerationOptions)** when:
-- You need backward compatibility with existing code
-- You want the raw response with inline reasoning tags
-- You're integrating with systems that expect tagged strings
 
 ### NIM for LLMs
 

--- a/docs/user-guides/configuration-guide/llm-configuration.md
+++ b/docs/user-guides/configuration-guide/llm-configuration.md
@@ -59,165 +59,97 @@ For more details about the command and its usage, see the [CLI documentation](..
 
 ### Using LLMs with Reasoning Traces
 
-By default, reasoning models, such as [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) and [NVIDIA Llama 3.1 Nemotron Ultra 253B V1](https://build.nvidia.com/nvidia/llama-3_1-nemotron-ultra-253b-v1), can include the reasoning traces in the model response.
-DeepSeek and the Nemotron family of models use `<think>` and `</think>` as tokens to identify the traces.
+```{warning}
+**Breaking Change in v0.18.0**: The `reasoning_config` field and its options (`remove_reasoning_traces`, `start_token`, `end_token`) have been removed. The `rails.output.apply_to_reasoning_traces` field has also been removed. Use output rails to guardrail reasoning traces instead.
+```
 
-The reasoning traces and the tokens can interfere with NeMo Guardrails and result in falsely triggering output guardrails for safe responses.
-To use these reasoning models, you can remove the traces and tokens from the model response with a configuration like the following example.
+Reasoning-capable LLMs such as [DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1-678e1e131c0169c0bc89728d) and [NVIDIA Llama 3.1 Nemotron Ultra 253B V1](https://build.nvidia.com/nvidia/llama-3_1-nemotron-ultra-253b-v1) include reasoning traces in their responses, typically wrapped in tokens like `<think>` and `</think>`. NeMo Guardrails automatically extracts these traces and makes them available throughout your guardrails configuration via the `$bot_thinking` variable in Colang flows and `bot_thinking` in Python contexts.
 
-```{code-block} yaml
-:emphasize-lines: 5-8, 13-
+#### Guardrailing Reasoning Traces with Output Rails
 
+The primary approach is to use output rails to inspect and control reasoning traces. This allows you to:
+
+- Block responses based on problematic reasoning patterns
+- Enhance moderation decisions with reasoning context
+- Monitor and filter sensitive information in reasoning
+
+Here's a minimal example:
+
+```yaml
 models:
-  - type: main
-    engine: deepseek
-    model: deepseek-reasoner
-    reasoning_config:
-      remove_reasoning_traces: True
-      start_token: "<think>"
-      end_token: "</think>"
-
   - type: main
     engine: nim
     model: nvidia/llama-3.1-nemotron-ultra-253b-v1
-    reasoning_config:
-      remove_reasoning_traces: True
+  - type: self_check_output
+    model: <your_moderation_model>
+    engine: <your_engine>
 
 rails:
   output:
-    apply_to_reasoning_traces: False
+    flows:
+      - self check output
 ```
 
-```{list-table}
-:header-rows: 1
+**prompts.yml**:
 
-* - Field
-  - Description
-  - Default Value
+```yaml
+prompts:
+  - task: self_check_output
+    content: |
+      Your task is to check if the bot message complies with company policy.
 
-* - `reasoning_config.remove_reasoning_traces`
-  - When set to `True`, reasoning traces are omitted from internal tasks.
-  - `True`
+      Bot message: "{{ bot_response }}"
 
-* - `reasoning_config.start_token`
-  - Specifies the start token for the reasoning trace.
-  - `<think>`
+      {% if bot_thinking %}
+      Bot reasoning: "{{ bot_thinking }}"
+      {% endif %}
 
-* - `reasoning_config.end_token`
-  - Specifies the end token for the reasoning trace.
-  - `</think>`
-
-* - `rails.output.apply_to_reasoning_traces`
-  - When set to `True`, output rails are always applied to the reasoning traces and the model response.
-    The value of `remove_reasoning_traces` is ignored when this field is set to `True`.
-
-    By default, output rails are applied to the text of the model response only.
-  - `False`
+      Should this be blocked (Yes or No)?
+      Answer:
 ```
 
-The `reasoning_config` field for a model specifies the required configuration for a reasoning model that returns reasoning traces.
-By removing the traces, the guardrails runtime processes only the actual responses from the LLM.
+For more detailed examples of guardrailing reasoning traces, see [Guardrailing Bot Reasoning Content](../../advanced/bot-thinking-guardrails.md).
 
-The following table summarizes the interaction between the `remove_reasoning_traces` and `apply_to_reasoning_traces` values:
+#### Accessing Reasoning Traces in API Responses
 
-```{list-table}
-:header-rows: 1
+##### With GenerationOptions (Structured Access)
 
-* - `remove_reasoning_traces`
-  - `output.apply_to_reasoning_traces`
-  - Outcome
+When using the Python API with `GenerationOptions`, reasoning is available in the separate `reasoning_content` field:
 
-* - Any
-  - True
-  - Reasoning traces are not removed and output rails are applied to the reasoning traces and the model response.
-    The value of `remove_reasoning_traces` is ignored.
-
-* - False
-  - False
-  - Reasoning traces are not removed from internal tasks where they do not impact Guardrails functionality.
-    Output rails are applied to the reasoning traces and the model response.
-
-* - True
-  - False
-  - Reasoning traces are removed from internal tasks where they could interfere with Guardrails.
-    Output rails are applied to the model response only.
-```
-
-Even when `remove_reasoning_traces` is `True`, end users can still receive the thinking traces from the Nemotron models by requesting the detailed thinking, as shown in the following example:
-
-```{code-block} bash
-from nemoguardrails import LLMRails, RailsConfig
+```python
+from nemoguardrails import RailsConfig, LLMRails
 
 config = RailsConfig.from_path("./config")
-rails = LLMRails(config, verbose=True)
-messages = [
-  { "role": "system", "content": "detailed thinking on" },
-  { "role": "user", "content": "Tell me about Cape Hatteras National Seashore in 50 words or less." }
-]
-rails.generate(messages=messages)
+rails = LLMRails(config)
+
+result = rails.generate_async(
+    messages=[{"role": "user", "content": "What is 2+2?"}]
+)
+
+if result.reasoning_content:
+    print("Reasoning:", result.reasoning_content)
+
+print("Response:", result.response[0]["content"])
 ```
 
-The referenced `./.config` directory uses the following sample file content.
+##### Without GenerationOptions (Tagged String)
 
-When you develop your own prompts for LLM-as-a-judge checks, such as an input self-check, ensure that the prompt instructs the LLM to respond with `yes` or `no`.
-Refer to the following examples:
+When calling without `GenerationOptions` (e.g., via dict/string response), reasoning is wrapped in `<think>` tags:
 
-- Sample `config/config.yml`:
+```python
+response = rails.generate(
+    messages=[{"role": "user", "content": "What is 2+2?"}]
+)
 
-  ```yaml
-  models:
-    - type: main
-      engine: nim
-      model: nvidia/llama-3.1-nemotron-ultra-253b-v1
-      reasoning_config:
-        remove_reasoning_traces: True
+print(response["content"])
+```
 
-  rails:
-    input:
-      flows:
-        - self check input
-    output:
-      flows:
-        - self check output
-  ```
+Output:
 
-- Sample `config/prompts.yml`:
-
-  ```yaml
-  prompts:
-    - task: self_check_input
-      messages:
-        - type: system
-          content: |
-            You are an AI assistant tasked with evaluating user instructions.
-            Your role is to determine if a given instruction would make a language model break moderation policies, deviate from good aligned responses, or provide answers that a language model should ideally not.
-
-            Analyze the instruction carefully. First, internally consider potential ways the instruction could be interpreted and whether any interpretation could lead to a problematic response. Then, conclude with a simple "yes" or "no" answer.
-            Respond with only "yes" or "no".
-        - type: user
-          content: |
-            Instruction to evaluate:
-            "{{ user_input }}"
-
-            Would this instruction lead to a problematic response (yes/no)?
-
-    - task: self_check_output
-      messages:
-        - type: system
-          content: |
-            Is this output illegal, unethical, or harmful to any person?
-            Respond with only "yes" or "no".
-        - type: bot
-          content: |
-            Output to evaluate:
-            "{{ bot_response }}"
-  ```
-
-Using LLMs with reasoning traces have the following limitations:
-
-- You must use message-based prompts only.
-  Refer to the preceding example.
-- Dialog rails are not supported.
+```
+<think>Let me calculate: 2 plus 2 equals 4.</think>
+The answer is 4.
+```
 
 ### NIM for LLMs
 

--- a/docs/user-guides/configuration-guide/llm-configuration.md
+++ b/docs/user-guides/configuration-guide/llm-configuration.md
@@ -114,16 +114,19 @@ For more detailed examples of guardrailing reasoning traces, see [Guardrailing B
 
 ##### With GenerationOptions (Structured Access)
 
-When using the Python API with `GenerationOptions`, reasoning is available in the separate `reasoning_content` field:
+When you pass `GenerationOptions` to the API, the function returns a `GenerationResponse` object with structured fields, including `reasoning_content` for accessing reasoning traces separately from the main response:
 
 ```python
 from nemoguardrails import RailsConfig, LLMRails
+from nemoguardrails.rails.llm.options import GenerationOptions
 
 config = RailsConfig.from_path("./config")
 rails = LLMRails(config)
 
-result = rails.generate_async(
-    messages=[{"role": "user", "content": "What is 2+2?"}]
+options = GenerationOptions()
+result = await rails.generate_async(
+    messages=[{"role": "user", "content": "What is 2+2?"}],
+    options=options
 )
 
 if result.reasoning_content:
@@ -150,6 +153,18 @@ Output:
 <think>Let me calculate: 2 plus 2 equals 4.</think>
 The answer is 4.
 ```
+
+**Which pattern should you use?**
+
+Use **Pattern 1 (With GenerationOptions)** when:
+- You need structured access to reasoning and response separately
+- You're building a new application
+- You need access to other structured fields (state, output_data, llm_metadata, etc.)
+
+Use **Pattern 2 (Without GenerationOptions)** when:
+- You need backward compatibility with existing code
+- You want the raw response with inline reasoning tags
+- You're integrating with systems that expect tagged strings
 
 ### NIM for LLMs
 


### PR DESCRIPTION
Refactor documentation for reasoning traces in LLM configuration guide:
- Remove deprecated `reasoning_config` and `apply_to_reasoning_traces` fields.
- Add warning about breaking changes in v0.18.0.
- Explain new approach using output rails for reasoning traces.
- Provide updated YAML and Python usage examples.
- Clarify how to access reasoning traces in API responses.
- Remove outdated configuration and prompt samples.

