### PR TITLE
perf(actions): lazy initialization of embedding indexes

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -112,13 +112,6 @@ class LLMGenerationActions:
         # calling the LLM with the user input.
         self.passthrough_fn: Optional[Callable[..., Awaitable[str]]] = None
 
-    async def init(self):
-        await asyncio.gather(
-            self._init_user_message_index(),
-            self._init_bot_message_index(),
-            self._init_flows_index(),
-        )
-
     def _extract_user_message_example(self, flow: Flow) -> None:
         """Heuristic to extract user message examples from a flow."""
         elements = [item for item in flow.elements if item["_type"] != "doc_string_stmt" and item["_type"] != "stmt"]

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -96,6 +96,7 @@ class LLMGenerationActions:
         self.user_message_index = None
         self.bot_message_index = None
         self.flows_index = None
+        self._init_lock = asyncio.Lock()
 
         self.get_embedding_search_provider_instance = get_embedding_search_provider_instance
 
@@ -290,15 +291,21 @@ class LLMGenerationActions:
 
     async def _ensure_user_message_index(self):
         if self.user_message_index is None and self.user_messages:
-            await self._init_user_message_index()
+            async with self._init_lock:
+                if self.user_message_index is None:
+                    await self._init_user_message_index()
 
     async def _ensure_bot_message_index(self):
         if self.bot_message_index is None and self.bot_messages and self.user_messages:
-            await self._init_bot_message_index()
+            async with self._init_lock:
+                if self.bot_message_index is None:
+                    await self._init_bot_message_index()
 
     async def _ensure_flows_index(self):
         if self.flows_index is None and self.config.flows:
-            await self._init_flows_index()
+            async with self._init_lock:
+                if self.flows_index is None:
+                    await self._init_flows_index()
 
     def _get_general_instructions(self):
         """Helper to extract the general instruction."""

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -20,7 +20,6 @@ import logging
 import random
 import re
 import sys
-import threading
 from dataclasses import asdict
 from functools import lru_cache
 from time import time
@@ -59,12 +58,10 @@ from nemoguardrails.llm.prompts import get_prompt
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
-from nemoguardrails.patch_asyncio import check_sync_call_from_async_loop
 from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.streaming import StreamingHandler
 from nemoguardrails.utils import (
-    get_or_create_event_loop,
     new_event_dict,
     new_uuid,
     safe_eval,
@@ -102,13 +99,8 @@ class LLMGenerationActions:
 
         self.get_embedding_search_provider_instance = get_embedding_search_provider_instance
 
-        # There are still some edge cases not covered by nest_asyncio.
-        # Using a separate thread always for now.
-        loop = get_or_create_event_loop()
-        if True or check_sync_call_from_async_loop():
-            t = threading.Thread(target=asyncio.run, args=(self.init(),))
-            t.start()
-            t.join()
+        if self.config.colang_version == "2.x":
+            self._process_flows()
 
         self.llm_task_manager = llm_task_manager
 
@@ -120,10 +112,6 @@ class LLMGenerationActions:
         self.passthrough_fn: Optional[Callable[..., Awaitable[str]]] = None
 
     async def init(self):
-        # For Colang 2.x we need to do some initial processing
-        if self.config.colang_version == "2.x":
-            self._process_flows()
-
         await asyncio.gather(
             self._init_user_message_index(),
             self._init_bot_message_index(),
@@ -247,6 +235,9 @@ class LLMGenerationActions:
         if not self.bot_messages:
             return
 
+        if not self.user_messages:
+            return
+
         items = []
         for intent, utterances in self.bot_messages.items():
             for text in utterances:
@@ -296,6 +287,18 @@ class LLMGenerationActions:
 
         # NOTE: this should be very fast, otherwise needs to be moved to separate thread.
         await self.flows_index.build()
+
+    async def _ensure_user_message_index(self):
+        if self.user_message_index is None and self.user_messages:
+            await self._init_user_message_index()
+
+    async def _ensure_bot_message_index(self):
+        if self.bot_message_index is None and self.bot_messages and self.user_messages:
+            await self._init_bot_message_index()
+
+    async def _ensure_flows_index(self):
+        if self.flows_index is None and self.config.flows:
+            await self._init_flows_index()
 
     def _get_general_instructions(self):
         """Helper to extract the general instruction."""
@@ -369,6 +372,8 @@ class LLMGenerationActions:
         generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
 
         streaming_handler = streaming_handler_var.get()
+
+        await self._ensure_user_message_index()
 
         # TODO: check for an explicit way of enabling the canonical form detection
 
@@ -620,6 +625,8 @@ class LLMGenerationActions:
                 return ActionResult(events=[bot_intent_event])
 
             user_intent = event["intent"]
+
+            await self._ensure_flows_index()
 
             # We search for the most relevant similar flows
             examples = ""
@@ -919,6 +926,8 @@ class LLMGenerationActions:
                 # Otherwise, we go through the process of creating the altered prompt,
                 # which includes examples, relevant chunks, etc.
 
+                await self._ensure_bot_message_index()
+
                 # We search for the most relevant similar bot utterance
                 examples = ""
                 # NOTE: disabling bot message index when there are no user messages
@@ -1042,6 +1051,8 @@ class LLMGenerationActions:
         if not var_name:
             var_name = last_event["action_result_key"]
 
+        await self._ensure_flows_index()
+
         # We search for the most relevant flows.
         examples = ""
         if self.flows_index:
@@ -1118,6 +1129,10 @@ class LLMGenerationActions:
         generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
 
         streaming_handler = streaming_handler_var.get()
+
+        await self._ensure_user_message_index()
+        await self._ensure_bot_message_index()
+        await self._ensure_flows_index()
 
         if self.config.user_messages:
             # TODO: based on the config we can use a specific canonical forms model

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -151,12 +151,16 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
     async def _ensure_flows_index(self):
         if self.flows_index is None and self.config.flows:
-            await self._init_flows_index()
+            async with self._init_lock:
+                if self.flows_index is None:
+                    await self._init_flows_index()
 
     async def _ensure_instruction_flows_index(self):
         if not hasattr(self, "instruction_flows_index") or self.instruction_flows_index is None:
-            if self.config.flows:
-                await self._init_flows_index()
+            async with self._init_lock:
+                if not hasattr(self, "instruction_flows_index") or self.instruction_flows_index is None:
+                    if self.config.flows:
+                        await self._init_flows_index()
 
     async def _collect_user_intent_and_examples(
         self, state: State, user_action: str, max_example_flows: int

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -149,9 +149,20 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         if self.instruction_flows_index is None:
             self.instruction_flows_index = self.flows_index
 
+    async def _ensure_flows_index(self):
+        if self.flows_index is None and self.config.flows:
+            await self._init_flows_index()
+
+    async def _ensure_instruction_flows_index(self):
+        if not hasattr(self, "instruction_flows_index") or self.instruction_flows_index is None:
+            if self.config.flows:
+                await self._init_flows_index()
+
     async def _collect_user_intent_and_examples(
         self, state: State, user_action: str, max_example_flows: int
     ) -> Tuple[List[str], str, bool]:
+        await self._ensure_user_message_index()
+
         # We search for the most relevant similar user intents
         examples = ""
         potential_user_intents = []
@@ -479,6 +490,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
     ) -> dict:
         """Generate a flow from the provided instructions."""
 
+        await self._ensure_instruction_flows_index()
+
         if self.instruction_flows_index is None:
             raise RuntimeError("No instruction flows index has been created.")
 
@@ -549,6 +562,9 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
     ) -> str:
         """Generate a flow from the provided NAME."""
 
+        await self._ensure_flows_index()
+        await self._ensure_instruction_flows_index()
+
         if self.flows_index is None:
             raise RuntimeError("No flows index has been created.")
 
@@ -608,6 +624,9 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
         if temperature is None:
             temperature = 0.0
+
+        await self._ensure_flows_index()
+        await self._ensure_instruction_flows_index()
 
         if self.instruction_flows_index is None:
             raise RuntimeError("No instruction flows index has been created.")
@@ -734,6 +753,8 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         """
         # Use action specific llm if registered else fallback to main llm
         generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+
+        await self._ensure_flows_index()
 
         # We search for the most relevant flows.
         examples = ""

--- a/tests/test_actions_llm_embedding_lazy_init.py
+++ b/tests/test_actions_llm_embedding_lazy_init.py
@@ -18,7 +18,6 @@ import textwrap
 import pytest
 
 from nemoguardrails import RailsConfig
-from nemoguardrails.imports import check_optional_dependency
 from tests.utils import TestChat
 
 BASE_CONFIG = textwrap.dedent("""
@@ -297,40 +296,23 @@ class TestFastEmbedNotDownloadedForSimpleRails:
                 del os.environ["FASTEMBED_CACHE_PATH"]
 
 
-_has_fastembed = check_optional_dependency("fastembed")
+class TestIndexInitializedAfterGenerate:
+    def test_user_message_index_initialized_after_generate(self):
+        config = RailsConfig.from_content(
+            yaml_content=BASE_CONFIG,
+            colang_content=USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS,
+        )
+        chat = TestChat(
+            config,
+            llm_completions=["express greeting", "Hello! How can I help you?"],
+        )
+        actions = chat.app.llm_generation_actions
 
+        assert actions.user_message_index is None, "Index should be None before generate"
 
-@pytest.mark.skipif(not _has_fastembed, reason="fastembed not installed")
-class TestFastEmbedDownloadedForDialogRails:
-    def test_dialog_rails_cache_created_on_generate(self, tmp_path):
-        import os
+        chat.app.generate(messages=[{"role": "user", "content": "hello"}])
 
-        cache_dir = tmp_path / "fastembed_cache"
-        cache_dir.mkdir()
-        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
-
-        try:
-            config = RailsConfig.from_content(
-                yaml_content=BASE_CONFIG,
-                colang_content=USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS,
-            )
-            chat = TestChat(
-                config,
-                llm_completions=["express greeting", "Hello! How can I help you?"],
-            )
-
-            cache_before = list(cache_dir.iterdir())
-            assert len(cache_before) == 0, "Cache should be empty before generate"
-
-            response = chat.app.generate(messages=[{"role": "user", "content": "hello"}])
-
-            assert response is not None
-
-            cache_after = list(cache_dir.iterdir())
-            assert len(cache_after) > 0, "FastEmbed cache should have models after generate with dialog rails"
-        finally:
-            if "FASTEMBED_CACHE_PATH" in os.environ:
-                del os.environ["FASTEMBED_CACHE_PATH"]
+        assert actions.user_message_index is not None, "Index should be initialized after generate"
 
 
 class TestConcurrentInitialization:

--- a/tests/test_actions_llm_embedding_lazy_init.py
+++ b/tests/test_actions_llm_embedding_lazy_init.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from nemoguardrails import LLMRails, RailsConfig
+from tests.utils import TestChat
+
+BASE_CONFIG = textwrap.dedent("""
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o
+""")
+
+INPUT_RAILS_CONFIG = textwrap.dedent("""
+    rails:
+      input:
+        flows:
+          - self check input
+
+    prompts:
+      - task: self_check_input
+        content: |
+          Instruction: Check if the user input is safe.
+          User input: {{ user_input }}
+          Answer [yes/no]:
+""")
+
+OUTPUT_RAILS_CONFIG = textwrap.dedent("""
+    rails:
+      output:
+        flows:
+          - self check output
+
+    prompts:
+      - task: self_check_output
+        content: |
+          Instruction: Check if the bot output is safe.
+          Bot output: {{ bot_response }}
+          Answer [yes/no]:
+""")
+
+INPUT_OUTPUT_RAILS_CONFIG = textwrap.dedent("""
+    rails:
+      input:
+        flows:
+          - self check input
+      output:
+        flows:
+          - self check output
+
+    prompts:
+      - task: self_check_input
+        content: |
+          Instruction: Check if the user input is safe.
+          User input: {{ user_input }}
+          Answer [yes/no]:
+      - task: self_check_output
+        content: |
+          Instruction: Check if the bot output is safe.
+          Bot output: {{ bot_response }}
+          Answer [yes/no]:
+""")
+
+PASSTHROUGH_CONFIG = textwrap.dedent("""
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o
+
+    passthrough: true
+""")
+
+USER_DEFINITIONS = textwrap.dedent("""
+    define user express greeting
+      "hello"
+      "hi there"
+
+    define user ask about weather
+      "what is the weather"
+      "how is the weather today"
+""")
+
+BOT_DEFINITIONS = textwrap.dedent("""
+    define bot express greeting
+      "Hello! How can I help you?"
+
+    define bot inform weather
+      "The weather is nice today."
+""")
+
+FLOW_DEFINITIONS = textwrap.dedent("""
+    define flow greeting
+      user express greeting
+      bot express greeting
+
+    define flow weather
+      user ask about weather
+      bot inform weather
+""")
+
+
+def _create_rails(yaml_content: str, colang_content: str = ""):
+    config = RailsConfig.from_content(
+        yaml_content=yaml_content,
+        colang_content=colang_content if colang_content else None,
+    )
+    return LLMRails(config)
+
+
+class TestEmbeddingIndexesNotCreatedAtInit:
+    def test_main_model_only(self):
+        rails = _create_rails(BASE_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_input_rails_only(self):
+        rails = _create_rails(BASE_CONFIG + INPUT_RAILS_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_output_rails_only(self):
+        rails = _create_rails(BASE_CONFIG + OUTPUT_RAILS_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_input_output_rails(self):
+        rails = _create_rails(BASE_CONFIG + INPUT_OUTPUT_RAILS_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_passthrough(self):
+        rails = _create_rails(PASSTHROUGH_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_user_definitions_only(self):
+        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_bot_definitions_only(self):
+        rails = _create_rails(BASE_CONFIG, BOT_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_user_and_bot_definitions(self):
+        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_flow_definitions_only(self):
+        rails = _create_rails(BASE_CONFIG, FLOW_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_full_dialog_rails(self):
+        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+    def test_input_rails_with_user_definitions(self):
+        rails = _create_rails(BASE_CONFIG + INPUT_RAILS_CONFIG, USER_DEFINITIONS)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+
+
+class TestConfigDataPresent:
+    def test_user_messages_present_in_config(self):
+        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS)
+        assert len(rails.config.user_messages) == 2
+
+    def test_bot_messages_include_library_defaults(self):
+        rails = _create_rails(BASE_CONFIG)
+        assert len(rails.config.bot_messages) >= 9
+
+    def test_non_system_flows_counted_correctly(self):
+        rails = _create_rails(BASE_CONFIG, FLOW_DEFINITIONS)
+        non_system = [f for f in rails.config.flows if not f.get("is_system_flow", False)]
+        assert len(non_system) == 2
+
+
+class TestFastEmbedNotDownloadedForSimpleRails:
+    def test_input_rails_no_cache_created(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(yaml_content=BASE_CONFIG + INPUT_RAILS_CONFIG)
+            chat = TestChat(config, llm_completions=["yes", "Hello!"])
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "Hello"}])
+
+            assert response is not None
+
+            cache_contents = list(cache_dir.iterdir())
+            assert len(cache_contents) == 0, f"FastEmbed cache should be empty but found: {cache_contents}"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]
+
+    def test_output_rails_no_cache_created(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(yaml_content=BASE_CONFIG + OUTPUT_RAILS_CONFIG)
+            chat = TestChat(config, llm_completions=["Hello!", "yes"])
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "Hello"}])
+
+            assert response is not None
+
+            cache_contents = list(cache_dir.iterdir())
+            assert len(cache_contents) == 0, f"FastEmbed cache should be empty but found: {cache_contents}"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]
+
+    def test_passthrough_no_cache_created(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(yaml_content=PASSTHROUGH_CONFIG)
+            chat = TestChat(config, llm_completions=["Hello!"])
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "Hello"}])
+
+            assert response is not None
+            assert response["content"] == "Hello!"
+
+            cache_contents = list(cache_dir.iterdir())
+            assert len(cache_contents) == 0, f"FastEmbed cache should be empty but found: {cache_contents}"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]
+
+
+class TestFastEmbedDownloadedForDialogRails:
+    def test_dialog_rails_cache_created_on_generate(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(
+                yaml_content=BASE_CONFIG,
+                colang_content=USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS,
+            )
+            chat = TestChat(
+                config,
+                llm_completions=["express greeting", "Hello! How can I help you?"],
+            )
+
+            cache_before = list(cache_dir.iterdir())
+            assert len(cache_before) == 0, "Cache should be empty before generate"
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "hello"}])
+
+            assert response is not None
+
+            cache_after = list(cache_dir.iterdir())
+            assert len(cache_after) > 0, "FastEmbed cache should have models after generate with dialog rails"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]

--- a/tests/test_actions_llm_embedding_lazy_init.py
+++ b/tests/test_actions_llm_embedding_lazy_init.py
@@ -15,7 +15,10 @@
 
 import textwrap
 
-from nemoguardrails import LLMRails, RailsConfig
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.imports import check_optional_dependency
 from tests.utils import TestChat
 
 BASE_CONFIG = textwrap.dedent("""
@@ -113,98 +116,100 @@ FLOW_DEFINITIONS = textwrap.dedent("""
 """)
 
 
-def _create_rails(yaml_content: str, colang_content: str = ""):
+def _create_test_chat(yaml_content: str, colang_content: str = "", llm_completions=None):
+    if llm_completions is None:
+        llm_completions = ["Hello!"]
     config = RailsConfig.from_content(
         yaml_content=yaml_content,
         colang_content=colang_content if colang_content else None,
     )
-    return LLMRails(config)
+    return TestChat(config, llm_completions=llm_completions)
 
 
 class TestEmbeddingIndexesNotCreatedAtInit:
     def test_main_model_only(self):
-        rails = _create_rails(BASE_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_input_rails_only(self):
-        rails = _create_rails(BASE_CONFIG + INPUT_RAILS_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG + INPUT_RAILS_CONFIG, llm_completions=["yes", "Hello!"])
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_output_rails_only(self):
-        rails = _create_rails(BASE_CONFIG + OUTPUT_RAILS_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG + OUTPUT_RAILS_CONFIG, llm_completions=["Hello!", "yes"])
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_input_output_rails(self):
-        rails = _create_rails(BASE_CONFIG + INPUT_OUTPUT_RAILS_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG + INPUT_OUTPUT_RAILS_CONFIG, llm_completions=["yes", "Hello!", "yes"])
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_passthrough(self):
-        rails = _create_rails(PASSTHROUGH_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(PASSTHROUGH_CONFIG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_user_definitions_only(self):
-        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, USER_DEFINITIONS)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_bot_definitions_only(self):
-        rails = _create_rails(BASE_CONFIG, BOT_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, BOT_DEFINITIONS)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_user_and_bot_definitions(self):
-        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_flow_definitions_only(self):
-        rails = _create_rails(BASE_CONFIG, FLOW_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, FLOW_DEFINITIONS)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_full_dialog_rails(self):
-        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
         assert actions.flows_index is None
 
     def test_input_rails_with_user_definitions(self):
-        rails = _create_rails(BASE_CONFIG + INPUT_RAILS_CONFIG, USER_DEFINITIONS)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG + INPUT_RAILS_CONFIG, USER_DEFINITIONS, llm_completions=["yes", "Hello!"])
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
@@ -213,16 +218,16 @@ class TestEmbeddingIndexesNotCreatedAtInit:
 
 class TestConfigDataPresent:
     def test_user_messages_present_in_config(self):
-        rails = _create_rails(BASE_CONFIG, USER_DEFINITIONS)
-        assert len(rails.config.user_messages) == 2
+        chat = _create_test_chat(BASE_CONFIG, USER_DEFINITIONS)
+        assert len(chat.app.config.user_messages) == 2
 
     def test_bot_messages_include_library_defaults(self):
-        rails = _create_rails(BASE_CONFIG)
-        assert len(rails.config.bot_messages) >= 9
+        chat = _create_test_chat(BASE_CONFIG)
+        assert len(chat.app.config.bot_messages) >= 9
 
     def test_non_system_flows_counted_correctly(self):
-        rails = _create_rails(BASE_CONFIG, FLOW_DEFINITIONS)
-        non_system = [f for f in rails.config.flows if not f.get("is_system_flow", False)]
+        chat = _create_test_chat(BASE_CONFIG, FLOW_DEFINITIONS)
+        non_system = [f for f in chat.app.config.flows if not f.get("is_system_flow", False)]
         assert len(non_system) == 2
 
 
@@ -292,6 +297,10 @@ class TestFastEmbedNotDownloadedForSimpleRails:
                 del os.environ["FASTEMBED_CACHE_PATH"]
 
 
+_has_fastembed = check_optional_dependency("fastembed")
+
+
+@pytest.mark.skipif(not _has_fastembed, reason="fastembed not installed")
 class TestFastEmbedDownloadedForDialogRails:
     def test_dialog_rails_cache_created_on_generate(self, tmp_path):
         import os
@@ -322,3 +331,57 @@ class TestFastEmbedDownloadedForDialogRails:
         finally:
             if "FASTEMBED_CACHE_PATH" in os.environ:
                 del os.environ["FASTEMBED_CACHE_PATH"]
+
+
+class TestConcurrentInitialization:
+    @pytest.mark.asyncio
+    async def test_concurrent_ensure_user_message_index_calls_init_once(self):
+        import asyncio
+
+        config = RailsConfig.from_content(
+            yaml_content=BASE_CONFIG,
+            colang_content=USER_DEFINITIONS,
+        )
+        chat = TestChat(config, llm_completions=["Hello!"])
+        actions = chat.app.llm_generation_actions
+
+        init_call_count = 0
+
+        async def counting_init():
+            nonlocal init_call_count
+            init_call_count += 1
+            await asyncio.sleep(0.05)
+            actions.user_message_index = "initialized"
+
+        actions._init_user_message_index = counting_init
+
+        tasks = [actions._ensure_user_message_index() for _ in range(10)]
+        await asyncio.gather(*tasks)
+
+        assert init_call_count == 1, f"Expected 1 init call, got {init_call_count}"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_ensure_flows_index_calls_init_once(self):
+        import asyncio
+
+        config = RailsConfig.from_content(
+            yaml_content=BASE_CONFIG,
+            colang_content=USER_DEFINITIONS + BOT_DEFINITIONS + FLOW_DEFINITIONS,
+        )
+        chat = TestChat(config, llm_completions=["Hello!"])
+        actions = chat.app.llm_generation_actions
+
+        init_call_count = 0
+
+        async def counting_init():
+            nonlocal init_call_count
+            init_call_count += 1
+            await asyncio.sleep(0.05)
+            actions.flows_index = "initialized"
+
+        actions._init_flows_index = counting_init
+
+        tasks = [actions._ensure_flows_index() for _ in range(10)]
+        await asyncio.gather(*tasks)
+
+        assert init_call_count == 1, f"Expected 1 init call, got {init_call_count}"

--- a/tests/v2_x/test_llm_embedding_lazy_init.py
+++ b/tests/v2_x/test_llm_embedding_lazy_init.py
@@ -15,10 +15,7 @@
 
 import textwrap
 
-import pytest
-
 from nemoguardrails import RailsConfig
-from nemoguardrails.imports import check_optional_dependency
 from tests.utils import TestChat
 
 BASE_CONFIG = textwrap.dedent("""
@@ -147,37 +144,20 @@ class TestFastEmbedNotDownloadedForSimpleRails:
                 del os.environ["FASTEMBED_CACHE_PATH"]
 
 
-_has_fastembed = check_optional_dependency("fastembed")
+class TestIndexInitializedAfterGenerate:
+    def test_user_message_index_initialized_after_generate(self):
+        config = RailsConfig.from_content(
+            yaml_content=BASE_CONFIG,
+            colang_content=DIALOG_COLANG,
+        )
+        chat = TestChat(
+            config,
+            llm_completions=["user expressed greeting"],
+        )
+        actions = chat.app.llm_generation_actions
 
+        assert actions.user_message_index is None, "Index should be None before generate"
 
-@pytest.mark.skipif(not _has_fastembed, reason="fastembed not installed")
-class TestFastEmbedDownloadedForDialogRails:
-    def test_dialog_rails_cache_created_on_generate(self, tmp_path):
-        import os
+        chat.app.generate(messages=[{"role": "user", "content": "hello"}])
 
-        cache_dir = tmp_path / "fastembed_cache"
-        cache_dir.mkdir()
-        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
-
-        try:
-            config = RailsConfig.from_content(
-                yaml_content=BASE_CONFIG,
-                colang_content=DIALOG_COLANG,
-            )
-            chat = TestChat(
-                config,
-                llm_completions=["user expressed greeting"],
-            )
-
-            cache_before = list(cache_dir.iterdir())
-            assert len(cache_before) == 0, "Cache should be empty before generate"
-
-            response = chat.app.generate(messages=[{"role": "user", "content": "hello"}])
-
-            assert response is not None
-
-            cache_after = list(cache_dir.iterdir())
-            assert len(cache_after) > 0, "FastEmbed cache should have models after generate with dialog rails"
-        finally:
-            if "FASTEMBED_CACHE_PATH" in os.environ:
-                del os.environ["FASTEMBED_CACHE_PATH"]
+        assert actions.user_message_index is not None, "Index should be initialized after generate"

--- a/tests/v2_x/test_llm_embedding_lazy_init.py
+++ b/tests/v2_x/test_llm_embedding_lazy_init.py
@@ -15,7 +15,10 @@
 
 import textwrap
 
-from nemoguardrails import LLMRails, RailsConfig
+import pytest
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.imports import check_optional_dependency
 from tests.utils import TestChat
 
 BASE_CONFIG = textwrap.dedent("""
@@ -70,18 +73,20 @@ DIALOG_COLANG = textwrap.dedent("""
 """)
 
 
-def _create_rails(yaml_content: str, colang_content: str = ""):
+def _create_test_chat(yaml_content: str, colang_content: str = "", llm_completions=None):
+    if llm_completions is None:
+        llm_completions = ["Hello!"]
     config = RailsConfig.from_content(
         yaml_content=yaml_content,
         colang_content=colang_content if colang_content else None,
     )
-    return LLMRails(config)
+    return TestChat(config, llm_completions=llm_completions)
 
 
 class TestEmbeddingIndexesNotCreatedAtInit:
     def test_main_model_only(self):
-        rails = _create_rails(BASE_CONFIG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, MINIMAL_COLANG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
@@ -89,8 +94,8 @@ class TestEmbeddingIndexesNotCreatedAtInit:
         assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
 
     def test_passthrough(self):
-        rails = _create_rails(PASSTHROUGH_CONFIG, PASSTHROUGH_COLANG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(PASSTHROUGH_CONFIG, PASSTHROUGH_COLANG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
@@ -98,8 +103,8 @@ class TestEmbeddingIndexesNotCreatedAtInit:
         assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
 
     def test_minimal_colang(self):
-        rails = _create_rails(BASE_CONFIG, MINIMAL_COLANG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, MINIMAL_COLANG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
@@ -107,8 +112,8 @@ class TestEmbeddingIndexesNotCreatedAtInit:
         assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
 
     def test_dialog_colang(self):
-        rails = _create_rails(BASE_CONFIG, DIALOG_COLANG)
-        actions = rails.llm_generation_actions
+        chat = _create_test_chat(BASE_CONFIG, DIALOG_COLANG)
+        actions = chat.app.llm_generation_actions
 
         assert actions.user_message_index is None
         assert actions.bot_message_index is None
@@ -142,6 +147,10 @@ class TestFastEmbedNotDownloadedForSimpleRails:
                 del os.environ["FASTEMBED_CACHE_PATH"]
 
 
+_has_fastembed = check_optional_dependency("fastembed")
+
+
+@pytest.mark.skipif(not _has_fastembed, reason="fastembed not installed")
 class TestFastEmbedDownloadedForDialogRails:
     def test_dialog_rails_cache_created_on_generate(self, tmp_path):
         import os

--- a/tests/v2_x/test_llm_embedding_lazy_init.py
+++ b/tests/v2_x/test_llm_embedding_lazy_init.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from nemoguardrails import LLMRails, RailsConfig
+from tests.utils import TestChat
+
+BASE_CONFIG = textwrap.dedent("""
+    colang_version: "2.x"
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o
+""")
+
+PASSTHROUGH_CONFIG = textwrap.dedent("""
+    colang_version: "2.x"
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o
+
+    passthrough: true
+""")
+
+PASSTHROUGH_COLANG = textwrap.dedent("""
+    import core
+    import llm
+
+    flow main
+        activate passthrough mode
+""")
+
+MINIMAL_COLANG = textwrap.dedent("""
+    import core
+    import llm
+
+    flow main
+        activate llm continuation
+""")
+
+DIALOG_COLANG = textwrap.dedent("""
+    import core
+    import llm
+
+    flow main
+        activate llm continuation
+        activate greeting
+
+    flow greeting
+        user expressed greeting
+        bot say "Hello! How can I help you?"
+
+    flow user expressed greeting
+        \"\"\"User expressed greeting in any way or form.\"\"\"
+        user said "hi"
+""")
+
+
+def _create_rails(yaml_content: str, colang_content: str = ""):
+    config = RailsConfig.from_content(
+        yaml_content=yaml_content,
+        colang_content=colang_content if colang_content else None,
+    )
+    return LLMRails(config)
+
+
+class TestEmbeddingIndexesNotCreatedAtInit:
+    def test_main_model_only(self):
+        rails = _create_rails(BASE_CONFIG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+        assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
+
+    def test_passthrough(self):
+        rails = _create_rails(PASSTHROUGH_CONFIG, PASSTHROUGH_COLANG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+        assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
+
+    def test_minimal_colang(self):
+        rails = _create_rails(BASE_CONFIG, MINIMAL_COLANG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+        assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
+
+    def test_dialog_colang(self):
+        rails = _create_rails(BASE_CONFIG, DIALOG_COLANG)
+        actions = rails.llm_generation_actions
+
+        assert actions.user_message_index is None
+        assert actions.bot_message_index is None
+        assert actions.flows_index is None
+        assert not hasattr(actions, "instruction_flows_index") or actions.instruction_flows_index is None
+
+
+class TestFastEmbedNotDownloadedForSimpleRails:
+    def test_passthrough_no_cache_created(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(
+                yaml_content=PASSTHROUGH_CONFIG,
+                colang_content=PASSTHROUGH_COLANG,
+            )
+            chat = TestChat(config, llm_completions=["Hello!"])
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "Hello"}])
+
+            assert response is not None
+
+            cache_contents = list(cache_dir.iterdir())
+            assert len(cache_contents) == 0, f"FastEmbed cache should be empty but found: {cache_contents}"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]
+
+
+class TestFastEmbedDownloadedForDialogRails:
+    def test_dialog_rails_cache_created_on_generate(self, tmp_path):
+        import os
+
+        cache_dir = tmp_path / "fastembed_cache"
+        cache_dir.mkdir()
+        os.environ["FASTEMBED_CACHE_PATH"] = str(cache_dir)
+
+        try:
+            config = RailsConfig.from_content(
+                yaml_content=BASE_CONFIG,
+                colang_content=DIALOG_COLANG,
+            )
+            chat = TestChat(
+                config,
+                llm_completions=["user expressed greeting"],
+            )
+
+            cache_before = list(cache_dir.iterdir())
+            assert len(cache_before) == 0, "Cache should be empty before generate"
+
+            response = chat.app.generate(messages=[{"role": "user", "content": "hello"}])
+
+            assert response is not None
+
+            cache_after = list(cache_dir.iterdir())
+            assert len(cache_after) > 0, "FastEmbed cache should have models after generate with dialog rails"
+        finally:
+            if "FASTEMBED_CACHE_PATH" in os.environ:
+                del os.environ["FASTEMBED_CACHE_PATH"]


### PR DESCRIPTION
## Description

Implements lazy initialization of embedding indexes (`user_message_index`, `bot_message_index`, `flows_index`, `instruction_flows_index`) so FastEmbed is only loaded when semantic search is actually needed.

Previously, embedding indexes were eagerly initialized at `LLMRails` construction time, causing FastEmbed models to be downloaded even for simple configurations that only use input/output rails or passthrough mode.

### Behavior by Configuration

| Configuration | Before | After |
|--------------|--------|-------|
| Input rails only (e.g., `self check input`) | Loads FastEmbed at init | No FastEmbed loaded |
| Output rails only (e.g., `self check output`) | Loads FastEmbed at init | No FastEmbed loaded |
| Input + Output rails | Loads FastEmbed at init | No FastEmbed loaded |
| Passthrough mode | Loads FastEmbed at init | No FastEmbed loaded |
| Dialog rails with user messages | Loads FastEmbed at init | Loads FastEmbed on first `generate()` |
| RAG with knowledge base | Loads FastEmbed at init | Unchanged (RAG has separate init) |

### Implementation

- Removed eager `init()` call from `LLMGenerationActions.__init__()`
- Added `_ensure_*_index()` helper methods for lazy initialization
- Actions call ensure methods before using indexes
- Same pattern applied to V2.x in `LLMGenerationActionsV2dotx`

## Test Plan

- [x] Added comprehensive tests for V1.0 (`tests/test_actions_llm_embedding_lazy_init.py`)
- [x] Added comprehensive tests for V2.x (`tests/v2_x/test_llm_embedding_lazy_init.py`)
- [x] Tests verify indexes are `None` at initialization
- [x] Tests verify FastEmbed cache stays empty for simple configs
- [x] Tests verify FastEmbed IS downloaded when dialog rails are used

