### PR TITLE
fix(runtime): set stop flag for exception-based rails in parallel mode

### DIFF
--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -313,7 +313,8 @@ class RuntimeV1_0(Runtime):
             result = await func(*args, **kwargs)
 
             has_stop = any(
-                event["type"] == "BotIntent" and event["intent"] == "stop"
+                (event["type"] == "BotIntent" and event["intent"] == "stop")
+                or event["type"].endswith("Exception")
                 for event in result
             )
 
@@ -377,7 +378,8 @@ class RuntimeV1_0(Runtime):
 
                     # Check if this rail requested to stop
                     has_stop = any(
-                        event["type"] == "BotIntent" and event["intent"] == "stop"
+                        (event["type"] == "BotIntent" and event["intent"] == "stop")
+                        or event["type"].endswith("Exception")
                         for event in result
                     )
 
@@ -402,6 +404,7 @@ class RuntimeV1_0(Runtime):
                                     if v == pending_task:
                                         del unique_flow_ids[k]
                                         break
+                        # Remove the stopped flow from unique_flow_ids so it's not in finished_task_results
                         del unique_flow_ids[flow_id]
                         break
                     else:
@@ -448,13 +451,13 @@ class RuntimeV1_0(Runtime):
                 for plog in logs:
                     # Filter out "Listen" and "start_flow" events from task processing log
                     if plog["type"] == "event" and (
-                        plog["data"]["type"] == "Listen"
-                        or plog["data"]["type"] == "start_flow"
+                        plog["data"]["type"] == "start_flow"
                     ):
                         continue
                     target_log.append(plog)
 
-            filter_and_append(stopped_task_processing_logs, processing_log)
+            # Only append finished rails logs. Stopped rail logs should not be appended
+            # again since they're already in the processing log from when they started
             filter_and_append(finished_task_processing_logs, processing_log)
 
         # We pack all events into a single event to add it to the event history.
@@ -463,6 +466,7 @@ class RuntimeV1_0(Runtime):
             data={"events": finished_task_results},
         )
 
+        # Return stopped_task_results separately so the caller knows to stop processing
         return ActionResult(
             events=[history_events] + stopped_task_results,
             context_updates=context_updates,

--- a/nemoguardrails/colang/v1_0/runtime/runtime.py
+++ b/nemoguardrails/colang/v1_0/runtime/runtime.py
@@ -449,7 +449,6 @@ class RuntimeV1_0(Runtime):
 
             def filter_and_append(logs, target_log):
                 for plog in logs:
-                    # Filter out "Listen" and "start_flow" events from task processing log
                     if plog["type"] == "event" and (
                         plog["data"]["type"] == "start_flow"
                     ):

--- a/nemoguardrails/logging/processing_log.py
+++ b/nemoguardrails/logging/processing_log.py
@@ -191,6 +191,15 @@ def compute_generation_log(processing_log: List[dict]) -> GenerationLog:
             elif event_type == "OutputRailsFinished":
                 output_rails_finished_at = event["timestamp"]
 
+            elif event_type.endswith("Exception"):
+                if activated_rail is not None and activated_rail.type in [
+                    "input",
+                    "output",
+                ]:
+                    activated_rail.stop = True
+                    if "stop" not in activated_rail.decisions:
+                        activated_rail.decisions.append("stop")
+
         elif event["type"] == "llm_call_info":
             if executed_action is not None:
                 executed_action.llm_calls.append(event["data"])
@@ -210,7 +219,8 @@ def compute_generation_log(processing_log: List[dict]) -> GenerationLog:
 
         if activated_rail.type in ["input", "output"]:
             activated_rail.stop = True
-            activated_rail.decisions.append("stop")
+            if "stop" not in activated_rail.decisions:
+                activated_rail.decisions.append("stop")
 
     # If we have input rails, we also record the general stats
     if input_rails_started_at:

--- a/tests/test_configs/parallel_rails_with_exceptions/actions.py
+++ b/tests/test_configs/parallel_rails_with_exceptions/actions.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemoguardrails.actions import action
+
+
+@action(is_system_action=True)
+async def check_safety_action(context: dict):
+    user_message = context.get("user_message", "")
+
+    unsafe_terms = ["unsafe", "dangerous", "harmful", "kill", "violence"]
+    is_safe = not any(term in user_message.lower() for term in unsafe_terms)
+
+    return is_safe
+
+
+@action(is_system_action=True)
+async def check_topic_action(context: dict):
+    user_message = context.get("user_message", "")
+
+    off_topic_terms = ["offtopic", "irrelevant", "unrelated", "stupid", "idiot"]
+    is_on_topic = not any(term in user_message.lower() for term in off_topic_terms)
+
+    return is_on_topic
+
+
+@action(is_system_action=True)
+async def check_with_context_update(context: dict):
+    user_message = context.get("user_message", "")
+
+    violation_count = context.get("violation_count", 0)
+    context["violation_count"] = violation_count + 1
+
+    blocked_terms = ["blocked", "forbidden"]
+    is_allowed = not any(term in user_message.lower() for term in blocked_terms)
+
+    return is_allowed
+
+
+@action(is_system_action=True)
+async def check_output_safety_action(context: dict):
+    bot_message = context.get("bot_message", "")
+
+    unsafe_terms = ["harmful", "dangerous", "unsafe", "violence"]
+    is_safe = not any(term in bot_message.lower() for term in unsafe_terms)
+
+    return is_safe
+
+
+@action(is_system_action=True)
+async def check_output_length_action(context: dict):
+    bot_message = context.get("bot_message", "")
+
+    max_length = 500
+    is_valid = len(bot_message) <= max_length
+
+    return is_valid

--- a/tests/test_configs/parallel_rails_with_exceptions/config.yml
+++ b/tests/test_configs/parallel_rails_with_exceptions/config.yml
@@ -1,0 +1,19 @@
+models:
+  - type: main
+    engine: openai
+    model: gpt-3.5-turbo-instruct
+
+rails:
+  input:
+    flows:
+      - check safety with exception
+      - check topic with exception
+    parallel: True
+
+  output:
+    flows:
+      - check output safety with exception
+      - check output length with exception
+    parallel: True
+
+enable_rails_exceptions: True

--- a/tests/test_configs/parallel_rails_with_exceptions/rails.co
+++ b/tests/test_configs/parallel_rails_with_exceptions/rails.co
@@ -1,0 +1,34 @@
+define flow check safety with exception
+  $is_safe = execute check_safety_action
+
+  if not $is_safe
+    create event SafetyCheckException(message="Input blocked by safety check")
+    stop
+
+define flow check topic with exception
+  $is_on_topic = execute check_topic_action
+
+  if not $is_on_topic
+    create event TopicCheckException(message="Input blocked by topic check")
+    stop
+
+define flow check with context update
+  $is_allowed = execute check_with_context_update
+
+  if not $is_allowed
+    create event ContextUpdateException(message="Input blocked with context update")
+    stop
+
+define flow check output safety with exception
+  $is_safe = execute check_output_safety_action
+
+  if not $is_safe
+    create event OutputSafetyException(message="Output blocked by safety check")
+    stop
+
+define flow check output length with exception
+  $is_valid_length = execute check_output_length_action
+
+  if not $is_valid_length
+    create event OutputLengthException(message="Output blocked due to length")
+    stop

--- a/tests/test_parallel_rails_exceptions.py
+++ b/tests/test_parallel_rails_exceptions.py
@@ -181,10 +181,15 @@ async def test_parallel_rails_exception_consistency_with_sequential():
     assert len(parallel_stopped) > 0, "Parallel mode should have stopped rails"
     assert len(sequential_stopped) > 0, "Sequential mode should have stopped rails"
 
+    assert len(parallel_stopped) == len(sequential_stopped), (
+        f"Parallel and sequential modes should stop the same number of rails. "
+        f"Parallel: {len(parallel_stopped)}, Sequential: {len(sequential_stopped)}"
+    )
+
     parallel_stopped_names = {r.name for r in parallel_stopped}
     sequential_stopped_names = {r.name for r in sequential_stopped}
 
-    assert len(parallel_stopped_names.intersection(sequential_stopped_names)) > 0, (
+    assert parallel_stopped_names == sequential_stopped_names, (
         f"Parallel and sequential modes should stop the same rails. "
         f"Parallel stopped: {parallel_stopped_names}, Sequential stopped: {sequential_stopped_names}"
     )
@@ -213,6 +218,16 @@ async def test_parallel_rails_exception_with_passing_rails():
 
     assert len(stopped_rails) > 0, "Should have at least one stopped rail"
     assert len(passed_rails) > 0, "Should have at least one passed rail"
+
+    safety_rail = next(
+        (r for r in result.log.activated_rails if "safety" in r.name.lower()), None
+    )
+    assert safety_rail is not None, "Safety rail should have executed"
+    assert safety_rail.stop, "Safety rail should have stopped"
+    assert any(
+        "check_safety_action" in action.action_name
+        for action in safety_rail.executed_actions
+    ), "check_safety_action should have fired"
 
     # stopped rails should have "stop" in decisions
     for rail in stopped_rails:
@@ -252,6 +267,12 @@ async def test_parallel_rails_multiple_simultaneous_violations():
     assert (
         len(stopped_rails) > 0
     ), "Expected at least one stopped rail when multiple violations occur"
+
+    stopped_rail_names = {r.name for r in stopped_rails}
+    assert (
+        "check safety with exception" in stopped_rail_names
+        or "check topic with exception" in stopped_rail_names
+    ), f"Expected safety or topic rail to stop, got: {stopped_rail_names}"
 
     for rail in stopped_rails:
         assert rail.stop is True, f"Stopped rail '{rail.name}' should have stop=True"
@@ -295,6 +316,16 @@ async def test_parallel_output_rails_exception_stop_flag():
     assert (
         len(stopped_output_rails) > 0
     ), "Expected at least one stopped output rail when output is blocked"
+
+    output_safety_rail = next(
+        (r for r in output_rails if "output safety" in r.name.lower()), None
+    )
+    assert output_safety_rail is not None, "Output safety rail should have executed"
+    assert output_safety_rail.stop, "Output safety rail should have stopped"
+    assert any(
+        "check_output_safety_action" in action.action_name
+        for action in output_safety_rail.executed_actions
+    ), "check_output_safety_action should have fired"
 
     for rail in stopped_output_rails:
         assert (

--- a/tests/test_parallel_rails_exceptions.py
+++ b/tests/test_parallel_rails_exceptions.py
@@ -150,7 +150,6 @@ async def test_parallel_rails_exception_consistency_with_sequential():
     config_parallel = RailsConfig.from_path(
         os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
     )
-    config_parallel.rails.input.parallel = True
 
     chat_parallel = TestChat(
         config_parallel,
@@ -165,6 +164,7 @@ async def test_parallel_rails_exception_consistency_with_sequential():
         os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
     )
     config_sequential.rails.input.parallel = False
+    config_sequential.rails.output.parallel = False
 
     chat_sequential = TestChat(
         config_sequential,

--- a/tests/test_parallel_rails_exceptions.py
+++ b/tests/test_parallel_rails_exceptions.py
@@ -1,0 +1,432 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+CONFIGS_FOLDER = os.path.join(os.path.dirname(__file__), "test_configs")
+
+OPTIONS = {
+    "log": {
+        "activated_rails": True,
+    }
+}
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_exception_stop_flag():
+    """Test that stop flag is set when a rail raises an exception in parallel mode."""
+
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "Hi there!",
+        ],
+    )
+
+    chat >> "This message contains an unsafe term"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [rail for rail in result.log.activated_rails if rail.stop]
+
+    assert len(stopped_rails) >= 1, (
+        f"Expected at least one stopped rail, but found {len(stopped_rails)}. "
+        f"This indicates the stop flag is not being set for exception-based rails."
+    )
+
+    for rail in stopped_rails:
+        assert "stop" in rail.decisions, (
+            f"Stopped rail '{rail.name}' has stop=True but 'stop' not in decisions: {rail.decisions}. "
+            f"This indicates inconsistency between stop flag and decisions list."
+        )
+
+    has_exception = any(
+        msg.get("role") == "exception"
+        for msg in result.response
+        if isinstance(msg, dict)
+    )
+    assert (
+        has_exception
+    ), "Expected response to contain exception when rail blocks with exception"
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_exception_no_duplicates():
+    """Test that exception-based rails don't create duplicate activated_rails entries."""
+
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "Hi there!",
+        ],
+    )
+
+    chat >> "This is an offtopic message"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [rail for rail in result.log.activated_rails if rail.stop]
+    assert (
+        len(stopped_rails) > 0
+    ), "Expected at least one stopped rail. Cannot test for duplicates if no rails stopped."
+
+    rail_names_with_actions = {}
+    for rail in result.log.activated_rails:
+        if rail.executed_actions:
+            name = rail.name
+            if name in rail_names_with_actions:
+                rail_names_with_actions[name] += 1
+            else:
+                rail_names_with_actions[name] = 1
+
+    duplicates = {k: v for k, v in rail_names_with_actions.items() if v > 1}
+    assert len(duplicates) == 0, (
+        f"Found duplicate rails with executed actions: {duplicates}. "
+        f"This indicates stopped rail events are being processed multiple times."
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_exception_single_stop_in_decisions():
+    """Test that 'stop' appears only once in decisions list.
+
+    This test would have FAILED before the final fix because both the exception
+    handler and end-of-processing logic were adding 'stop' without checking.
+    """
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "Hi there!",
+        ],
+    )
+
+    chat >> "This contains both unsafe and offtopic terms"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [rail for rail in result.log.activated_rails if rail.stop]
+
+    assert (
+        len(stopped_rails) > 0
+    ), "Expected at least one stopped rail. Cannot test 'stop' count if no rails stopped."
+
+    for rail in stopped_rails:
+        stop_count = rail.decisions.count("stop")
+        assert stop_count == 1, (
+            f"Rail '{rail.name}' has 'stop' appearing {stop_count} times in decisions: {rail.decisions}. "
+            f"Expected exactly 1. This indicates duplicate 'stop' additions."
+        )
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_exception_consistency_with_sequential():
+    """Test that parallel mode with exceptions behaves like sequential mode.
+
+    This test verifies that the fix makes parallel and sequential modes consistent.
+    """
+    config_parallel = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    config_parallel.rails.input.parallel = True
+
+    chat_parallel = TestChat(
+        config_parallel,
+        llm_completions=["Hi there!"],
+    )
+    chat_parallel >> "This message has an unsafe word"
+    result_parallel = await chat_parallel.app.generate_async(
+        messages=chat_parallel.history, options=OPTIONS
+    )
+
+    config_sequential = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    config_sequential.rails.input.parallel = False
+
+    chat_sequential = TestChat(
+        config_sequential,
+        llm_completions=["Hi there!"],
+    )
+    chat_sequential >> "This message has an unsafe word"
+    result_sequential = await chat_sequential.app.generate_async(
+        messages=chat_sequential.history, options=OPTIONS
+    )
+
+    parallel_stopped = [r for r in result_parallel.log.activated_rails if r.stop]
+    sequential_stopped = [r for r in result_sequential.log.activated_rails if r.stop]
+
+    assert len(parallel_stopped) > 0, "Parallel mode should have stopped rails"
+    assert len(sequential_stopped) > 0, "Sequential mode should have stopped rails"
+
+    parallel_stopped_names = {r.name for r in parallel_stopped}
+    sequential_stopped_names = {r.name for r in sequential_stopped}
+
+    assert len(parallel_stopped_names.intersection(sequential_stopped_names)) > 0, (
+        f"Parallel and sequential modes should stop the same rails. "
+        f"Parallel stopped: {parallel_stopped_names}, Sequential stopped: {sequential_stopped_names}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_exception_with_passing_rails():
+    """Test that when one rail stops with exception, others that passed are tracked correctly.
+
+    This ensures that only the blocking rail has stop=True, not all rails.
+    """
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=["Hi there!"],
+    )
+
+    # this message triggers safety check but not topic check
+    chat >> "This message is unsafe but on topic"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [r for r in result.log.activated_rails if r.stop]
+    passed_rails = [r for r in result.log.activated_rails if not r.stop]
+
+    assert len(stopped_rails) > 0, "Should have at least one stopped rail"
+    assert len(passed_rails) > 0, "Should have at least one passed rail"
+
+    # stopped rails should have "stop" in decisions
+    for rail in stopped_rails:
+        assert (
+            "stop" in rail.decisions
+        ), f"Stopped rail {rail.name} missing 'stop' in decisions"
+
+    # passed rails should NOT have "stop" in decisions
+    for rail in passed_rails:
+        assert (
+            "stop" not in rail.decisions
+        ), f"Passed rail {rail.name} incorrectly has 'stop' in decisions"
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_multiple_simultaneous_violations():
+    """Test when multiple rails detect violations simultaneously.
+
+    This is a critical edge case that tests race conditions - when 2+ rails
+    both detect violations at nearly the same time, our exception detection
+    should handle whichever completes first.
+    """
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=["Hi there!"],
+    )
+
+    # this input violates BOTH safety (has "unsafe") AND topic (has "stupid")
+    chat >> "This is an unsafe and stupid message"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [r for r in result.log.activated_rails if r.stop]
+
+    assert (
+        len(stopped_rails) > 0
+    ), "Expected at least one stopped rail when multiple violations occur"
+
+    for rail in stopped_rails:
+        assert rail.stop is True, f"Stopped rail '{rail.name}' should have stop=True"
+        assert (
+            "stop" in rail.decisions
+        ), f"Stopped rail '{rail.name}' should have 'stop' in decisions"
+
+    has_exception = any(
+        msg.get("role") == "exception"
+        for msg in result.response
+        if isinstance(msg, dict)
+    )
+    assert has_exception, "Expected exception in response when rails block"
+
+
+@pytest.mark.asyncio
+async def test_parallel_output_rails_exception_stop_flag():
+    """Test that stop flag is set for output rails with exceptions in parallel mode.
+
+    This verifies that our fix works for output rails, not just input rails,
+    since both use the same _run_flows_in_parallel mechanism.
+    """
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "This is a response with harmful content that should be blocked",
+        ],
+    )
+
+    chat >> "Hello"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    output_rails = [r for r in result.log.activated_rails if r.type == "output"]
+    assert len(output_rails) > 0, "Expected at least one output rail to be activated"
+
+    stopped_output_rails = [r for r in output_rails if r.stop]
+
+    assert (
+        len(stopped_output_rails) > 0
+    ), "Expected at least one stopped output rail when output is blocked"
+
+    for rail in stopped_output_rails:
+        assert (
+            "stop" in rail.decisions
+        ), f"Stopped output rail '{rail.name}' should have 'stop' in decisions"
+
+    has_exception = any(
+        msg.get("role") == "exception"
+        for msg in result.response
+        if isinstance(msg, dict)
+    )
+    assert has_exception, "Expected exception when output rail blocks"
+
+
+@pytest.mark.asyncio
+async def test_parallel_rails_context_updates_preserved():
+    """Test that context updates are preserved when a rail stops with exception.
+
+    This verifies that even when a rail raises an exception, any context updates
+    it made before stopping are still captured.
+    """
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+
+    config.rails.input.flows.append("check with context update")
+
+    chat = TestChat(
+        config,
+        llm_completions=["Hi there!"],
+    )
+
+    chat >> "This message is blocked and should increment violation count"
+    result = await chat.app.generate_async(messages=chat.history, options=OPTIONS)
+
+    stopped_rails = [r for r in result.log.activated_rails if r.stop]
+
+    assert len(stopped_rails) > 0, "Expected at least one stopped rail"
+
+    for rail in stopped_rails:
+        assert rail.stop is True
+        assert "stop" in rail.decisions
+
+
+@pytest.mark.asyncio
+async def test_input_rails_only_parallel_with_exceptions():
+    """Test parallel input rails with NO output rails configured."""
+
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["Hi there!"],
+    )
+
+    options_input_only = {
+        "log": {
+            "activated_rails": True,
+        },
+        "rails": {
+            "input": True,
+            "output": False,
+            "dialog": False,
+            "retrieval": False,
+        },
+    }
+
+    chat >> "This is an unsafe message"
+    result = await chat.app.generate_async(
+        messages=chat.history, options=options_input_only
+    )
+
+    input_rails = [r for r in result.log.activated_rails if r.type == "input"]
+    output_rails = [r for r in result.log.activated_rails if r.type == "output"]
+
+    assert len(input_rails) > 0, "Should have input rails"
+    assert len(output_rails) == 0, "Should have no output rails"
+
+    stopped_input_rails = [r for r in input_rails if r.stop]
+    assert (
+        len(stopped_input_rails) > 0
+    ), "Expected at least one stopped input rail when input is blocked"
+
+    for rail in stopped_input_rails:
+        assert rail.stop is True
+        assert "stop" in rail.decisions
+
+
+@pytest.mark.asyncio
+async def test_output_rails_only_parallel_with_exceptions():
+    """Test parallel output rails with NO input rails configured."""
+    config = RailsConfig.from_path(
+        os.path.join(CONFIGS_FOLDER, "parallel_rails_with_exceptions")
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "This response contains harmful content",
+        ],
+    )
+
+    options_output_only = {
+        "log": {
+            "activated_rails": True,
+        },
+        "rails": {
+            "input": False,
+            "output": True,
+            "dialog": False,
+            "retrieval": False,
+        },
+    }
+
+    chat >> "Hello"
+    result = await chat.app.generate_async(
+        messages=chat.history, options=options_output_only
+    )
+
+    input_rails = [r for r in result.log.activated_rails if r.type == "input"]
+    output_rails = [r for r in result.log.activated_rails if r.type == "output"]
+
+    assert len(input_rails) == 0, "Should have no input rails"
+    assert len(output_rails) > 0, "Should have output rails"
+
+    stopped_output_rails = [r for r in output_rails if r.stop]
+    assert (
+        len(stopped_output_rails) > 0
+    ), "Expected at least one stopped output rail when output is blocked"
+
+    for rail in stopped_output_rails:
+        assert rail.stop is True
+        assert "stop" in rail.decisions


### PR DESCRIPTION
## Description

Fixes the `stop` flag not being set to `True` for exception-based rails when running in parallel mode. Previously, when `parallel: True` and `enable_rails_exceptions: True`, rails that raised exceptions (like `ContentSafetyCheckInputException`) had `stop=False` instead of `stop=True`, creating inconsistency with sequential mode.

### Root Cause

The parallel execution code only checked for `BotIntent` with `intent == "stop"` to determine if a rail stopped. Exception events were not recognized as stop conditions, causing:
- `InputRailFinished` post-event to be added even when rail raised exception
- `stop` flag to remain `False`
- Inconsistent behavior between parallel and sequential modes
