### PR TITLE
chore(test): reduce default pytest log level from DEBUG to WARNING

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = -p no:warnings
-log_level = DEBUG
+log_level = WARNING
 
 # The flag below should only be activated in special debug sessions
 # i.e. the test hangs and we need to see what happened up to that point.

--- a/tests/test_jailbreak_actions.py
+++ b/tests/test_jailbreak_actions.py
@@ -229,6 +229,9 @@ class TestJailbreakDetectionActions:
     @pytest.mark.asyncio
     async def test_jailbreak_detection_model_local_success(self, monkeypatch, caplog):
         """Test successful local model execution."""
+        import logging
+
+        caplog.set_level(logging.INFO)
         from nemoguardrails.library.jailbreak_detection.actions import (
             jailbreak_detection_model,
         )


### PR DESCRIPTION
The DEBUG level was flooding test output with verbose nemoguardrails logs,making it difficult to read test results. 

  - Changed default pytest log level from DEBUG to WARNING to reduce noise in test output
  - Verbose logging can still be enabled per-request using `--log-level=DEBUG` or `--log-level=INFO`
  - Fixed test that checks INFO-level log messages to explicitly set `caplog.set_level(logging.INFO)`
