### PR TITLE
fix(tests): Remove temp files created in aiperf unit-tests

### DIFF
--- a/nemoguardrails/llm/providers/huggingface/streamers.py
+++ b/nemoguardrails/llm/providers/huggingface/streamers.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Optional
 
 TRANSFORMERS_AVAILABLE = True
 try:
-    from transformers.generation.streamers import (
-        TextStreamer,  # type: ignore[import-untyped]
+    from transformers.generation.streamers import (  # type: ignore[import-untyped]
+        TextStreamer,
     )
 except ImportError:
     # Fallback if transformers is not available

--- a/nemoguardrails/llm/providers/huggingface/streamers.py
+++ b/nemoguardrails/llm/providers/huggingface/streamers.py
@@ -18,8 +18,8 @@ from typing import TYPE_CHECKING, Optional
 
 TRANSFORMERS_AVAILABLE = True
 try:
-    from transformers.generation.streamers import (  # type: ignore[import-untyped]
-        TextStreamer,
+    from transformers.generation.streamers import (
+        TextStreamer,  # type: ignore[import-untyped]
     )
 except ImportError:
     # Fallback if transformers is not available

--- a/tests/benchmark/test_run_aiperf.py
+++ b/tests/benchmark/test_run_aiperf.py
@@ -34,13 +34,13 @@ from benchmark.aiperf.run_aiperf import AIPerfRunner, AIPerfSummary
 
 
 @pytest.fixture
-def create_config_data():
+def create_config_data(tmp_path):
     """Returns a function with sample basic config, and allows mutation of fields to cover
     more cases or add extra fields"""
 
     def _create_config(
         batch_name="test_batch",
-        output_base_dir="test_output",
+        output_base_dir=str(tmp_path),
         model="test-model",
         tokenizer="test-tokenizer",
         url="http://localhost:8000",
@@ -125,7 +125,7 @@ class TestAIPerfRunnerInit:
         assert runner.config_path == config_file
         assert isinstance(runner.config, AIPerfConfig)
         assert runner.config.batch_name == "test_batch"
-        assert runner.config.output_base_dir == "test_output"
+        assert runner.config.output_base_dir == str(config_file.parent)
         assert runner.config.base_config.model == "test-model"
         assert runner.config.base_config.tokenizer == "test-tokenizer"
         assert runner.config.base_config.url == "http://localhost:8000"


### PR DESCRIPTION
## Summary

In unit-tests, the [AIPerfConfig](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/benchmark/aiperf/aiperf_models.py#L81) `output_base_dir` was set to `test_output` in the pytest feature [create_config_data()](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/tests/benchmark/test_run_aiperf.py#L43). In two tests, the config was used and created directories below the PWD. This fix changes each test to default `output_base_dir` to a temporary directory created by pytest using the [tmp_path fixture](https://docs.pytest.org/en/stable/how-to/tmp_path.html).

## Description

### Before the change

```
$ poetry run pytest -q
$ ls -1 test_output/test_batch/20251211_190139  # Timestamp will match run time
concurrency1
concurrency2
process_result.json
run_metadata.json
```

### After the change

```
$ poetry run pytest -q
$ ls -1 test_output
ls: test_output: No such file or directory
```

## Related Issue(s)

#1501 

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
