### PR TITLE
fix(bot-thinking): tackle bug with reasoning trace leak across llm calls

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -339,8 +339,10 @@ def _store_reasoning_traces(response) -> None:
         # both extraction methods to support different provider implementations.
         reasoning_content = _extract_and_remove_think_tags(response)
 
-    if reasoning_content:
-        reasoning_trace_var.set(reasoning_content)
+    # Always set the variable, even if reasoning_content is None.
+    # This ensures each LLM call has a clean slate and prevents stale reasoning
+    # traces from previous LLM calls (e.g., safety checks) from leaking through.
+    reasoning_trace_var.set(reasoning_content)
 
 
 def _extract_reasoning_from_content_blocks(response) -> Optional[str]:

--- a/tests/test_reasoning_trace_extraction.py
+++ b/tests/test_reasoning_trace_extraction.py
@@ -129,6 +129,27 @@ class TestStoreReasoningTracesUnit:
 
         reasoning_trace_var.set(None)
 
+    def test_store_reasoning_traces_clears_previous_when_no_new_reasoning(self):
+        """Test that previous reasoning traces are cleared when new response has no reasoning.
+
+        This prevents stale reasoning from previous LLM calls (e.g., safety checks)
+        from leaking into subsequent responses.
+        """
+        # Set up a previous reasoning trace (simulating a safety check)
+        previous_trace = "Previous safety check reasoning that should be cleared"
+        reasoning_trace_var.set(previous_trace)
+
+        # Simulate a response with NO reasoning content (like from gpt-4o-mini)
+        response = AIMessage(content="Regular response without reasoning", additional_kwargs={})
+
+        _store_reasoning_traces(response)
+
+        # The previous trace should be cleared, not persist
+        stored_trace = reasoning_trace_var.get()
+        assert stored_trace is None, "Previous reasoning trace should be cleared when new response has no reasoning"
+
+        reasoning_trace_var.set(None)
+
     def test_store_reasoning_traces_with_multiline_content(self):
         multiline_reasoning = """Thought process:
 1. First, understand the user's intent


### PR DESCRIPTION
## Description

This PR fixes a bug where reasoning traces from internal LLM calls (such as content safety checks) were leaking into the user-facing bot response.

###The Problem

When using reasoning-capable models for content safety checks (e.g., nvidia/Nemotron-Content-Safety-Reasoning-4B), the <think> reasoning traces from the safety model were incorrectly being prepended to the final bot response. 

For example:
```<think>The human user's request is unharmful...</think>I can do quite a bit! Here are some of the things I can help you with...```

The `_store_reasoning_traces()` function in `nemoguardrails/actions/llm/utils.py` only sets `reasoning_trace_var` when new reasoning content is found, but **does not clear it** when no reasoning is found. This causes:

1. Input safety rail runs → content safety model stores its reasoning in `reasoning_trace_var`
2. Main LLM (e.g., `gpt-4o-mini`) runs → doesn't produce reasoning → `reasoning_trace_var` **still contains stale safety model reasoning**
3. `generate_bot_message` retrieves this stale reasoning and creates a `BotThinking` event with the wrong content
4. Final output includes the safety model's reasoning prepended to the actual response

### The Fix

Always set `reasoning_trace_var` in `_store_reasoning_traces()`, even when `reasoning_content` is `None`. This ensures each LLM call starts with a clean slate and prevents stale reasoning traces from leaking through.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA/NeMo-Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
