### PR TITLE
feat(library): add regex detection rails

### DIFF
--- a/docs/user-guides/community/regex.md
+++ b/docs/user-guides/community/regex.md
@@ -1,0 +1,200 @@
+# Regex Detection Integration
+
+The NVIDIA NeMo Guardrails library provides out-of-the-box support for content moderation based on regex pattern matching. This integration enables you to detect and block content that matches specific patterns in user inputs, bot outputs, and retrieved knowledge base chunks.
+
+## Overview
+
+Regex detection is useful for scenarios such as:
+
+- Blocking specific keywords or phrases
+- Detecting patterns like Social Security Numbers, credit card numbers, or other sensitive data formats
+- Filtering profanity or inappropriate content using basic regex pattern matching
+
+## Setup
+
+No additional packages are required. The regex detection rails is built into the NVIDIA NeMo Guardrails library.
+
+## Usage
+
+The regex detection rails uses a flexible configuration that allows you to define specific regex patterns for input, output, and retrieval checking.
+
+### Configuration Structure
+
+Add the regex configuration to your `config.yml` file:
+
+```yaml
+rails:
+  config:
+    regex_detection:
+      input:
+        patterns:
+          - "\\b(password|secret|api[_-]?key)\\b"
+          - "\\d{3}-\\d{2}-\\d{4}"  # SSN pattern
+        case_insensitive: true
+      output:
+        patterns:
+          - "\\bconfidential\\b"
+          - "\\binternal[_-]?use[_-]?only\\b"
+        case_insensitive: true
+      retrieval:
+        patterns:
+          - "\\bclassified\\b"
+        case_insensitive: false
+  input:
+    flows:
+      - regex check input
+  output:
+    flows:
+      - regex check output
+  retrieval:
+    flows:
+      - regex check retrieval
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `patterns` | List[str] | `[]` | List of regex patterns to match against the text |
+| `case_insensitive` | bool | `false` | Whether to perform case-insensitive matching |
+
+### Input Rails
+
+To detect regex patterns in user input:
+
+```yaml
+rails:
+  config:
+    regex_detection:
+      input:
+        patterns:
+          - "\\b(hack|exploit|bypass)\\b"
+        case_insensitive: true
+  input:
+    flows:
+      - regex check input
+```
+
+### Output Rails
+
+To detect regex patterns in bot output:
+
+```yaml
+rails:
+  config:
+    regex_detection:
+      output:
+        patterns:
+          - "\\bdo not share\\b"
+        case_insensitive: true
+  output:
+    flows:
+      - regex check output
+```
+
+### Retrieval Rails
+
+ When a chunk matches any of the configured retrieval patterns, **that chunk is removed** from the retrieval results and is not passed to the model. Only chunks that do not match the patterns are kept and used as context.
+
+ To detect regex patterns in retrieved knowledge base chunks:
+
+```yaml
+rails:
+  config:
+    regex_detection:
+      retrieval:
+        patterns:
+          - "\\bproprietary\\b"
+        case_insensitive: true
+  retrieval:
+    flows:
+      - regex check retrieval
+```
+
+## Complete Example
+
+Here's a comprehensive example configuration:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: gpt-4
+
+rails:
+  config:
+    regex_detection:
+      input:
+        patterns:
+          # Block sensitive data patterns
+          - "\\d{3}-\\d{2}-\\d{4}"          # SSN
+          - "\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}"  # Credit card
+          - "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}"  # Email
+          # Block specific keywords
+          - "\\b(password|secret|api[_-]?key|token)\\b"
+        case_insensitive: true
+      output:
+        patterns:
+          - "\\b(confidential|internal[_-]?only|do[_-]?not[_-]?share)\\b"
+        case_insensitive: true
+
+  input:
+    flows:
+      - regex check input
+
+  output:
+    flows:
+      - regex check output
+```
+
+## Return Value
+
+The `detect_regex_pattern` action returns a `RegexDetectionResult` with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `is_match` | bool | `True` if any pattern matched, `False` otherwise. |
+| `text` | str | The original text that was checked. |
+| `detections` | List[str] | List of the pattern strings that matched. Empty if no match. |
+
+For example, if the input text `"my SSN is 123-45-6789"` is checked against a pattern `\\d{3}-\\d{2}-\\d{4}`, the result would be:
+
+```json
+{
+  "is_match": true,
+  "text": "my SSN is 123-45-6789",
+  "detections": ["\\d{3}-\\d{2}-\\d{4}"]
+}
+```
+
+## Regex Pattern Tips
+
+When writing Python regex patterns, keep in mind:
+
+1. **Escape backslashes**: In YAML, use double backslashes (`\\`) for regex escape sequences (e.g., `\\b` for word boundary, `\\d` for digit).
+
+2. **Word boundaries**: Use `\\b` to match whole words only. For example, `\\bpassword\\b` matches "password" but not "passwords" or "mypassword".
+
+3. **Character classes**: Use `[_-]?` to match optional separators (e.g., `api[_-]?key` matches "apikey", "api-key", and "api_key").
+
+4. **Common patterns**:
+   - SSN: `\\d{3}-\\d{2}-\\d{4}`
+   - Credit card: `\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}`
+   - Email: `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}`
+   - Phone: `\\(?\\d{3}\\)?[-.\\s]?\\d{3}[-.\\s]?\\d{4}`
+
+For more information about Python regex rules, please refer to the [official documentation](https://docs.python.org/3/howto/regex.html#regex-howto).
+
+## Regex Rail Behavior
+
+When a regex rail has a regex pattern match, the following steps happen (depending on rails type):
+
+**Input and output rails**
+1. The action returns a `RegexDetectionResult` with `is_match=True` and the matched pattern(s) in `detections`.
+2. The bot responds with: `"I'm sorry, I can't respond to that."` (using the standard `bot refuse to respond` message).
+3. The flow is aborted.
+
+**Retrieval rails**
+1. Chunks that match any retrieval pattern are **removed** from the retrieval results. Only non-matching chunks are passed to the model as context.
+
+**NOTE:** The matched pattern(s) are available in `result["detections"]` for logging and debugging. They are also logged at `INFO` level by the action.

--- a/nemoguardrails/library/regex/__init__.py
+++ b/nemoguardrails/library/regex/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import List, TypedDict
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions import action
+
+log = logging.getLogger(__name__)
+
+
+class RegexDetectionResult(TypedDict):
+    is_match: bool
+    text: str
+    detections: List[str]
+
+
+@action(is_system_action=True)
+async def detect_regex_pattern(
+    source: str,
+    text: str,
+    config: RailsConfig,
+) -> RegexDetectionResult:
+    """Checks whether the provided text matches any forbidden regex pattern.
+
+    Args:
+        source: The source for the text, i.e. "input", "output", "retrieval".
+        text: The text to check.
+        config: The rails configuration object.
+
+    Returns:
+        RegexDetectionResult: A TypedDict containing:
+            - is_match (bool): Whether any pattern matched.
+            - text (str): The original text that was checked.
+            - detections (List[str]): List of pattern strings that matched.
+    """
+    if source not in ("input", "output", "retrieval"):
+        raise ValueError("source must be one of 'input', 'output', or 'retrieval'")
+
+    regex_config = config.rails.config.regex_detection
+    if regex_config is None:
+        log.warning("No regex_detection configuration found.")
+        return RegexDetectionResult(is_match=False, text=text, detections=[])
+
+    options = getattr(regex_config, source, None)
+
+    if options is None:
+        log.warning("No regex rails configuration found for source: %s", source)
+        return RegexDetectionResult(is_match=False, text=text, detections=[])
+
+    compiled_patterns = options.compiled_patterns
+    if not compiled_patterns:
+        log.debug("No regex patterns specified for source: %s", source)
+        return RegexDetectionResult(is_match=False, text=text, detections=[])
+
+    if not text:
+        log.debug("Empty text provided, skipping regex check.")
+        return RegexDetectionResult(is_match=False, text=text, detections=[])
+
+    # Match against pre-compiled patterns and collect all matches.
+    matched: List[str] = []
+    for compiled, raw_pattern in zip(compiled_patterns, options.patterns):
+        if compiled.search(text):
+            log.info("Regex pattern matched: %s", raw_pattern)
+            matched.append(raw_pattern)
+
+    if matched:
+        return RegexDetectionResult(is_match=True, text=text, detections=matched)
+
+    return RegexDetectionResult(is_match=False, text=text, detections=[])

--- a/nemoguardrails/library/regex/flows.co
+++ b/nemoguardrails/library/regex/flows.co
@@ -1,0 +1,33 @@
+# INPUT RAILS
+
+flow regex check input
+  """Check if the user input matches any forbidden regex patterns."""
+  $result = await DetectRegexMatchAction(source="input", text=$user_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    abort
+
+
+# OUTPUT RAILS
+
+
+flow regex check output
+  """Check if the bot output matches any forbidden regex patterns."""
+  $result = await DetectRegexMatchAction(source="output", text=$bot_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    abort
+
+
+# RETRIEVAL RAILS
+
+
+flow regex check retrieval
+  """Check if the relevant chunks from the knowledge base match any forbidden regex patterns.
+  """
+  $result = await DetectRegexMatchAction(source="retrieval", text=$relevant_chunks)
+
+  if $result["is_match"]
+    $relevant_chunks = ""

--- a/nemoguardrails/library/regex/flows.v1.co
+++ b/nemoguardrails/library/regex/flows.v1.co
@@ -1,0 +1,35 @@
+define bot refuse to respond
+  "I'm sorry, I can't respond to that."
+
+# INPUT RAILS
+
+define subflow regex check input
+  """Check if the user input matches any forbidden regex patterns."""
+  $result = execute detect_regex_pattern(source="input", text=$user_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    stop
+
+
+# OUTPUT RAILS
+
+
+define subflow regex check output
+  """Check if the bot output matches any forbidden regex patterns."""
+  $result = execute detect_regex_pattern(source="output", text=$bot_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    stop
+
+
+# RETRIEVAL RAILS
+
+
+define subflow regex check retrieval
+  """Check if the relevant chunks from the knowledge base match any forbidden regex patterns."""
+  $result = execute detect_regex_pattern(source="retrieval", text=$relevant_chunks)
+
+  if $result["is_match"]
+    $relevant_chunks = ""

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -17,6 +17,7 @@
 
 import logging
 import os
+import re
 import warnings
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
@@ -26,6 +27,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     SecretStr,
     model_validator,
     root_validator,
@@ -240,6 +242,56 @@ class SensitiveDataDetection(BaseModel):
     retrieval: SensitiveDataDetectionOptions = Field(
         default_factory=SensitiveDataDetectionOptions,
         description="Configuration of the entities to be detected on retrieved relevant chunks.",
+    )
+
+
+class RegexDetectionOptions(BaseModel):
+    """Configuration options for regex pattern detection on a specific source."""
+
+    patterns: List[str] = Field(
+        default_factory=list,
+        description="List of regex patterns to match against the text.",
+    )
+    case_insensitive: bool = Field(
+        default=False,
+        description="Whether to perform case-insensitive matching.",
+    )
+
+    _compiled_patterns: List["re.Pattern[str]"] = PrivateAttr(default_factory=list)
+
+    @model_validator(mode="after")
+    def compile_patterns(self) -> "RegexDetectionOptions":
+        """Pre-compile regex patterns at config load time."""
+        flags = re.IGNORECASE if self.case_insensitive else 0
+        compiled = []
+        for i, pattern in enumerate(self.patterns):
+            try:
+                compiled.append(re.compile(pattern, flags))
+            except re.error as e:
+                raise ValueError(f"Invalid regex pattern at index {i} ({pattern!r}): {e}") from e
+        object.__setattr__(self, "_compiled_patterns", compiled)
+        return self
+
+    @property
+    def compiled_patterns(self) -> List["re.Pattern[str]"]:
+        """Return the pre-compiled regex patterns."""
+        return self._compiled_patterns
+
+
+class RegexDetection(BaseModel):
+    """Configuration for regex pattern detection."""
+
+    input: RegexDetectionOptions = Field(
+        default_factory=RegexDetectionOptions,
+        description="Configuration for regex patterns to detect on user input.",
+    )
+    output: RegexDetectionOptions = Field(
+        default_factory=RegexDetectionOptions,
+        description="Configuration for regex patterns to detect on bot output.",
+    )
+    retrieval: RegexDetectionOptions = Field(
+        default_factory=RegexDetectionOptions,
+        description="Configuration for regex patterns to detect on retrieved relevant chunks.",
     )
 
 
@@ -1020,6 +1072,11 @@ class RailsConfigData(BaseModel):
     sensitive_data_detection: Optional[SensitiveDataDetection] = Field(
         default_factory=SensitiveDataDetection,
         description="Configuration for detecting sensitive data.",
+    )
+
+    regex_detection: Optional[RegexDetection] = Field(
+        default_factory=RegexDetection,
+        description="Configuration for regex pattern detection.",
     )
 
     jailbreak_detection: Optional[JailbreakDetectionConfig] = Field(

--- a/tests/test_regex_detection.py
+++ b/tests/test_regex_detection.py
@@ -1,0 +1,648 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pydantic import ValidationError
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions import action
+from nemoguardrails.actions.actions import ActionResult
+from tests.utils import TestChat
+
+
+@pytest.mark.unit
+def test_regex_detection_input_blocks_matching_pattern():
+    """Test that input containing a matching regex pattern is blocked."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\d{3}-\\\\d{2}-\\\\d{4}"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello there!"'],
+    )
+
+    # This should trigger the input rail (contains SSN pattern)
+    chat >> "My SSN is 123-45-6789"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_input_allows_non_matching():
+    """Test that input not matching any regex pattern is allowed."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\d{3}-\\\\d{2}-\\\\d{4}"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello there!"'],
+    )
+
+    # This should NOT trigger the input rail (no SSN pattern)
+    chat >> "Hi there!"
+    chat << "Hello there!"
+
+
+@pytest.mark.unit
+def test_regex_detection_output_blocks_matching_pattern():
+    """Test that output containing a matching regex pattern is blocked."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  output:
+                    patterns:
+                      - "\\\\bconfidential\\\\b"
+              output:
+                flows:
+                  - regex check output
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "This is confidential information."'],
+    )
+
+    # The LLM output contains "confidential" which should be blocked
+    chat >> "Hi!"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_case_insensitive():
+    """Test that case insensitive matching works correctly."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpassword\\\\b"
+                    case_insensitive: true
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello!"'],
+    )
+
+    # Should match regardless of case
+    chat >> "My PASSWORD is secret"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_case_sensitive():
+    """Test that case sensitive matching works correctly (default behavior)."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpassword\\\\b"
+                    case_insensitive: false
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello!"'],
+    )
+
+    # Should NOT match because case is different
+    chat >> "My PASSWORD is secret"
+    chat << "Hello!"
+
+
+@pytest.mark.unit
+def test_regex_detection_multiple_patterns():
+    """Test that multiple regex patterns work correctly."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bsecret\\\\b"
+                      - "\\\\bpassword\\\\b"
+                      - "\\\\bapi[_-]?key\\\\b"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello!"',
+            "  express greeting",
+            '  "Hello!"',
+            "  express greeting",
+            '  "Hello!"',
+        ],
+    )
+
+    # First pattern should match
+    chat >> "This is a secret message"
+    chat << "I'm sorry, I can't respond to that."
+
+    # Second pattern should match
+    chat >> "My password is 12345"
+    chat << "I'm sorry, I can't respond to that."
+
+    # Third pattern should match (with hyphen variant)
+    chat >> "The api-key is abc123"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_empty_patterns_allows_all():
+    """Test that empty patterns list allows all input."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns: []
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello!"'],
+    )
+
+    # Should pass because no patterns are defined
+    chat >> "My password is secret and my SSN is 123-45-6789"
+    chat << "Hello!"
+
+
+@pytest.mark.unit
+def test_regex_detection_input_and_output():
+    """Test regex detection on both input and output."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpassword\\\\b"
+                  output:
+                    patterns:
+                      - "\\\\bsecret\\\\b"
+              input:
+                flows:
+                  - regex check input
+              output:
+                flows:
+                  - regex check output
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Here is a secret!"',
+            "  express greeting",
+            '  "Hello!"',
+        ],
+    )
+
+    # Input should pass, but output should be blocked
+    chat >> "Hi there!"
+    chat << "I'm sorry, I can't respond to that."
+
+    # Input should be blocked
+    chat >> "My password is 12345"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_complex_patterns():
+    """Test regex detection with complex patterns like email and phone."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\\\.[a-zA-Z]{2,}"
+                      - "\\\\(?\\\\d{3}\\\\)?[-.\\\\s]?\\\\d{3}[-.\\\\s]?\\\\d{4}"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello!"',
+            "  express greeting",
+            '  "Hello!"',
+        ],
+    )
+
+    # Email pattern should match
+    chat >> "Contact me at john.doe@example.com"
+    chat << "I'm sorry, I can't respond to that."
+
+    # Phone pattern should match
+    chat >> "Call me at (555) 123-4567"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_invalid_pattern_raises_at_config_load():
+    """Invalid regex patterns are caught at config load time via model_validator, not at runtime."""
+    with pytest.raises(ValidationError) as excinfo:
+        RailsConfig.from_content(
+            yaml_content="""
+                models: []
+                rails:
+                  config:
+                    regex_detection:
+                      input:
+                        patterns:
+                          - "[unclosed"
+                          - "\\\\bvalid\\\\b"
+                  input:
+                    flows:
+                      - regex check input
+            """,
+            colang_content="""
+                define user express greeting
+                  "hi"
+
+                define flow
+                  user express greeting
+                  bot express greeting
+
+                define bot inform answer unknown
+                  "I can't answer that."
+            """,
+        )
+    assert "Invalid regex pattern" in str(excinfo.value)
+    assert "[unclosed" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_regex_detection_word_boundary():
+    """Test that word boundaries work correctly."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpass\\\\b"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello!"'],
+    )
+
+    # "password" should NOT match because we're looking for "pass" as a whole word
+    chat >> "My password is secret"
+    chat << "Hello!"
+
+
+@pytest.mark.unit
+def test_regex_detection_word_boundary_matches():
+    """Test that word boundaries match correctly when the word is standalone."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  input:
+                    patterns:
+                      - "\\\\bpass\\\\b"
+              input:
+                flows:
+                  - regex check input
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define bot refuse to respond
+              "I'm sorry, I can't respond to that."
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Hello!"'],
+    )
+
+    # "pass" as standalone word should match
+    chat >> "Please pass the test"
+    chat << "I'm sorry, I can't respond to that."
+
+
+@pytest.mark.unit
+def test_regex_detection_retrieval_clears_matching_chunks():
+    """Test that retrieved chunks matching a regex pattern are cleared.
+
+    Retrieval rails run inside bot message generation, so they cannot emit a new
+    bot message.  Instead the matched chunks are cleared (set to empty string) so
+    the LLM never sees the flagged content.  A second retrieval flow verifies the
+    chunks were actually cleared.
+    """
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  retrieval:
+                    patterns:
+                      - "\\\\bclassified\\\\b"
+                    case_insensitive: true
+              retrieval:
+                flows:
+                  - regex check retrieval
+                  - check relevant chunks
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define flow check relevant chunks
+              execute check_relevant_chunks(relevant_chunks=$relevant_chunks)
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Here is what I found."'],
+    )
+
+    @action()
+    def retrieve_relevant_chunks():
+        context_updates = {"relevant_chunks": "This document is classified material."}
+        return ActionResult(
+            return_value=context_updates["relevant_chunks"],
+            context_updates=context_updates,
+        )
+
+    @action()
+    def check_relevant_chunks(relevant_chunks: str):
+        # After the regex retrieval rail, matched chunks should be cleared.
+        assert relevant_chunks == ""
+
+    chat.app.register_action(retrieve_relevant_chunks)
+    chat.app.register_action(check_relevant_chunks)
+
+    # The retrieved chunk contains "classified" — the rail clears it, but the
+    # bot still responds (without the dangerous KB context).
+    chat >> "Hi!"
+    chat << "Here is what I found."
+
+
+@pytest.mark.unit
+def test_regex_detection_retrieval_allows_non_matching():
+    """Test that retrieved chunks not matching any pattern are left untouched."""
+    config = RailsConfig.from_content(
+        yaml_content="""
+            models: []
+            rails:
+              config:
+                regex_detection:
+                  retrieval:
+                    patterns:
+                      - "\\\\bclassified\\\\b"
+              retrieval:
+                flows:
+                  - regex check retrieval
+                  - check relevant chunks
+        """,
+        colang_content="""
+            define user express greeting
+              "hi"
+
+            define flow
+              user express greeting
+              bot express greeting
+
+            define flow check relevant chunks
+              execute check_relevant_chunks(relevant_chunks=$relevant_chunks)
+        """,
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=["  express greeting", '  "Here is what I found."'],
+    )
+
+    @action()
+    def retrieve_relevant_chunks():
+        context_updates = {"relevant_chunks": "This document is public information."}
+        return ActionResult(
+            return_value=context_updates["relevant_chunks"],
+            context_updates=context_updates,
+        )
+
+    @action()
+    def check_relevant_chunks(relevant_chunks: str):
+        # No match, so chunks should be passed through unchanged.
+        assert relevant_chunks == "This document is public information."
+
+    chat.app.register_action(retrieve_relevant_chunks)
+    chat.app.register_action(check_relevant_chunks)
+
+    # The retrieved chunk does NOT contain "classified" — passes through unchanged.
+    chat >> "Hi!"
+    chat << "Here is what I found."


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Adds flexible regex pattern detection as rails. The logic to perform regex matches on inputs and/or is built into the NeMo library and users can define specific regex patterns they want to block at configuration time. 

### Configuration Options
* `patterns` - list of regex patterns to match against the text 
* `case_insensitive` - whether to perform case-insensitive matching 

## Example config
```
rails:
  config:
    regex:
      input:
        patterns:
          - "\\b(password|secret|api[_-]?key)\\b"
          - "\\d{3}-\\d{2}-\\d{4}"  # SSN pattern
        case_insensitive: true
      output:
        patterns:
          - "\\bconfidential\\b"
          - "\\binternal[_-]?use[_-]?only\\b"
        case_insensitive: true
      retrieval:
        patterns:
          - "\\bclassified\\b"
        case_insensitive: false
  input:
    flows:
      - detect regex on input
  output:
    flows:
      - detect regex on output
  retrieval:
    flows:
      - detect regex on retrieval
```
## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
