### PR TITLE
chore(deps): bump marshmallow to 3.26.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2388,13 +2388,13 @@ files = [
 
 [[package]]
 name = "marshmallow"
-version = "3.26.1"
+version = "3.26.2"
 description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c"},
-    {file = "marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6"},
+    {file = "marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73"},
+    {file = "marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Bumps marshmallow from 3.26.1 to 3.26.2.

This release fixes CVE-2025-68480 by merging error store messages without rebuilding collections. See the changelog for details: https://github.com/marshmallow-code/marshmallow/blob/3.26.2/CHANGELOG.rst


https://github.com/NVIDIA-NeMo/Guardrails/pull/1556