### PR TITLE
fix(providers): handle langchain 1.2.1 dict type for _SUPPORTED_PROVIDERS

### DIFF
--- a/nemoguardrails/llm/providers/providers.py
+++ b/nemoguardrails/llm/providers/providers.py
@@ -88,6 +88,8 @@ _CUSTOM_CHAT_PROVIDERS = {"nim"}
 def _discover_langchain_partner_chat_providers() -> Set[str]:
     from langchain.chat_models.base import _SUPPORTED_PROVIDERS
 
+    if isinstance(_SUPPORTED_PROVIDERS, dict):
+        return set(_SUPPORTED_PROVIDERS.keys()) | _CUSTOM_CHAT_PROVIDERS
     return _SUPPORTED_PROVIDERS | _CUSTOM_CHAT_PROVIDERS
 
 


### PR DESCRIPTION
Fixes [failing job](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/20797939918)
- Fix compatibility with langchain 1.2.1 where `_SUPPORTED_PROVIDERS` changed from `set` to `dict`
- Add type check to extract keys when dict is encountered

See:
https://github.com/langchain-ai/langchain/releases/tag/langchain%3D%3D1.2.1


The job passes on this branch: https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/21177710938
