### PR TITLE
fix(llm): Add async streaming support to ChatNVIDIA provider patch

### DIFF
--- a/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
+++ b/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
@@ -57,7 +57,7 @@ def stream_decorator(func):  # pragma: no cover
     return wrapper
 
 
-def async_stream_decorator(func):
+def async_stream_decorator(func):  # pragma: no cover
     @wraps(func)
     async def wrapper(
         self,

--- a/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
+++ b/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
@@ -18,7 +18,6 @@ import logging
 from functools import wraps
 from typing import Any, Dict, List, Optional
 
-from langchain_core.callbacks import Callbacks
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -134,14 +133,12 @@ class ChatNVIDIA(ChatNVIDIAOriginal):  # pragma: no cover
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
-        callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> ChatResult:
         return super()._generate(
             messages=messages,
             stop=stop,
             run_manager=run_manager,
-            callbacks=callbacks,
             **kwargs,
         )
 

--- a/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
+++ b/nemoguardrails/llm/providers/_langchain_nvidia_ai_endpoints_patch.py
@@ -18,8 +18,15 @@ import logging
 from functools import wraps
 from typing import Any, Dict, List, Optional
 
-from langchain_core.callbacks.manager import CallbackManagerForLLMRun
-from langchain_core.language_models.chat_models import generate_from_stream
+from langchain_core.callbacks import Callbacks
+from langchain_core.callbacks.manager import (
+    AsyncCallbackManagerForLLMRun,
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import (
+    agenerate_from_stream,
+    generate_from_stream,
+)
 from langchain_core.messages import BaseMessage
 from langchain_core.outputs import ChatResult
 from langchain_nvidia_ai_endpoints import ChatNVIDIA as ChatNVIDIAOriginal
@@ -46,6 +53,28 @@ def stream_decorator(func):  # pragma: no cover
             return generate_from_stream(stream_iter)
         else:
             return func(self, messages, stop, run_manager, **kwargs)
+
+    return wrapper
+
+
+def async_stream_decorator(func):
+    @wraps(func)
+    async def wrapper(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        stream: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        should_stream = stream if stream is not None else self.streaming
+        if should_stream:
+            stream_iter = self._astream(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            )
+            return await agenerate_from_stream(stream_iter)
+        else:
+            return await func(self, messages, stop, run_manager, **kwargs)
 
     return wrapper
 
@@ -105,9 +134,26 @@ class ChatNVIDIA(ChatNVIDIAOriginal):  # pragma: no cover
         messages: List[BaseMessage],
         stop: Optional[List[str]] = None,
         run_manager: Optional[CallbackManagerForLLMRun] = None,
+        callbacks: Callbacks = None,
         **kwargs: Any,
     ) -> ChatResult:
         return super()._generate(
+            messages=messages,
+            stop=stop,
+            run_manager=run_manager,
+            callbacks=callbacks,
+            **kwargs,
+        )
+
+    @async_stream_decorator
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        return await super()._agenerate(
             messages=messages, stop=stop, run_manager=run_manager, **kwargs
         )
 

--- a/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
+++ b/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
@@ -386,9 +386,9 @@ streaming: True
         total_time = chunk_times[-1] - chunk_times[0]
 
         assert len(chunks) > 0, "Should receive at least one chunk"
-        assert ttft < (total_time / 2), (
-            f"TTFT ({ttft:.3f}s) should be less than half of total time ({total_time:.3f}s)"
-        )
+        assert ttft < (
+            total_time / 2
+        ), f"TTFT ({ttft:.3f}s) should be less than half of total time ({total_time:.3f}s)"
         assert len(chunk_times) > 2, "Should receive multiple chunks for streaming"
 
         full_response = "".join(chunks)

--- a/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
+++ b/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
@@ -19,12 +19,13 @@ import time
 from unittest.mock import patch
 
 import pytest
+
+langchain_nvidia_ai_endpoints = pytest.importorskip("langchain_nvidia_ai_endpoints")
+
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 
 from nemoguardrails.llm.providers._langchain_nvidia_ai_endpoints_patch import ChatNVIDIA
-
-langchain_nvidia_ai_endpoints = pytest.importorskip("langchain_nvidia_ai_endpoints")
 
 LIVE_TEST_MODE = os.environ.get("LIVE_TEST_MODE")
 

--- a/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
+++ b/tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py
@@ -1,0 +1,395 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+from nemoguardrails.llm.providers._langchain_nvidia_ai_endpoints_patch import ChatNVIDIA
+
+langchain_nvidia_ai_endpoints = pytest.importorskip("langchain_nvidia_ai_endpoints")
+
+LIVE_TEST_MODE = os.environ.get("LIVE_TEST_MODE")
+
+
+class FakeCallbackHandler:
+    def __init__(self):
+        self.llm_streams = 0
+        self.tokens = []
+
+    async def on_llm_new_token(self, token: str, **kwargs):
+        self.llm_streams += 1
+        self.tokens.append(token)
+
+
+class TestAsyncStreamDecorator:
+    @pytest.mark.asyncio
+    async def test_decorator_with_streaming_enabled(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+
+        messages = [HumanMessage(content="Hello")]
+
+        with patch.object(chat, "_astream") as mock_astream:
+            mock_chunk = ChatGenerationChunk(message=AIMessageChunk(content="Hi there"))
+            mock_astream.return_value = AsyncIteratorMock([mock_chunk])
+
+            result = await chat._agenerate(messages)
+
+            assert isinstance(result, ChatResult)
+            assert len(result.generations) == 1
+            assert result.generations[0].message.content == "Hi there"
+            mock_astream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_decorator_with_streaming_disabled(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=False,
+        )
+
+        messages = [HumanMessage(content="Hello")]
+
+        with patch(
+            "langchain_nvidia_ai_endpoints.ChatNVIDIA._agenerate"
+        ) as mock_parent_agenerate:
+            expected_result = ChatResult(
+                generations=[
+                    ChatGeneration(message=AIMessage(content="Response from parent"))
+                ]
+            )
+            mock_parent_agenerate.return_value = expected_result
+
+            result = await chat._agenerate(messages)
+
+            assert result == expected_result
+            mock_parent_agenerate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_decorator_preserves_function_metadata(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+        )
+
+        assert chat._agenerate.__name__ == "_agenerate"
+        assert asyncio.iscoroutinefunction(chat._agenerate)
+
+    @pytest.mark.asyncio
+    async def test_streaming_aggregates_multiple_chunks(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+
+        messages = [HumanMessage(content="Hello")]
+
+        with patch.object(chat, "_astream") as mock_astream:
+            chunks = [
+                ChatGenerationChunk(message=AIMessageChunk(content="Hello ")),
+                ChatGenerationChunk(message=AIMessageChunk(content="world")),
+                ChatGenerationChunk(message=AIMessageChunk(content="!")),
+            ]
+            mock_astream.return_value = AsyncIteratorMock(chunks)
+
+            result = await chat._agenerate(messages)
+
+            assert isinstance(result, ChatResult)
+            assert len(result.generations) == 1
+            assert result.generations[0].message.content == "Hello world!"
+            mock_astream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_streaming_with_empty_chunks(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+
+        messages = [HumanMessage(content="Hello")]
+
+        with patch.object(chat, "_astream") as mock_astream:
+            chunks = [
+                ChatGenerationChunk(message=AIMessageChunk(content="")),
+                ChatGenerationChunk(message=AIMessageChunk(content="Hello")),
+                ChatGenerationChunk(message=AIMessageChunk(content="")),
+            ]
+            mock_astream.return_value = AsyncIteratorMock(chunks)
+
+            result = await chat._agenerate(messages)
+
+            assert isinstance(result, ChatResult)
+            assert len(result.generations) == 1
+            assert result.generations[0].message.content == "Hello"
+
+
+class TestChatNVIDIAPatch:
+    @pytest.mark.asyncio
+    async def test_agenerate_calls_patched_agenerate(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=False,
+        )
+
+        messages = [[HumanMessage(content="Hello")], [HumanMessage(content="Hi")]]
+
+        with patch(
+            "langchain_nvidia_ai_endpoints.ChatNVIDIA._agenerate"
+        ) as mock_parent:
+            mock_parent.return_value = ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Response"))]
+            )
+
+            result = await chat.agenerate(messages)
+
+            assert isinstance(result.generations, list)
+            assert len(result.generations) == 2
+            for generation_list in result.generations:
+                assert len(generation_list) == 1
+                assert generation_list[0].message.content == "Response"
+            assert mock_parent.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_agenerate_with_streaming_enabled(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+
+        messages = [[HumanMessage(content="Hello")]]
+
+        with patch.object(chat, "_astream") as mock_astream:
+            chunks = [
+                ChatGenerationChunk(message=AIMessageChunk(content="Hello ")),
+                ChatGenerationChunk(message=AIMessageChunk(content="world")),
+            ]
+            mock_astream.return_value = AsyncIteratorMock(chunks)
+
+            result = await chat.agenerate(messages)
+
+            assert isinstance(result.generations, list)
+            assert len(result.generations) == 1
+            assert len(result.generations[0]) == 1
+            assert result.generations[0][0].message.content == "Hello world"
+            mock_astream.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_streaming_field_exists(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+        )
+
+        assert hasattr(chat, "streaming")
+        assert chat.streaming == False
+
+        chat_with_streaming = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+        assert chat_with_streaming.streaming == True
+
+    @pytest.mark.asyncio
+    async def test_backward_compatibility_sync_generate(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=False,
+        )
+
+        messages = [[HumanMessage(content="Hello")]]
+
+        with patch("langchain_nvidia_ai_endpoints.ChatNVIDIA._generate") as mock_parent:
+            mock_parent.return_value = ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Response"))]
+            )
+
+            result = chat.generate(messages)
+
+            assert isinstance(result.generations, list)
+            assert len(result.generations[0]) == 1
+            assert result.generations[0][0].message.content == "Response"
+            mock_parent.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_streaming_handles_multiple_message_batches(self):
+        chat = ChatNVIDIA(
+            model="meta/llama-3.3-70b-instruct",
+            base_url="http://localhost:8000/v1",
+            streaming=True,
+        )
+
+        messages = [
+            [HumanMessage(content="First message")],
+            [HumanMessage(content="Second message")],
+        ]
+
+        with patch.object(chat, "_astream") as mock_astream:
+            mock_astream.side_effect = [
+                AsyncIteratorMock(
+                    [
+                        ChatGenerationChunk(message=AIMessageChunk(content="First ")),
+                        ChatGenerationChunk(message=AIMessageChunk(content="response")),
+                    ]
+                ),
+                AsyncIteratorMock(
+                    [
+                        ChatGenerationChunk(message=AIMessageChunk(content="Second ")),
+                        ChatGenerationChunk(message=AIMessageChunk(content="response")),
+                    ]
+                ),
+            ]
+
+            result = await chat.agenerate(messages)
+
+            assert len(result.generations) == 2
+            assert result.generations[0][0].message.content == "First response"
+            assert result.generations[1][0].message.content == "Second response"
+            assert mock_astream.call_count == 2
+
+
+class TestIntegrationWithLLMRails:
+    @pytest.mark.asyncio
+    async def test_chatnvidia_with_llmrails_async(self):
+        from nemoguardrails import LLMRails, RailsConfig
+
+        config = RailsConfig.from_content(
+            config={
+                "models": [
+                    {
+                        "type": "main",
+                        "engine": "nim",
+                        "model": "meta/llama-3.3-70b-instruct",
+                    }
+                ]
+            }
+        )
+
+        with patch(
+            "nemoguardrails.llm.providers._langchain_nvidia_ai_endpoints_patch.ChatNVIDIA._agenerate"
+        ) as mock_agenerate:
+            mock_agenerate.return_value = ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Test response"))]
+            )
+
+            rails = LLMRails(config)
+
+            result = await rails.generate_async(
+                messages=[{"role": "user", "content": "Hello"}]
+            )
+
+            assert result is not None
+            assert "content" in result
+            assert result["content"] == "Test response"
+
+    @pytest.mark.asyncio
+    async def test_chatnvidia_streaming_with_llmrails(self):
+        from nemoguardrails import LLMRails, RailsConfig
+
+        config = RailsConfig.from_content(
+            config={
+                "models": [
+                    {
+                        "type": "main",
+                        "engine": "nim",
+                        "model": "meta/llama-3.3-70b-instruct",
+                        "parameters": {"streaming": True},
+                    }
+                ],
+                "streaming": True,
+            }
+        )
+
+        rails = LLMRails(config)
+
+        chat_model = rails.llm
+
+        assert hasattr(chat_model, "streaming")
+        assert chat_model.streaming == True
+
+
+class AsyncIteratorMock:
+    def __init__(self, items):
+        self.items = items
+        self.index = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.index >= len(self.items):
+            raise StopAsyncIteration
+        item = self.items[self.index]
+        self.index += 1
+        return item
+
+
+@pytest.mark.skipif(
+    not LIVE_TEST_MODE,
+    reason="This test requires LIVE_TEST_MODE environment variable to be set for live testing",
+)
+class TestChatNVIDIAStreamingE2E:
+    @pytest.mark.asyncio
+    async def test_stream_async_ttft_with_nim(self):
+        from nemoguardrails import LLMRails, RailsConfig
+        from nemoguardrails.actions.llm.utils import LLMCallException
+
+        yaml_content = """
+models:
+  - type: main
+    engine: nim
+    model: meta/llama-3.3-70b-instruct
+
+streaming: True
+"""
+        config = RailsConfig.from_content(yaml_content=yaml_content)
+        rails = LLMRails(config)
+
+        chunk_times = [time.time()]
+        chunks = []
+
+        async for chunk in rails.stream_async(
+            messages=[
+                {"role": "user", "content": "Count to 20 by 2s, e.g. 2 4 6 8 ..."}
+            ]
+        ):
+            chunks.append(chunk)
+            chunk_times.append(time.time())
+
+        ttft = chunk_times[1] - chunk_times[0]
+        total_time = chunk_times[-1] - chunk_times[0]
+
+        assert len(chunks) > 0, "Should receive at least one chunk"
+        assert ttft < (total_time / 2), (
+            f"TTFT ({ttft:.3f}s) should be less than half of total time ({total_time:.3f}s)"
+        )
+        assert len(chunk_times) > 2, "Should receive multiple chunks for streaming"
+
+        full_response = "".join(chunks)
+        assert len(full_response) > 0, "Full response should not be empty"


### PR DESCRIPTION
## Description

Adds async streaming support to the patched ChatNVIDIA provider, enabling `stream_async()` to properly stream with NIM models. Prior to this fix, `stream_async()` with the NIM engine would block for the complete generation and yield all content at once, rather than streaming incrementally.

## Problem

Before this fix, async streaming tests would **fail** because chunks weren't streamed incrementally:

```python
async def test_ttft(engine, model):
    config = RailsConfig.from_content(yaml_content=f"""
models:
  - type: main
    engine: nim
    model: {model}
streaming: True
""")
    rails = LLMRails(config)
    chunk_times = [time.time()]
    async for chunk in rails.stream_async(messages=[...]):
        chunk_times.append(time.time())

    ttft = chunk_times[1] - chunk_times[0]  # Time to first token
    total_time = chunk_times[-1] - chunk_times[0]

    # this assertion fails without the fix:
    assert ttft < (total_time / 2), "TTFT should be less than half of total time"
```

for example:
```python
await test_ttft(model="meta/llama-3.3-70b-instruct", engine="nim")
 ```
 
 Tested it on all the supported versions:
 
 ```markdown
   Version         TTFT (s)     Total Time (s)
  ------------------------------------------
  0.3.1           0.473        2.875
  0.3.2           0.498        2.797
  0.3.3           0.476        2.745
  0.3.4           0.450        2.507
  0.3.5           0.489        2.760
  0.3.6           0.461        2.787
  0.3.7           0.444        2.886
  0.3.8           0.432        2.831
  0.3.9           0.479        2.794
  0.3.10          0.440        2.426
  0.3.11          0.433        2.909
  0.3.12          0.471        2.692
  0.3.13          0.455        2.603
  0.3.14          0.474        2.825
  0.3.15          0.444        2.488
  0.3.16          0.473        2.645
  0.3.17          0.432        2.857
  0.3.18          0.473        3.438
  0.3.19          0.458        2.824
```

prior to the fix

```markdown
  Version         Error Type                Error Message
  --------------------------------------------------------------------------------
  Version         Error Type                Error Message
  --------------------------------------------------------------------------------
  0.3.0           AssertionError            TTFT (3.1635499000549316) should be l...
  0.3.1           AssertionError            TTFT (2.7374980449676514) should be l...
  0.3.2           AssertionError            TTFT (2.588848829269409) should be le...
  0.3.3           AssertionError            TTFT (2.7798001766204834) should be l...
  0.3.4           AssertionError            TTFT (2.870666980743408) should be le...
  0.3.5           AssertionError            TTFT (2.900015115737915) should be le...
  0.3.6           AssertionError            TTFT (3.027787923812866) should be le...
  0.3.7           AssertionError            TTFT (2.741342782974243) should be le...
  0.3.8           AssertionError            TTFT (2.8514771461486816) should be l...
  0.3.9           AssertionError            TTFT (3.0388290882110596) should be l...
  0.3.10          AssertionError            TTFT (3.1536900997161865) should be l...
  0.3.11          AssertionError            TTFT (2.754746913909912) should be le...
  0.3.12          AssertionError            TTFT (2.7870500087738037) should be l...
  0.3.13          AssertionError            TTFT (2.575707197189331) should be le..
  0.3.14          AssertionError            TTFT (2.9357969760894775) should be l...
  0.3.15          AssertionError            TTFT (2.972874879837036) should be le...
  0.3.16          AssertionError            TTFT (2.6601181030273438) should be l...
  0.3.17          AssertionError            TTFT (3.1566638946533203) should be l...
  0.3.18          AssertionError            TTFT (3.070240020751953) should be le...
  0.3.19          RuntimeError              list index out of range
```

in 0.3.19 async api support is added to ChatNVIDIA, that's why we are getting a different error. This is fixed too.

```
LIVE_TEST_MODE=1 poetry run pytest tests/llm_providers/test_langchain_nvidia_ai_endpoints_patch.py -v
```
ensure you have `langchain-nvidia-ai-endpoints` installed and NVIDIA_API_KEY set.