### PR TITLE
chore(docker): upgrade to Python 3.12-slim base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10
+FROM python:3.12-slim
 
-# Install git and gcc/g++ for annoy
-RUN apt-get update && apt-get install -y git gcc g++
+RUN apt-get update && apt-get install -y --no-install-recommends git gcc g++ \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set POETRY_VERSION environment variable
 ENV POETRY_VERSION=1.8.2


### PR DESCRIPTION
## Description


Switch base image from python:3.10 to python:3.12-slim for improved performance and smaller image size. Use --no-install-recommends for apt package installation and clean up apt cache to reduce final image size.


<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
