### PR TITLE
fix(ci): run latest-deps tests on all OS with all Python versions

### DIFF
--- a/.github/workflows/latest-deps-tests.yml
+++ b/.github/workflows/latest-deps-tests.yml
@@ -9,13 +9,13 @@ jobs:
   latest-deps-tests-matrix:
     strategy:
       matrix:
-        os: [Ubuntu]
+        os: [Ubuntu, macOS, Windows]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: Ubuntu
             image: ubuntu-latest
           - os: macOS
-            image: macos-15
+            image: macos-latest
           - os: Windows
             image: windows-latest
       fail-fast: false


### PR DESCRIPTION
Fix the GitHub Actions workflow for latest dependencies testing to properly run all Python versions (3.10, 3.11, 3.12, 3.13) on all operating systems (Ubuntu, macOS, Windows). Previously, macOS and Windows jobs were not being generated with Python versions, causing them to default to Python 3.9.13 which is incompatible with the project requirements (>=3.10,<3.14).


Fixed workflow: https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/19674975603
