### PR TITLE
chore: update Pangea User-Agent repo URL (#1595)

### DIFF
--- a/nemoguardrails/library/pangea/actions.py
+++ b/nemoguardrails/library/pangea/actions.py
@@ -108,7 +108,7 @@ async def pangea_ai_guard(
                 "Accept": "application/json",
                 "Authorization": f"Bearer {pangea_api_token}",
                 "Content-Type": "application/json",
-                "User-Agent": "NeMo Guardrails (https://github.com/NVIDIA/NeMo-Guardrails)",
+                "User-Agent": "NeMo Guardrails (https://github.com/NVIDIA-NeMo/Guardrails)",
             },
         )
         try:


### PR DESCRIPTION
Update repository URL in Pangea integration User-Agent header.

## Description

This PR updates the remaining reference to the old repository URL in the Pangea integration User-Agent header.
Only the `User-Agent` header string in `nemoguardrails/library/pangea/actions.py` is changed to point to `https://github.com/NVIDIA-NeMo/Guardrails`.

## Related Issue(s)

Fixes #1595.

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
  - @tgasser-nv @trebedea
