### PR TITLE
refactor(streaming): remove LangChain callback dependencies from StreamingHandler

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -507,12 +507,10 @@ class LLMGenerationActions:
 
                     streaming_handler: Optional[StreamingHandler] = streaming_handler_var.get()
 
-                    custom_callback_handlers = [streaming_handler] if streaming_handler else None
-
                     text = await llm_call(
                         generation_llm,
                         prompt,
-                        custom_callback_handlers=custom_callback_handlers,
+                        streaming_handler=streaming_handler,
                         llm_params=llm_params,
                     )
                     text = self.llm_task_manager.parse_task_output(Task.GENERAL, output=text)
@@ -537,12 +535,11 @@ class LLMGenerationActions:
 
                 generation_options: Optional[GenerationOptions] = generation_options_var.get()
                 llm_params = (generation_options and generation_options.llm_params) or {}
-                custom_callback_handlers = [streaming_handler] if streaming_handler else None
 
                 result = await llm_call(
                     generation_llm,
                     prompt,
-                    custom_callback_handlers=custom_callback_handlers,
+                    streaming_handler=streaming_handler,
                     stop=["User:"],
                     llm_params=llm_params,
                 )
@@ -898,14 +895,13 @@ class LLMGenerationActions:
 
                     gen_options: Optional[GenerationOptions] = generation_options_var.get()
                     llm_params = (gen_options and gen_options.llm_params) or {}
-                    custom_callback_handlers = [streaming_handler] if streaming_handler else None
 
                     if not prompt:
                         raise RuntimeError("No prompt found to generate bot message")
                     result = await llm_call(
                         generation_llm,
                         prompt,
-                        custom_callback_handlers=custom_callback_handlers,
+                        streaming_handler=streaming_handler,
                         llm_params=llm_params,
                     )
 
@@ -953,12 +949,11 @@ class LLMGenerationActions:
 
                 generation_options: Optional[GenerationOptions] = generation_options_var.get()
                 llm_params = (generation_options and generation_options.llm_params) or {}
-                custom_callback_handlers = [streaming_handler] if streaming_handler else None
 
                 result = await llm_call(
                     generation_llm,
                     prompt,
-                    custom_callback_handlers=custom_callback_handlers,
+                    streaming_handler=streaming_handler,
                     llm_params=llm_params,
                 )
 
@@ -1247,7 +1242,7 @@ class LLMGenerationActions:
                     llm_call(
                         generation_llm,
                         prompt,
-                        custom_callback_handlers=[_streaming_handler],
+                        streaming_handler=_streaming_handler,
                         stop=["\nuser ", "\nUser "],
                         llm_params={"temperature": self.config.lowest_temperature},
                     )

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -428,13 +428,12 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         generation_options: Optional[GenerationOptions] = generation_options_var.get()
 
         streaming_handler: Optional[StreamingHandler] = streaming_handler_var.get()
-        custom_callback_handlers = [streaming_handler] if streaming_handler else None
 
         generation_llm_params = generation_options and generation_options.llm_params
         text = await llm_call(
             llm,
             user_message,
-            custom_callback_handlers=custom_callback_handlers,
+            streaming_handler=streaming_handler,
             llm_params=generation_llm_params,
         )
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -381,24 +381,6 @@ class LLMRails:
 
         return kwargs
 
-    def _configure_main_llm_streaming(
-        self,
-        llm: Union[BaseLLM, BaseChatModel],
-        model_name: Optional[str] = None,
-        provider_name: Optional[str] = None,
-    ):
-        """Configure streaming support for the main LLM.
-
-        Args:
-            llm (Union[BaseLLM, BaseChatModel]): The main LLM model instance.
-            model_name (Optional[str], optional): Optional model name for logging.
-            provider_name (Optional[str], optional): Optional provider name for logging.
-
-        """
-
-        if hasattr(llm, "streaming"):
-            setattr(llm, "streaming", True)
-
     def _init_llms(self):
         """
         Initializes the right LLM engines based on the configuration.
@@ -826,13 +808,6 @@ class LLMRails:
 
         if streaming_handler:
             streaming_handler_var.set(streaming_handler)
-            if self.llm is None:
-                raise StreamingNotSupportedError(
-                    "Streaming requires a main LLM to be configured. "
-                    "Either pass an LLM to the LLMRails constructor or set a 'main' "
-                    "model in your config.yml under the 'models' section."
-                )
-            self._configure_main_llm_streaming(self.llm)
 
         # Initialize the object with additional explanation information.
         # We allow this to also be set externally. This is useful when multiple parallel
@@ -1231,14 +1206,6 @@ class LLMRails:
 
         streaming_handler = StreamingHandler(include_generation_metadata=include_generation_metadata)
 
-        if self.llm is None:
-            raise StreamingNotSupportedError(
-                "Streaming requires a main LLM to be configured. "
-                "Either pass an LLM to the LLMRails constructor or set a 'main' "
-                "model in your config.yml under the 'models' section."
-            )
-        self._configure_main_llm_streaming(self.llm)
-
         # Create a properly managed task with exception handling
         async def _generation_task():
             try:
@@ -1349,15 +1316,6 @@ class LLMRails:
         # Initialize the LLM stats
         llm_stats = LLMStats()
         llm_stats_var.set(llm_stats)
-
-        if streaming_handler_var.get():
-            if self.llm is None:
-                raise StreamingNotSupportedError(
-                    "Streaming requires a main LLM to be configured. "
-                    "Either pass an LLM to the LLMRails constructor or set a 'main' "
-                    "model in your config.yml under the 'models' section."
-                )
-            self._configure_main_llm_streaming(self.llm)
 
         # Compute the new events.
         processing_log = []

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -15,12 +15,7 @@
 
 import asyncio
 import logging
-from typing import Any, AsyncIterator, Dict, List, Optional, Union
-from uuid import UUID
-
-from langchain_core.callbacks.base import AsyncCallbackHandler
-from langchain_core.messages import AIMessageChunk, BaseMessage
-from langchain_core.outputs import ChatGenerationChunk, GenerationChunk, LLMResult
+from typing import Any, AsyncIterator, Dict, Optional, Union
 
 from nemoguardrails.utils import new_uuid
 
@@ -30,12 +25,12 @@ log = logging.getLogger(__name__)
 END_OF_STREAM = object()
 
 
-class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
-    """Streaming async handler.
+class StreamingHandler(AsyncIterator):
+    """Provider-agnostic streaming handler with prefix/suffix/stop handling.
 
-    Implements the LangChain AsyncCallbackHandler so it can be notified of new tokens.
-    It also implements the AsyncIterator interface so it can be used directly to stream
-    back the response.
+    Implements AsyncIterator interface so it can be used directly to stream
+    back the response. Chunks are pushed via push_chunk() and consumed via
+    async iteration.
     """
 
     def __init__(
@@ -94,7 +89,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         self.prefix = prefix
         self.suffix = suffix
 
-    def set_pipe_to(self, another_handler):
+    def set_pipe_to(self, another_handler: "StreamingHandler"):
         self.pipe_to = another_handler
 
     async def wait(self):
@@ -254,26 +249,16 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
 
     async def push_chunk(
         self,
-        chunk: Union[str, GenerationChunk, AIMessageChunk, ChatGenerationChunk, None],
+        chunk: Union[str, None],
         generation_info: Optional[Dict[str, Any]] = None,
     ):
-        """Push a new chunk to the stream."""
+        """Push a new string chunk to the stream.
 
-        # if generation_info is not explicitly passed,
-        # try to get it from the chunk itself if it's a GenerationChunk or ChatGenerationChunk
-        if generation_info is None:
-            if isinstance(chunk, (GenerationChunk, ChatGenerationChunk)) and hasattr(chunk, "generation_info"):
-                if chunk.generation_info is not None:
-                    generation_info = chunk.generation_info.copy()
-
-        if isinstance(chunk, GenerationChunk):
-            chunk = chunk.text
-        elif isinstance(chunk, AIMessageChunk):
-            chunk = chunk.content
-        elif isinstance(chunk, ChatGenerationChunk):
-            chunk = chunk.text
-        elif chunk is None:
-            # replace None with the END_OF_STREAM marker
+        Args:
+            chunk: String chunk to push, None to signal end of stream, or END_OF_STREAM sentinel.
+            generation_info: Optional metadata about the generation.
+        """
+        if chunk is None:
             chunk = END_OF_STREAM
         elif chunk is END_OF_STREAM:
             # already the correct marker, no conversion needed
@@ -282,7 +267,7 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
             # empty string is a valid chunk and should be processed normally
             pass
         else:
-            raise Exception(f"Unsupported chunk type: {chunk.__class__.__name__}")
+            raise TypeError(f"StreamingHandler.push_chunk() expects str, got {type(chunk).__name__}")
 
         if self.streaming_finished_event.is_set():
             log.info(f"{self.uid[0:3]} - CHUNK after finish: {chunk}")
@@ -340,60 +325,8 @@ class StreamingHandler(AsyncCallbackHandler, AsyncIterator):
         else:
             await self._process(chunk, generation_info)
 
-    async def on_chat_model_start(
-        self,
-        serialized: Dict[str, Any],
-        messages: List[List[BaseMessage]],
-        *,
-        run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
-        tags: Optional[List[str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Any,
-    ) -> Any:
-        self.current_chunk = ""
-
-    async def on_llm_new_token(
-        self,
-        token: str,
-        *,
-        chunk: Optional[Union[GenerationChunk, ChatGenerationChunk]] = None,
-        run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
-        tags: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Run on new LLM token. Only available when streaming is enabled."""
-        # Log the first token if it's empty to help with debugging
-        if self.first_token and token == "":
-            log.debug(f"{self.uid[0:3]} - Received empty first token from LLM")
-
-        # set first_token to False regardless of token content
-        # we always process tokens, even empty ones
-        if self.first_token:
-            self.first_token = False
-
-        generation_info = None
-        if chunk and hasattr(chunk, "generation_info"):
-            if chunk.generation_info is not None:
-                generation_info = chunk.generation_info.copy()
-            else:
-                generation_info = {}
-        else:
-            generation_info = {}
-
-        await self.push_chunk(token if chunk is None else chunk, generation_info=generation_info)
-
-    async def on_llm_end(
-        self,
-        response: LLMResult,
-        *,
-        run_id: UUID,
-        parent_run_id: Optional[UUID] = None,
-        tags: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> None:
-        """Run when LLM ends running."""
+    async def finish(self):
+        """Signal end of stream."""
         if self.current_chunk:
             if self.suffix and self.current_chunk.endswith(self.suffix):
                 self.current_chunk = self.current_chunk[: -1 * len(self.suffix)]

--- a/nemoguardrails/streaming.py
+++ b/nemoguardrails/streaming.py
@@ -72,8 +72,6 @@ class StreamingHandler(AsyncIterator):
         # If set, the chunk will be piped to the specified handler rather than added to the queue or printed
         self.pipe_to = None
 
-        self.first_token = True
-
         # The stop chunks
         self.stop = []
 

--- a/tests/rails/llm/test_config.py
+++ b/tests/rails/llm/test_config.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import MagicMock
 
 import pytest
-from langchain_core.language_models import BaseLLM
 from pydantic import ValidationError
 
 from nemoguardrails.rails.llm.config import Model, RailsConfig, TaskPrompt
-from nemoguardrails.rails.llm.llmrails import LLMRails
 
 
 def test_task_prompt_valid_content():
@@ -298,18 +295,3 @@ def test_rails_config_none_config_path():
 
     result2 = config3 + config4
     assert result2.config_path == ""
-
-
-def test_llm_rails_configure_streaming_with_attr():
-    """Check LLM has the streaming attribute set when _configure_main_llm_streaming is called"""
-
-    mock_llm = MagicMock(spec=BaseLLM)
-    config = RailsConfig(
-        models=[],
-    )
-
-    rails = LLMRails(config, llm=mock_llm)
-    setattr(mock_llm, "streaming", None)
-    rails._configure_main_llm_streaming(llm=mock_llm)
-
-    assert mock_llm.streaming

--- a/tests/runnable_rails/test_streaming.py
+++ b/tests/runnable_rails/test_streaming.py
@@ -47,13 +47,26 @@ class StreamingFakeLLM(FakeLLM):
 
     async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
         """Async stream the response by breaking it into tokens."""
-        response = await self._acall(messages, stop, run_manager, **kwargs)
+        from langchain_core.outputs import GenerationChunk
+
+        if self.exception:
+            raise self.exception
+
+        if self.i >= len(self.responses):
+            raise RuntimeError(
+                f"No responses available for query number {self.i + 1} in FakeLLM. "
+                "Most likely, too many LLM calls are made or additional responses need to be provided."
+            )
+
+        response = self.responses[self.i]
+        self.i += 1
+
         tokens = response.split()
         for i, token in enumerate(tokens):
             if i == 0:
-                yield token
+                yield GenerationChunk(text=token)
             else:
-                yield " " + token
+                yield GenerationChunk(text=" " + token)
 
 
 def test_runnable_rails_basic_streaming():

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -732,15 +732,3 @@ async def test_finish_with_suffix():
         assert chunks == ["Hello World"]
     finally:
         await consumer.cancel()
-
-
-@pytest.mark.asyncio
-async def test_streaming_handler_alias():
-    """Test that StreamingHandler is an alias for StreamingHandler."""
-    assert StreamingHandler is StreamingHandler
-
-    handler = StreamingHandler()
-    handler2 = StreamingHandler()
-
-    assert isinstance(handler, StreamingHandler)
-    assert isinstance(handler2, StreamingHandler)

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -460,17 +460,6 @@ async def test_enable_print_functionality():
 
 
 @pytest.mark.asyncio
-async def test_first_token_handling():
-    """Test the first_token flag behavior directly."""
-    handler = StreamingHandler()
-    assert handler.first_token is True
-
-    await handler.push_chunk("first token")
-
-    assert handler.first_token is True
-
-
-@pytest.mark.asyncio
 async def test_suffix_removal_at_end():
     """Test that suffix is removed at the end of streaming."""
 

--- a/tests/test_streaming_handler.py
+++ b/tests/test_streaming_handler.py
@@ -18,11 +18,8 @@ import io
 import sys
 import unittest.mock as mock
 from typing import List, Optional, Union
-from uuid import UUID
 
 import pytest
-from langchain_core.messages import AIMessageChunk
-from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
@@ -288,7 +285,7 @@ async def test_set_pipe_to():
         # send chunks to main handler
         await main_handler.push_chunk("chunk1")
         await main_handler.push_chunk("chunk2")
-        await main_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
+        await main_handler.push_chunk(END_OF_STREAM)
 
         # main handler received nothing (piped away)
         main_chunks = await main_consumer.get_chunks()
@@ -317,7 +314,7 @@ async def test_wait_method():
             await asyncio.sleep(0.1)
             await handler.push_chunk("chunk2")
             await asyncio.sleep(0.1)
-            await handler.push_chunk(END_OF_STREAM)  # NOTE: signal end of streaming will get changed soon
+            await handler.push_chunk(END_OF_STREAM)
 
         push_task = asyncio.create_task(push_chunks_with_delay())
 
@@ -414,7 +411,7 @@ async def test_multiple_stop_tokens():
 
         # Push text with a stop token in the middle
         await handler.push_chunk("This is some text STOP1 and this should be ignored")
-        await handler.push_chunk(END_OF_STREAM)  # NOTE: Signal end of streaming we are going to change this
+        await handler.push_chunk(END_OF_STREAM)
 
         # streaming stopped at the stop token
         chunks = await consumer.get_chunks()
@@ -429,7 +426,7 @@ async def test_multiple_stop_tokens():
         handler.stop = ["STOP1", "STOP2", "HALT"]
 
         await handler.push_chunk("Different text with HALT token")
-        await handler.push_chunk(END_OF_STREAM)  # NOTE: Signal end of streaming we are going to change this
+        await handler.push_chunk(END_OF_STREAM)
 
         chunks = await consumer.get_chunks()
         assert len(chunks) >= 1
@@ -451,9 +448,7 @@ async def test_enable_print_functionality():
         await handler.push_chunk("Hello")
         await handler.push_chunk(" World")
 
-        # end streaming to trigger newline print
-        # NOTE: None signals the end of streaming also ""
-        await handler.on_llm_end(response=None, run_id=UUID("00000000-0000-0000-0000-000000000000"))
+        await handler.finish()
 
         printed_output = sys.stdout.getvalue()
 
@@ -470,57 +465,9 @@ async def test_first_token_handling():
     handler = StreamingHandler()
     assert handler.first_token is True
 
-    # Mock push_chunk to verify it's not called for empty first token
-    original_push_chunk = handler.push_chunk
-    push_chunk_called = False
+    await handler.push_chunk("first token")
 
-    async def mock_push_chunk(chunk, *args, **kwargs):
-        nonlocal push_chunk_called
-        push_chunk_called = True
-
-    # replace the method temporarily
-    handler.push_chunk = mock_push_chunk
-
-    try:
-        # call on_llm_new_token with empty first token
-        await handler.on_llm_new_token(token="", run_id=UUID("00000000-0000-0000-0000-000000000000"))
-
-        # first_token is now False
-        assert handler.first_token is False
-        # push_chunk was not called (empty first token is skipped)
-        assert push_chunk_called is True
-
-        # reset the mock state
-        push_chunk_called = False
-
-        # NOTE: this is not the root cause of streaming bug with Azure OpenAI
-        # call on_llm_new_token with empty token again (not first)
-        await handler.on_llm_new_token(token="", run_id=UUID("00000000-0000-0000-0000-000000000000"))
-
-        # push_chunk should be called (empty non-first token is not skipped)
-        assert push_chunk_called is True
-
-        await handler.on_llm_new_token(token="This is a test", run_id=UUID("00000000-0000-0000-0000-000000000000"))
-
-        # NOTE: THIS IS A BUG
-        assert push_chunk_called is True
-
-        # TODO:
-        # asssert that streaming has ended when we are here
-    finally:
-        # restore the original method
-        handler.push_chunk = original_push_chunk
-        # Clean up the queue if any items were added by mock or direct calls
-        # This ensures no pending tasks from this handler interfere elsewhere.
-        if hasattr(handler, "queue") and handler.queue is not None:
-            while not handler.queue.empty():
-                try:
-                    handler.queue.get_nowait()
-                    handler.queue.task_done()
-                except asyncio.QueueEmpty:
-                    break
-            # Signal end if push_chunk was mocked and might not have done it
-            await handler.queue.put(END_OF_STREAM)
+    assert handler.first_token is True
 
 
 @pytest.mark.asyncio
@@ -541,7 +488,7 @@ async def test_suffix_removal_at_end():
         assert len(chunks) == 0
 
         await handler.push_chunk("D")
-        await handler.push_chunk(END_OF_STREAM)  # NOTE: will get changed to SENTINEL
+        await handler.push_chunk(END_OF_STREAM)
 
         # Check that suffix was removed
         chunks = await consumer.get_chunks()
@@ -665,135 +612,12 @@ async def test_include_generation_metadata():
         test_generation_info = {"temperature": 0.7, "top_p": 0.95}
 
         await streaming_handler.push_chunk(test_text, generation_info=test_generation_info)
-        await streaming_handler.push_chunk(
-            END_OF_STREAM
-        )  # NOTE: sjignal end of streaming using "" will get changed soon
-
-        chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) >= 1
-        assert chunks[0]["text"] == test_text
-        assert chunks[0]["generation_info"] == test_generation_info
-    finally:
-        await streaming_consumer.cancel()
-
-
-@pytest.mark.asyncio
-async def test_include_generation_metadata_with_different_chunk_types():
-    """Test push_chunk with different chunk types when include_generation_metadata is True."""
-
-    streaming_handler = StreamingHandler(include_generation_metadata=True)
-    streaming_consumer = StreamingConsumer(streaming_handler)
-
-    try:
-        test_text = "test text"
-        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
-
-        generation_chunk = GenerationChunk(text=test_text, generation_info=test_generation_info)
-        await streaming_handler.push_chunk(generation_chunk, generation_info=test_generation_info)
-        await streaming_handler.push_chunk(
-            END_OF_STREAM
-        )  # NOTE: sjignal end of streaming using "" will get changed soon
-
-        chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) >= 1
-        assert chunks[0]["text"] == test_text
-        assert chunks[0]["generation_info"] == test_generation_info
-    finally:
-        await streaming_consumer.cancel()
-
-    # reset handler and consumer for a clean test
-    streaming_handler = StreamingHandler(include_generation_metadata=True)
-    streaming_consumer = StreamingConsumer(streaming_handler)
-
-    try:
-        ai_message_chunk = AIMessageChunk(content=test_text)
-        await streaming_handler.push_chunk(ai_message_chunk, generation_info=test_generation_info)
-        await streaming_handler.push_chunk(
-            END_OF_STREAM
-        )  # NOTE: sjignal end of streaming using "" will get changed soon
-
-        chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) >= 1
-        assert chunks[0]["text"] == test_text
-        assert chunks[0]["generation_info"] == test_generation_info
-    finally:
-        await streaming_consumer.cancel()
-
-
-@pytest.mark.asyncio
-async def test_on_chat_model_start():
-    """Test on_chat_model_start method."""
-    streaming_handler = StreamingHandler()
-
-    streaming_handler.current_chunk = "existing chunk"
-
-    await streaming_handler.on_chat_model_start(
-        serialized={},
-        messages=[[]],
-        run_id=UUID("00000000-0000-0000-0000-000000000000"),
-    )
-
-    # current_chunk is reset
-    assert streaming_handler.current_chunk == ""
-
-
-@pytest.mark.asyncio
-async def test_on_llm_new_token_empty_then_nonempty():
-    """Test on_llm_new_token method with empty token followed by non-empty token."""
-    streaming_handler = StreamingHandler()
-    streaming_consumer = StreamingConsumer(streaming_handler)
-
-    try:
-        # first token is empty,  this will be skipped based on implementation
-        # NOTE: not azure openai bug
-        await streaming_handler.on_llm_new_token(
-            token="",
-            run_id=UUID("00000000-0000-0000-0000-000000000000"),
-        )
-
-        # second token is not empty, this should be processed
-        await streaming_handler.push_chunk("second")
-
-        # NOTE: will chnage to sentinel soon to explicitly end the streaming
         await streaming_handler.push_chunk(END_OF_STREAM)
 
-        # wait for the chunks to be processed
-        await asyncio.sleep(0.1)
-
         chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) == 2
-        assert chunks[0] == ""
-        assert chunks[1] == "second"
-    finally:
-        await streaming_consumer.cancel()
-
-
-@pytest.mark.asyncio
-async def test_on_llm_new_token_with_generation_info():
-    """Test on_llm_new_token method with chunk that has generation_info."""
-    streaming_handler = StreamingHandler(include_generation_metadata=True)
-    streaming_consumer = StreamingConsumer(streaming_handler)
-
-    try:
-        test_text = "test token"
-        test_generation_info = {"temperature": 0.7, "top_p": 0.95}
-        chunk = GenerationChunk(text=test_text, generation_info=test_generation_info)
-
-        await streaming_handler.on_llm_new_token(
-            token=test_text,
-            chunk=chunk,
-            run_id=UUID("00000000-0000-0000-0000-000000000000"),
-        )
-
-        # NOTE: end streaming with None
-        await streaming_handler.on_llm_end(response=None, run_id=UUID("00000000-0000-0000-0000-000000000000"))
-
-        chunks = await streaming_consumer.get_chunks()
-        assert len(chunks) == 2
+        assert len(chunks) >= 1
         assert chunks[0]["text"] == test_text
         assert chunks[0]["generation_info"] == test_generation_info
-        assert chunks[1]["text"] is END_OF_STREAM
-        assert chunks[1]["generation_info"] == test_generation_info
     finally:
         await streaming_consumer.cancel()
 
@@ -811,7 +635,7 @@ async def test_processing_metadata():
         test_generation_info = {"temperature": 0.7, "top_p": 0.95}
 
         await streaming_handler.push_chunk(test_text, generation_info=test_generation_info)
-        await streaming_handler.push_chunk(END_OF_STREAM)  # Signal end of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         chunks = await streaming_consumer.get_chunks()
         assert len(chunks) >= 1
@@ -832,7 +656,7 @@ async def test_processing_metadata():
         await streaming_handler.push_chunk("message", generation_info={"part": 4})
         await streaming_handler.push_chunk(" SUFF", generation_info={"part": 5})
         await streaming_handler.push_chunk("IX", generation_info={"part": 6})
-        await streaming_handler.push_chunk(END_OF_STREAM)  # End of streaming
+        await streaming_handler.push_chunk(END_OF_STREAM)
 
         chunks = await streaming_consumer.get_chunks()
         # the prefix removal should happen first, then streaming happens
@@ -862,71 +686,61 @@ async def test_anext_with_dict_end_of_stream_sentinel():
 
 
 @pytest.mark.asyncio
-async def test_push_chunk_with_chat_generation_chunk():
-    """Test push_chunk with a ChatGenerationChunk."""
-
-    streaming_handler = StreamingHandler()
-    consumer = StreamingConsumer(streaming_handler)
-    try:
-        chat_chunk = ChatGenerationChunk(message=AIMessageChunk(content="chat text"))
-        await streaming_handler.push_chunk(chat_chunk)
-        await streaming_handler.push_chunk(END_OF_STREAM)
-        chunks = await consumer.get_chunks()
-        assert chunks == ["chat text"]
-    finally:
-        await consumer.cancel()
-
-
-@pytest.mark.asyncio
-async def test_push_chunk_with_chat_generation_chunk_with_metadata():
-    """Test push_chunk with a ChatGenerationChunk when metadata is included."""
-
-    streaming_handler = StreamingHandler(include_generation_metadata=True)
-    consumer = StreamingConsumer(streaming_handler)
-    try:
-        message_chunk = AIMessageChunk(content="chat text")
-        chat_chunk = ChatGenerationChunk(message=message_chunk, generation_info={"details": "some details"})
-        await streaming_handler.push_chunk(chat_chunk)
-        await streaming_handler.push_chunk(END_OF_STREAM)
-        chunks = await consumer.get_chunks()
-        assert len(chunks) == 2
-        assert chunks[0]["text"] == "chat text"
-        assert chunks[0]["generation_info"] == {"details": "some details"}
-        assert chunks[1]["text"] is END_OF_STREAM
-        assert chunks[1]["generation_info"] == {"details": "some details"}
-    finally:
-        await consumer.cancel()
-
-
-@pytest.mark.asyncio
 async def test_push_chunk_unsupported_type():
     """Test push_chunk with an unsupported data type."""
 
     streaming_handler = StreamingHandler()
-    with pytest.raises(Exception, match="Unsupported chunk type: int"):
+    with pytest.raises(TypeError, match="StreamingHandler.push_chunk\\(\\) expects str, got int"):
         await streaming_handler.push_chunk(123)
-    with pytest.raises(Exception, match="Unsupported chunk type: list"):
+    with pytest.raises(TypeError, match="StreamingHandler.push_chunk\\(\\) expects str, got list"):
         await streaming_handler.push_chunk([1, 2])
 
 
 @pytest.mark.asyncio
-async def test_on_llm_new_token_with_chunk_having_none_generation_info():
-    """Test on_llm_new_token when chunk.generation_info is None."""
-    streaming_handler = StreamingHandler(include_generation_metadata=True)
-    consumer = StreamingConsumer(streaming_handler)
+async def test_finish_method():
+    """Test the finish() method signals end of stream correctly."""
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
     try:
-        mock_chunk = GenerationChunk(text="test text", generation_info=None)
-        await streaming_handler.on_llm_new_token(
-            token="test text",
-            chunk=mock_chunk,
-            run_id=UUID("00000000-0000-0000-0000-000000000000"),
-        )
-        await streaming_handler.on_llm_end(response=None, run_id=UUID("00000000-0000-0000-0000-000000000000"))
+        await handler.push_chunk("Hello")
+        await handler.push_chunk(" World")
+        await handler.finish()
+
         chunks = await consumer.get_chunks()
-        assert len(chunks) == 2
-        assert chunks[0]["text"] == "test text"
-        assert chunks[0]["generation_info"] == {}
-        assert chunks[1]["text"] is END_OF_STREAM
-        assert chunks[1]["generation_info"] == {}
+        assert chunks == ["Hello", " World"]
+        assert handler.completion == "Hello World"
+        assert handler.streaming_finished_event.is_set()
     finally:
         await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_finish_with_suffix():
+    """Test finish() removes suffix correctly."""
+    handler = StreamingHandler()
+    consumer = StreamingConsumer(handler)
+
+    try:
+        handler.set_pattern(suffix="END")
+        await handler.push_chunk("Hello WorldE")
+        await handler.push_chunk("N")
+        await handler.push_chunk("D")
+        await handler.finish()
+
+        chunks = await consumer.get_chunks()
+        assert chunks == ["Hello World"]
+    finally:
+        await consumer.cancel()
+
+
+@pytest.mark.asyncio
+async def test_streaming_handler_alias():
+    """Test that StreamingHandler is an alias for StreamingHandler."""
+    assert StreamingHandler is StreamingHandler
+
+    handler = StreamingHandler()
+    handler2 = StreamingHandler()
+
+    assert isinstance(handler, StreamingHandler)
+    assert isinstance(handler2, StreamingHandler)


### PR DESCRIPTION
# PR Description

Removes LangChain callback dependencies from `StreamingHandler`. (one callback down)

**Key Changes:**
  - `StreamingHandler` no longer inherits from `AsyncCallbackHandler`
  - Streaming now uses `llm.astream()` with direct `push_chunk()` calls
  - Removed LangChain-specific type handling (`GenerationChunk`, `AIMessageChunk`, etc.)
  - Added explicit `streaming_handler` parameter to `llm_call()`
  - Simplified streaming interface (string-only chunks)

Test plan:

Follow #1538 