### PR TITLE
fix(llmrails): skip output rails when dialog disabled and no bot_message provided

### DIFF
--- a/nemoguardrails/rails/llm/llm_flows.co
+++ b/nemoguardrails/rails/llm/llm_flows.co
@@ -28,11 +28,10 @@ define flow run dialog rails
 
   # If the dialog_rails are disabled
   if $generation_options and $generation_options.rails.dialog == False
-    # If the output rails are also disabled, we just return user message.
-    if $generation_options.rails.output == False
+    # If output rails are disabled or there's no bot message to check, skip output rails.
+    if $generation_options.rails.output == False or $bot_message is None
       create event StartUtteranceBotAction(script=$user_message)
     else
-      # we take the $bot_message from context.
       create event BotMessage(text=$bot_message)
   else
     # If not, we continue the usual process

--- a/tests/test_parallel_rails_exceptions.py
+++ b/tests/test_parallel_rails_exceptions.py
@@ -375,8 +375,11 @@ async def test_output_rails_only_parallel_with_exceptions():
         },
     }
 
-    chat >> "Hello"
-    result = await chat.app.generate_async(messages=chat.history, options=options_output_only)
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "This response contains harmful content"},
+    ]
+    result = await chat.app.generate_async(messages=messages, options=options_output_only)
 
     input_rails = [r for r in result.log.activated_rails if r.type == "input"]
     output_rails = [r for r in result.log.activated_rails if r.type == "output"]


### PR DESCRIPTION

When `generate_async` is called with `options={"dialog": False, "output": True}` and no `bot_message` is provided in context, output rails were incorrectly running and checking `None`. This fix ensures output rails only run when there's actual output to check.


Test matrix:

  | input | output | dialog | expect_input | expect_output |
  |-------|--------|--------|--------------|---------------|
  | T     | T      | T      | T            | T             |
  | T     | T      | F      | T            | F ← bug fix   |
  | T     | F      | T      | T            | F             |
  | T     | F      | F      | T            | F             |
  | F     | T      | T      | F            | T             |
  | F     | T      | F      | F            | F ← bug fix   |
  | F     | F      | T      | F            | F             |
  | F     | F      | F      | F            | F             |


