### PR TITLE
feat(llmrails): add check_async method for input/output rails validation

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1482,7 +1482,8 @@ class LLMRails:
             last_content = messages[-1].get("content", "") if messages else ""
             return RailsResult(status=RailStatus.PASSED, content=last_content)
 
-        original_content = _get_last_user_or_assistant_content(messages)
+        target_role = "assistant" if "output" in options["rails"] else "user"
+        original_content = _get_content_by_role(messages, target_role)
         messages = _normalize_messages_for_rails(messages, options["rails"])
         options["log"] = {"activated_rails": True}
 
@@ -1860,6 +1861,13 @@ def _normalize_messages_for_rails(
 def _get_last_user_or_assistant_content(messages: List[dict]) -> str:
     for msg in reversed(messages):
         if msg.get("role") in ("user", "assistant"):
+            return msg.get("content", "")
+    return ""
+
+
+def _get_content_by_role(messages: List[dict], role: str) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") == role:
             return msg.get("content", "")
     return ""
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -96,6 +96,8 @@ from nemoguardrails.rails.llm.options import (
     GenerationLog,
     GenerationOptions,
     GenerationResponse,
+    RailsResult,
+    RailStatus,
 )
 from nemoguardrails.rails.llm.utils import (
     get_action_details_from_flow_id,
@@ -1443,6 +1445,61 @@ class LLMRails:
         loop = get_or_create_event_loop()
         return loop.run_until_complete(self.process_events_async(events, state, blocking))
 
+    async def check_async(self, messages: List[dict]) -> RailsResult:
+        """Run rails on messages based on their content (asynchronous).
+
+        Automatically determines which rails to run:
+        - Only user messages: runs input rails
+        - Only assistant messages: runs output rails
+        - Both user and assistant messages: runs both input and output rails
+        - No user/assistant messages: logs warning and returns passing result
+
+        Args:
+            messages: List of message dicts with 'role' and 'content' fields.
+                     Supported roles: user, assistant, system, context, tool.
+
+        Returns:
+            RailsResult containing:
+            - status: PASSED, MODIFIED, or BLOCKED
+            - content: The final content after rails processing
+            - rail: Name of the rail that blocked (if blocked)
+
+        Examples:
+            Check user input:
+                result = await rails.check_async([{"role": "user", "content": "Hello!"}])
+                if result.status == RailStatus.BLOCKED:
+                    print(f"Blocked by: {result.rail}")
+
+            Check bot output with context:
+                result = await rails.check_async([
+                    {"role": "user", "content": "Hello!"},
+                    {"role": "assistant", "content": "Hi there!"}
+                ])
+        """
+        options = _determine_rails_from_messages(messages)
+
+        if options is None:
+            last_content = messages[-1].get("content", "") if messages else ""
+            return RailsResult(status=RailStatus.PASSED, content=last_content)
+
+        original_content = _get_last_user_or_assistant_content(messages)
+        messages = _normalize_messages_for_rails(messages, options["rails"])
+        options["log"] = {"activated_rails": True}
+
+        response = await self.generate_async(messages=messages, options=options)
+
+        if not isinstance(response, GenerationResponse):
+            raise RuntimeError(f"Expected GenerationResponse, got {type(response).__name__}")
+
+        blocking_rail = _get_blocking_rail(response)
+        result_content = _get_response_content(response)
+
+        if blocking_rail:
+            return RailsResult(status=RailStatus.BLOCKED, content=result_content, rail=blocking_rail)
+        if result_content != original_content:
+            return RailsResult(status=RailStatus.MODIFIED, content=result_content)
+        return RailsResult(status=RailStatus.PASSED, content=result_content)
+
     def register_action(self, action: Callable, name: Optional[str] = None) -> Self:
         """Register a custom action for the rails configuration."""
         self.runtime.register_action(action, name)
@@ -1766,3 +1823,58 @@ class LLMRails:
                 # yield the individual chunks directly from the buffer strategy
                 for chunk in user_output_chunks:
                     yield chunk
+
+
+def _determine_rails_from_messages(messages: List[dict]) -> Optional[dict]:
+    roles = {msg.get("role") for msg in reversed(messages)}
+    has_user = "user" in roles
+    has_assistant = "assistant" in roles
+
+    if not has_user and not has_assistant:
+        log.warning(
+            "check() called with no user or assistant messages. "
+            "Only system, context, or tool messages found. "
+            "Returning passing result without running rails."
+        )
+        return None
+
+    if has_user and has_assistant:
+        return {"rails": ["input", "output"]}
+    if has_user:
+        return {"rails": ["input"]}
+    return {"rails": ["output"]}
+
+
+def _normalize_messages_for_rails(
+    messages: List[dict],
+    rails: List[str],
+) -> List[dict]:
+    if rails == ["output"]:
+        has_user = any(msg.get("role") == "user" for msg in messages)
+        if not has_user:
+            return [{"role": "user", "content": ""}] + messages
+
+    return messages
+
+
+def _get_last_user_or_assistant_content(messages: List[dict]) -> str:
+    for msg in reversed(messages):
+        if msg.get("role") in ("user", "assistant"):
+            return msg.get("content", "")
+    return ""
+
+
+def _get_blocking_rail(response: "GenerationResponse") -> Optional[str]:
+    if response.log and response.log.activated_rails:
+        for rail in response.log.activated_rails:
+            if rail.stop:
+                return rail.name
+    return None
+
+
+def _get_response_content(response: "GenerationResponse") -> str:
+    if isinstance(response.response, list) and response.response:
+        return response.response[-1].get("content", "")
+    if isinstance(response.response, str):
+        return response.response
+    return ""

--- a/nemoguardrails/rails/llm/options.py
+++ b/nemoguardrails/rails/llm/options.py
@@ -77,11 +77,24 @@ To get more details on the LLM calls that were executed, including the raw respo
 
 """
 
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, root_validator
 
 from nemoguardrails.logging.explain import LLMCallInfo
+
+
+class RailStatus(str, Enum):
+    PASSED = "passed"
+    MODIFIED = "modified"
+    BLOCKED = "blocked"
+
+
+class RailsResult(BaseModel):
+    status: RailStatus = Field(description="Status of the rails check: passed, modified, or blocked.")
+    content: str = Field(description="The content after rails processing.")
+    rail: Optional[str] = Field(default=None, description="Name of the rail that blocked or modified the content.")
 
 
 class GenerationLogOptions(BaseModel):

--- a/tests/test_llmrails_check_async.py
+++ b/tests/test_llmrails_check_async.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import LLMRails, RailsConfig
+from nemoguardrails.rails.llm.llmrails import (
+    _determine_rails_from_messages,
+    _get_blocking_rail,
+    _get_last_user_or_assistant_content,
+    _get_response_content,
+    _normalize_messages_for_rails,
+)
+from nemoguardrails.rails.llm.options import ActivatedRail, GenerationLog, GenerationResponse, RailStatus
+
+
+class TestDetermineRailsFromMessages:
+    def test_empty_messages_returns_none(self, caplog):
+        result = _determine_rails_from_messages([])
+        assert result is None
+        assert "check() called with no user or assistant messages" in caplog.text
+
+    def test_user_only_returns_input_rails(self):
+        messages = [{"role": "user", "content": "hello"}]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["input"]}
+
+    def test_assistant_only_returns_output_rails(self):
+        messages = [{"role": "assistant", "content": "hello"}]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["output"]}
+
+    def test_user_and_assistant_returns_both_rails(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["input", "output"]}
+
+    def test_only_system_messages_returns_none(self, caplog):
+        messages = [{"role": "system", "content": "You are helpful."}]
+        result = _determine_rails_from_messages(messages)
+        assert result is None
+        assert "check() called with no user or assistant messages" in caplog.text
+
+    def test_only_context_messages_returns_none(self, caplog):
+        messages = [{"role": "context", "content": {"key": "value"}}]
+        result = _determine_rails_from_messages(messages)
+        assert result is None
+
+    def test_only_tool_messages_returns_none(self, caplog):
+        messages = [{"role": "tool", "content": "tool output", "tool_call_id": "123"}]
+        result = _determine_rails_from_messages(messages)
+        assert result is None
+
+    def test_system_and_user_returns_input_rails(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hello"},
+        ]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["input"]}
+
+    def test_system_and_assistant_returns_output_rails(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["output"]}
+
+    def test_multiple_users_returns_input_rails(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "user", "content": "hello again"},
+        ]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["input"]}
+
+    def test_complex_conversation_returns_both_rails(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "how are you?"},
+            {"role": "assistant", "content": "I'm fine"},
+        ]
+        result = _determine_rails_from_messages(messages)
+        assert result == {"rails": ["input", "output"]}
+
+
+class TestNormalizeMessagesForRails:
+    def test_input_rails_returns_unchanged(self):
+        messages = [{"role": "user", "content": "hello"}]
+        result = _normalize_messages_for_rails(messages, ["input"])
+        assert result == messages
+
+    def test_output_rails_with_user_returns_unchanged(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = _normalize_messages_for_rails(messages, ["output"])
+        assert result == messages
+
+    def test_output_rails_without_user_adds_empty_user(self):
+        messages = [{"role": "assistant", "content": "hello"}]
+        result = _normalize_messages_for_rails(messages, ["output"])
+        assert len(result) == 2
+        assert result[0] == {"role": "user", "content": ""}
+        assert result[1] == messages[0]
+
+    def test_both_rails_returns_unchanged(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = _normalize_messages_for_rails(messages, ["input", "output"])
+        assert result == messages
+
+    def test_output_rails_with_system_only_adds_empty_user(self):
+        messages = [
+            {"role": "system", "content": "Be helpful"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        result = _normalize_messages_for_rails(messages, ["output"])
+        assert len(result) == 3
+        assert result[0] == {"role": "user", "content": ""}
+
+
+class TestGetLastUserOrAssistantContent:
+    def test_single_user_message(self):
+        messages = [{"role": "user", "content": "hello"}]
+        assert _get_last_user_or_assistant_content(messages) == "hello"
+
+    def test_single_assistant_message(self):
+        messages = [{"role": "assistant", "content": "hi there"}]
+        assert _get_last_user_or_assistant_content(messages) == "hi there"
+
+    def test_user_and_assistant_returns_last(self):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        assert _get_last_user_or_assistant_content(messages) == "hi there"
+
+    def test_assistant_then_user_returns_user(self):
+        messages = [
+            {"role": "assistant", "content": "hi there"},
+            {"role": "user", "content": "hello"},
+        ]
+        assert _get_last_user_or_assistant_content(messages) == "hello"
+
+    def test_only_system_returns_empty(self):
+        messages = [{"role": "system", "content": "Be helpful"}]
+        assert _get_last_user_or_assistant_content(messages) == ""
+
+    def test_empty_messages_returns_empty(self):
+        assert _get_last_user_or_assistant_content([]) == ""
+
+    def test_system_before_user(self):
+        messages = [
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "hello"},
+        ]
+        assert _get_last_user_or_assistant_content(messages) == "hello"
+
+    def test_missing_content_returns_empty(self):
+        messages = [{"role": "user"}]
+        assert _get_last_user_or_assistant_content(messages) == ""
+
+
+class TestGetBlockingRail:
+    def test_no_log_returns_none(self):
+        response = GenerationResponse(response="hello")
+        response.log = None
+        assert _get_blocking_rail(response) is None
+
+    def test_empty_activated_rails_returns_none(self):
+        response = GenerationResponse(response="hello")
+        response.log = GenerationLog(activated_rails=[])
+        assert _get_blocking_rail(response) is None
+
+    def test_no_blocking_rail_returns_none(self):
+        response = GenerationResponse(response="hello")
+        rail = ActivatedRail(type="input", name="test rail", stop=False)
+        response.log = GenerationLog(activated_rails=[rail])
+        assert _get_blocking_rail(response) is None
+
+    def test_blocking_rail_returns_name(self):
+        response = GenerationResponse(response="hello")
+        rail = ActivatedRail(type="input", name="content safety", stop=True)
+        response.log = GenerationLog(activated_rails=[rail])
+        assert _get_blocking_rail(response) == "content safety"
+
+    def test_multiple_rails_returns_first_blocking(self):
+        response = GenerationResponse(response="hello")
+        rail1 = ActivatedRail(type="input", name="rail1", stop=False)
+        rail2 = ActivatedRail(type="input", name="rail2", stop=True)
+        rail3 = ActivatedRail(type="output", name="rail3", stop=True)
+        response.log = GenerationLog(activated_rails=[rail1, rail2, rail3])
+        assert _get_blocking_rail(response) == "rail2"
+
+
+class TestGetResponseContent:
+    def test_string_response(self):
+        response = GenerationResponse(response="hello world")
+        assert _get_response_content(response) == "hello world"
+
+    def test_list_response_with_content(self):
+        response = GenerationResponse(response=[{"role": "assistant", "content": "hello"}])
+        assert _get_response_content(response) == "hello"
+
+    def test_list_response_multiple_messages(self):
+        response = GenerationResponse(
+            response=[
+                {"role": "assistant", "content": "first"},
+                {"role": "assistant", "content": "second"},
+            ]
+        )
+        assert _get_response_content(response) == "second"
+
+    def test_empty_list_response(self):
+        response = GenerationResponse(response=[])
+        assert _get_response_content(response) == ""
+
+    def test_list_response_missing_content(self):
+        response = GenerationResponse(response=[{"role": "assistant"}])
+        assert _get_response_content(response) == ""
+
+
+@pytest.fixture
+def mock_rails():
+    config = RailsConfig.from_content(
+        """
+        define flow input rail
+          if $user_message == "block"
+            bot refuse to respond
+            stop
+          else if $user_message == "modify"
+            $user_message = "modified input"
+
+        define flow output rail
+          if $bot_message == "block output"
+            bot refuse to respond
+            stop
+          else if $bot_message == "modify output"
+            $bot_message = "modified output"
+        """,
+        """
+        rails:
+            input:
+                flows:
+                    - input rail
+            output:
+                flows:
+                    - output rail
+        """,
+    )
+    return LLMRails(config)
+
+
+class TestCheckAsyncIntegration:
+    @pytest.mark.asyncio
+    async def test_input_passed(self, mock_rails):
+        messages = [{"role": "user", "content": "hello"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+        assert result.content == "hello"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_input_blocked(self, mock_rails):
+        messages = [{"role": "user", "content": "block"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.BLOCKED
+        assert result.rail is not None
+
+    @pytest.mark.asyncio
+    async def test_input_modified(self, mock_rails):
+        messages = [{"role": "user", "content": "modify"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == "modified input"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_output_passed(self, mock_rails):
+        messages = [{"role": "assistant", "content": "hello"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+        assert result.content == "hello"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_output_blocked(self, mock_rails):
+        messages = [{"role": "assistant", "content": "block output"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.BLOCKED
+        assert result.rail is not None
+
+    @pytest.mark.asyncio
+    async def test_output_modified(self, mock_rails):
+        messages = [{"role": "assistant", "content": "modify output"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.MODIFIED
+        assert result.content == "modified output"
+        assert result.rail is None
+
+    @pytest.mark.asyncio
+    async def test_input_output_both_passed(self, mock_rails):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_input_output_input_blocked(self, mock_rails):
+        messages = [
+            {"role": "user", "content": "block"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_input_output_output_blocked(self, mock_rails):
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "block output"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.BLOCKED
+
+    @pytest.mark.asyncio
+    async def test_no_user_or_assistant_returns_passed(self, mock_rails):
+        messages = [{"role": "system", "content": "Be helpful"}]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+        assert result.content == "Be helpful"
+
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_passed(self, mock_rails):
+        result = await mock_rails.check_async([])
+        assert result.status == RailStatus.PASSED
+        assert result.content == ""
+
+    @pytest.mark.asyncio
+    async def test_with_system_and_user(self, mock_rails):
+        messages = [
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "hello"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_with_context_and_user(self, mock_rails):
+        messages = [
+            {"role": "context", "content": {"key": "value"}},
+            {"role": "user", "content": "hello"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+
+    @pytest.mark.asyncio
+    async def test_complex_conversation(self, mock_rails):
+        messages = [
+            {"role": "system", "content": "Be helpful"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "how are you"},
+            {"role": "assistant", "content": "fine"},
+        ]
+        result = await mock_rails.check_async(messages)
+        assert result.status == RailStatus.PASSED
+        assert result.content == "fine"


### PR DESCRIPTION
## Description

Add a new `check_async` method to `LLMRails` that allows standalone validation of messages against input/output rails without requiring a full conversation flow.

**Key features:**
- Automatically determines which rails to run based on message roles:
  - User messages only → input rails
  - Assistant messages only → output rails
  - Both user and assistant → input and output rails
- Returns a simple `RailsResult` with status (PASSED/MODIFIED/BLOCKED), content, and blocking rail name
