### PR TITLE
fix(library): add `valid` alias to action results in GuardrailsAI integration (#1578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - *(llm)* Filter temperature parameter for OpenAI reasoning models ([#1526](https://github.com/NVIDIA-NeMo/Guardrails/issues/1526))
 - *(bot-thinking)* Tackle bug with reasoning trace leak across llm calls ([#1582](https://github.com/NVIDIA-NeMo/Guardrails/issues/1582))
 - *(providers)* Handle langchain 1.2.1 dict type for _SUPPORTED_PROVIDERS ([#1589](https://github.com/NVIDIA-NeMo/Guardrails/issues/1589))
+- *(guardrails_ai)* Add `valid` alias to action results for Colang flows
 
 ### 🚜 Refactor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - *(llm)* Filter temperature parameter for OpenAI reasoning models ([#1526](https://github.com/NVIDIA-NeMo/Guardrails/issues/1526))
 - *(bot-thinking)* Tackle bug with reasoning trace leak across llm calls ([#1582](https://github.com/NVIDIA-NeMo/Guardrails/issues/1582))
 - *(providers)* Handle langchain 1.2.1 dict type for _SUPPORTED_PROVIDERS ([#1589](https://github.com/NVIDIA-NeMo/Guardrails/issues/1589))
-- *(guardrails_ai)* Add `valid` alias to action results for Colang flows
 
 ### 🚜 Refactor
 

--- a/docs/user-guides/community/guardrails-ai.md
+++ b/docs/user-guides/community/guardrails-ai.md
@@ -72,6 +72,13 @@ rails:
       - guardrailsai check output $validator="restricttotopic"
 ```
 
+### Result Format in Colang Flows
+
+The GuardrailsAI actions (`validate_guardrails_ai_input` and `validate_guardrails_ai_output`) return a dict that is stored in `$result` when used in flows. This dict contains:
+
+- **`validation_result`**: The raw GuardrailsAI validation outcome (e.g., `PassResult` or `FailResult`).
+- **`valid`**: A boolean derived from the GuardrailsAI `validation_passed` field. Use this in flow conditions such as `if not $result["valid"]` to decide whether to block.
+
 ## Built-in Validators
 
 The integration includes support for the following validators that are pre-registered in the NeMo Guardrails validator registry. For detailed parameter specifications and usage examples, refer to the official [GuardrailsAI Hub](https://hub.guardrailsai.com/) documentation for each validator:

--- a/nemoguardrails/library/guardrails_ai/actions.py
+++ b/nemoguardrails/library/guardrails_ai/actions.py
@@ -107,7 +107,7 @@ def validate_guardrails_ai_input(
         context: Optional context dictionary
 
     Returns:
-        Dict with validation_result
+        Dict with validation_result and valid (bool derived from validation_passed).
     """
 
     text = text or context.get("user_message", "")
@@ -120,10 +120,11 @@ def validate_guardrails_ai_input(
 
     joined_parameters = {**parameters, **metadata}
 
-    validation_result = validate_guardrails_ai(validator, text, **joined_parameters)
+    result = validate_guardrails_ai(validator, text, **joined_parameters)
+    valid = guardrails_ai_validation_mapping(result)
 
-    # Transform to the expected format for Colang flows
-    return validation_result
+    # Return both validation_result and valid for backward compatibility with Colang flows
+    return {**result, "valid": valid}
 
 
 @action(
@@ -146,7 +147,7 @@ def validate_guardrails_ai_output(
         context: Optional context dictionary
 
     Returns:
-        Dict with validation_result
+        Dict with validation_result and valid (bool derived from validation_passed).
     """
 
     text = text or context.get("bot_message", "")
@@ -160,9 +161,11 @@ def validate_guardrails_ai_output(
     # join parameters and metadata into a single dict
     joined_parameters = {**parameters, **metadata}
 
-    validation_result = validate_guardrails_ai(validator, text, **joined_parameters)
+    result = validate_guardrails_ai(validator, text, **joined_parameters)
+    valid = guardrails_ai_validation_mapping(result)
 
-    return validation_result
+    # Return both validation_result and valid for backward compatibility with Colang flows
+    return {**result, "valid": valid}
 
 
 def validate_guardrails_ai(validator_name: str, text: str, **kwargs) -> Dict[str, Any]:

--- a/tests/test_guardrails_ai_actions.py
+++ b/tests/test_guardrails_ai_actions.py
@@ -95,9 +95,7 @@ class TestGuardrailsAIIntegration:
         mock_get_guard.return_value = mock_guard
 
         mock_config = Mock()
-        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(
-            parameters={}, metadata={}
-        )
+        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(parameters={}, metadata={})
 
         result = validate_guardrails_ai_input(
             validator="toxic_language",
@@ -122,9 +120,7 @@ class TestGuardrailsAIIntegration:
         mock_get_guard.return_value = mock_guard
 
         mock_config = Mock()
-        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(
-            parameters={}, metadata={}
-        )
+        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(parameters={}, metadata={})
 
         result = validate_guardrails_ai_output(
             validator="toxic_language",

--- a/tests/test_guardrails_ai_actions.py
+++ b/tests/test_guardrails_ai_actions.py
@@ -84,6 +84,60 @@ class TestGuardrailsAIIntegration:
         assert mapped3 is True
 
     @patch("nemoguardrails.library.guardrails_ai.actions._get_guard")
+    def test_validate_guardrails_ai_input_returns_valid_key(self, mock_get_guard):
+        """Test that validate_guardrails_ai_input returns both validation_result and valid."""
+        from nemoguardrails.library.guardrails_ai.actions import validate_guardrails_ai_input
+
+        mock_guard = Mock()
+        mock_validation_result = Mock()
+        mock_validation_result.validation_passed = True
+        mock_guard.validate.return_value = mock_validation_result
+        mock_get_guard.return_value = mock_guard
+
+        mock_config = Mock()
+        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(
+            parameters={}, metadata={}
+        )
+
+        result = validate_guardrails_ai_input(
+            validator="toxic_language",
+            config=mock_config,
+            text="Hello, this is safe",
+        )
+
+        assert "validation_result" in result
+        assert "valid" in result
+        assert result["validation_result"] == mock_validation_result
+        assert result["valid"] is True
+
+    @patch("nemoguardrails.library.guardrails_ai.actions._get_guard")
+    def test_validate_guardrails_ai_output_returns_valid_key(self, mock_get_guard):
+        """Test that validate_guardrails_ai_output returns both validation_result and valid."""
+        from nemoguardrails.library.guardrails_ai.actions import validate_guardrails_ai_output
+
+        mock_guard = Mock()
+        mock_validation_result = Mock()
+        mock_validation_result.validation_passed = False
+        mock_guard.validate.return_value = mock_validation_result
+        mock_get_guard.return_value = mock_guard
+
+        mock_config = Mock()
+        mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(
+            parameters={}, metadata={}
+        )
+
+        result = validate_guardrails_ai_output(
+            validator="toxic_language",
+            config=mock_config,
+            text="Blocked content",
+        )
+
+        assert "validation_result" in result
+        assert "valid" in result
+        assert result["validation_result"] == mock_validation_result
+        assert result["valid"] is False
+
+    @patch("nemoguardrails.library.guardrails_ai.actions._get_guard")
     def test_validate_guardrails_ai_success(self, mock_get_guard):
         """Test successful validation with current interface."""
         from nemoguardrails.library.guardrails_ai.actions import validate_guardrails_ai

--- a/tests/test_guardrails_ai_e2e_actions.py
+++ b/tests/test_guardrails_ai_e2e_actions.py
@@ -19,6 +19,8 @@ These tests run against actual Guardrails validators when installed.
 They can be skipped in CI/environments where validators aren't available.
 """
 
+from unittest.mock import Mock
+
 import pytest
 
 from nemoguardrails.imports import check_optional_dependency
@@ -147,7 +149,7 @@ class TestGuardrailsAIE2EIntegration:
 
     @pytest.mark.skipif(not GUARDRAILS_AVAILABLE, reason="Guardrails not installed")
     def test_validation_mapping_e2e(self):
-        """E2E test: Validation mapping with real validation results."""
+        """E2E test: Validation mapping returns boolean (validation_passed)."""
         from nemoguardrails.library.guardrails_ai.actions import (
             guardrails_ai_validation_mapping,
             validate_guardrails_ai,
@@ -162,8 +164,7 @@ class TestGuardrailsAIE2EIntegration:
             )
 
             mapped = guardrails_ai_validation_mapping(result)
-            assert mapped["valid"] is True
-            assert "validation_result" in mapped
+            assert mapped is True
 
             result_fail = validate_guardrails_ai(
                 validator_name="regex_match",
@@ -173,7 +174,39 @@ class TestGuardrailsAIE2EIntegration:
             )
 
             mapped_fail = guardrails_ai_validation_mapping(result_fail)
-            assert mapped_fail["valid"] is False
+            assert mapped_fail is False
+
+    @pytest.mark.skipif(not GUARDRAILS_AVAILABLE, reason="Guardrails not installed")
+    def test_action_returns_valid_for_colang_flows_e2e(self):
+        """E2E test: Actions return both validation_result and valid for Colang flows."""
+        from nemoguardrails.library.guardrails_ai.actions import (
+            validate_guardrails_ai_input,
+            validate_guardrails_ai_output,
+        )
+
+        if VALIDATORS_AVAILABLE.get("regex_match", False):
+            mock_config = Mock()
+            mock_config.rails.config.guardrails_ai.get_validator_config.return_value = Mock(
+                parameters={"regex": "^[A-Z].*", "on_fail": "noop"}, metadata={}
+            )
+
+            result_input = validate_guardrails_ai_input(
+                validator="regex_match",
+                config=mock_config,
+                text="Hello world",
+            )
+            assert "validation_result" in result_input
+            assert "valid" in result_input
+            assert result_input["valid"] is True
+
+            result_output = validate_guardrails_ai_output(
+                validator="regex_match",
+                config=mock_config,
+                text="hello world",
+            )
+            assert "validation_result" in result_output
+            assert "valid" in result_output
+            assert result_output["valid"] is False
 
     @pytest.mark.skipif(not GUARDRAILS_AVAILABLE, reason="Guardrails not installed")
     def test_metadata_parameter_e2e(self):


### PR DESCRIPTION

## Related Issues

- Fixes #1578

## Summary

This PR fixes a mismatch between the GuardrailsAI actions and the
GuardrailsAI Colang flows:

- Colang flows (`nemoguardrails/library/guardrails_ai/flows.co` and `flows.v1.co`)
  expect `$result["valid"]` when deciding whether to block.
- GuardrailsAI actions (`validate_guardrails_ai_input` /
  `validate_guardrails_ai_output`) previously returned only
  `{"validation_result": <ValidationOutcome>}` without a `valid` key.
- At runtime, the raw action return is stored in `$result`, while
  `output_mapping` is only used by `is_output_blocked()`. As a result,
  `$result` contained `validation_result` (with `validation_passed` in
  GuardrailsAI ≥ 0.3) but no `valid` key, leading to `KeyError: 'valid'`
  when flows evaluated `$result["valid"]`.

## What this PR changes

1. **GuardrailsAI actions**

   File: `nemoguardrails/library/guardrails_ai/actions.py`

   - `validate_guardrails_ai_input` and `validate_guardrails_ai_output` now:

     ```python
     result = validate_guardrails_ai(validator, text, **joined_parameters)
     valid = guardrails_ai_validation_mapping(result)
     return {**result, "valid": valid}
     ```

   - `validate_guardrails_ai` continues to return a dict with a single
     `validation_result` key, so passing its result into
     `guardrails_ai_validation_mapping` is safe.

   This makes `$result["valid"]` available in Colang flows while preserving
   `validation_result` unchanged.

2. **Tests**

   Files:

   - `tests/test_guardrails_ai_actions.py`
   - `tests/test_guardrails_ai_e2e_actions.py`

   Updates:

   - Add unit tests to assert that `validate_guardrails_ai_input` and
     `validate_guardrails_ai_output` return both `validation_result` and
     `valid`, with `valid` reflecting the GuardrailsAI `validation_passed`
     outcome.
   - Align `test_validation_mapping_e2e` with the contract of
     `guardrails_ai_validation_mapping` (returns a boolean).
   - Add an e2e-style test to verify that the actions return a dict with
     `validation_result` and `valid` suitable for use in Colang flows.

3. **Docs**

   File: `docs/user-guides/community/guardrails-ai.md`

   - Add a short **“Result Format in Colang Flows”** section explaining that
     GuardrailsAI actions return a dict stored in `$result` with:
     - `validation_result`: raw GuardrailsAI outcome.
     - `valid`: boolean derived from `validation_passed`, intended for
       conditions like `if not $result["valid"]`.

4. **Changelog**

   File: `CHANGELOG.md`

   - Under `## [0.20.0]` → `### 🐛 Bug Fixes`:

     ```markdown
     - *(guardrails_ai)* Add `valid` alias to action results for Colang flows
     ```

## Rationale

During investigation I checked the current `develop` branch (actions, Colang
flows, and related tests/commits) to confirm this is not intentional behavior
and that there is no existing adapter writing `valid` into `$result`.

There were two possible fixes:

- **Option A:** change the Colang flows to read `validation_passed`
  directly (e.g. `$result["validation_result"].validation_passed`).
- **Option B:** keep the flows as-is and add a backward-compatible adapter
  in the GuardrailsAI action layer, so actions return `validation_result`
  plus a `valid` boolean.

This PR implements **Option B** to maintain backward compatibility with
existing and custom flows that already use `$result["valid"]`, while
still aligning with GuardrailsAI’s `validation_passed` field under the
hood.

## Testing

Local tests (virtualenv):

```bash
python -m pytest tests/test_guardrails_ai_actions.py -v
python -m pytest tests/test_guardrails_ai_e2e_actions.py -v
```

All GuardrailsAI unit tests pass. GuardrailsAI e2e tests that do not
depend on external validators/services pass; the rest are skipped when
those validators are not available.

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
  - @okhleif-10