### PR TITLE
ci: remove duplicate coverage runs on push events

### DIFF
--- a/.github/workflows/test-coverage-report.yml
+++ b/.github/workflows/test-coverage-report.yml
@@ -1,8 +1,6 @@
 name: Coverage Report
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
- Removed `push` trigger from coverage workflow to prevent duplicate runs
- Coverage will now only run on pull request events
