### PR TITLE
feat(library): update Fiddler Guardrails API to match new specification

### DIFF
--- a/nemoguardrails/library/fiddler/actions.py
+++ b/nemoguardrails/library/fiddler/actions.py
@@ -67,6 +67,7 @@ async def call_fiddler_guardrail(
                             "fdl_harassing",
                             "fdl_hateful",
                             "fdl_sexist",
+                            "fdl_roleplaying",
                         ]
                     )
                 else:
@@ -94,7 +95,7 @@ async def call_fiddler_safety_user(config: RailsConfig, context: Optional[dict] 
         log.error("Fiddler Jailbreak Guardrails could not be run. User message must be provided.")
         return False
 
-    data = {"prompt": [user_message]}
+    data = {"input": user_message}
     return await call_fiddler_guardrail(
         endpoint=base_url + "/v3/guardrails/ftl-safety",
         data=data,
@@ -120,7 +121,7 @@ async def call_fiddler_safety_bot(config: RailsConfig, context: Optional[dict] =
         log.error("Fiddler Safety Guardrails could not be run. Bot message must be provided.")
         return False
 
-    data = {"prompt": [bot_message]}
+    data = {"input": bot_message}
     return await call_fiddler_guardrail(
         endpoint=base_url + "/v3/guardrails/ftl-safety",
         data=data,
@@ -142,12 +143,12 @@ async def call_fiddler_faithfulness(config: RailsConfig, context: Optional[dict]
         return False
 
     bot_message = context.get("bot_message", "")
-    knowledge = context.get("relevant_chunks", [])
+    knowledge = context.get("relevant_chunks", "")
     if not bot_message:
         log.error("Fiddler Faithfulness Guardrails could not be run. Chatbot message must be provided.")
         return False
 
-    data = {"response": [bot_message], "context": [knowledge]}
+    data = {"context": knowledge, "response": bot_message}
     return await call_fiddler_guardrail(
         endpoint=base_url + "/v3/guardrails/ftl-response-faithfulness",
         data=data,

--- a/tests/test_fiddler_rails.py
+++ b/tests/test_fiddler_rails.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_fiddler_rails.py
+++ b/tests/test_fiddler_rails.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import os
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aioresponses import aioresponses
@@ -62,6 +64,7 @@ async def test_fiddler_safety_rails(monkeypatch):
                 "fdl_harassing": 0.5,
                 "fdl_hateful": 0.5,
                 "fdl_sexist": 0.5,
+                "fdl_roleplaying": 0.5,
             },
         )
 
@@ -99,6 +102,7 @@ async def test_fiddler_safety_rails_pass(monkeypatch):
                 "fdl_harassing": 0.02,
                 "fdl_hateful": 0.02,
                 "fdl_sexist": 0.02,
+                "fdl_roleplaying": 0.02,
             },
         )
         chat >> "Do you ship within 2 days?"
@@ -134,6 +138,7 @@ async def test_fiddler_thresholds(monkeypatch):
                 "fdl_harassing": 0.5,
                 "fdl_hateful": 0.5,
                 "fdl_sexist": 0.5,
+                "fdl_roleplaying": 0.5,
             },
         )
         chat >> "Do you ship within 2 days?"
@@ -186,3 +191,187 @@ async def test_fiddler_faithfulness_rails_pass(monkeypatch):
         )
         chat >> "Do you ship within 2 days?"
         await chat.bot_async("Yes, shipping can be done in 2 days.")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fiddler_safety_request_format_user_message(monkeypatch):
+    """Unit test: Verify safety guardrail sends correct request format for user message."""
+    from nemoguardrails.library.fiddler.actions import call_fiddler_safety_user
+
+    monkeypatch.setenv("FIDDLER_API_KEY", "test-key")
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        rails:
+          config:
+            fiddler:
+              fiddler_endpoint: https://testfiddler.ai
+              safety_threshold: 0.5
+        """
+    )
+
+    mock_session = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "fdl_harmful": 0.1,
+            "fdl_violent": 0.1,
+            "fdl_unethical": 0.1,
+            "fdl_illegal": 0.1,
+            "fdl_sexual": 0.1,
+            "fdl_racist": 0.1,
+            "fdl_jailbreaking": 0.1,
+            "fdl_harassing": 0.1,
+            "fdl_hateful": 0.1,
+            "fdl_sexist": 0.1,
+            "fdl_roleplaying": 0.1,
+        }
+    )
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock()
+
+    mock_post_context = AsyncMock()
+    mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_context.__aexit__ = AsyncMock()
+    mock_session.post = MagicMock(return_value=mock_post_context)
+
+    mock_client_session = MagicMock()
+    mock_client_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_client_session.return_value.__aexit__ = AsyncMock()
+
+    with patch("nemoguardrails.library.fiddler.actions.aiohttp.ClientSession", mock_client_session):
+        context = {"user_message": "Hello, how are you?"}
+        result = await call_fiddler_safety_user(config, context)
+
+    # Verify request format
+    assert mock_session.post.called
+    call_args = mock_session.post.call_args
+    request_payload = call_args[1]["json"]
+    assert "data" in request_payload
+    assert request_payload["data"]["input"] == "Hello, how are you?"
+    assert "prompt" not in request_payload["data"]  # Old format should not be present
+    assert not isinstance(
+        request_payload["data"]["input"], list
+    )  # Should be string, not list
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fiddler_safety_request_format_bot_message(monkeypatch):
+    """Unit test: Verify safety guardrail sends correct request format for bot message."""
+    from nemoguardrails.library.fiddler.actions import call_fiddler_safety_bot
+
+    monkeypatch.setenv("FIDDLER_API_KEY", "test-key")
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        rails:
+          config:
+            fiddler:
+              fiddler_endpoint: https://testfiddler.ai
+              safety_threshold: 0.5
+        """
+    )
+
+    mock_session = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "fdl_harmful": 0.1,
+            "fdl_violent": 0.1,
+            "fdl_unethical": 0.1,
+            "fdl_illegal": 0.1,
+            "fdl_sexual": 0.1,
+            "fdl_racist": 0.1,
+            "fdl_jailbreaking": 0.1,
+            "fdl_harassing": 0.1,
+            "fdl_hateful": 0.1,
+            "fdl_sexist": 0.1,
+            "fdl_roleplaying": 0.1,
+        }
+    )
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock()
+
+    mock_post_context = AsyncMock()
+    mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_context.__aexit__ = AsyncMock()
+    mock_session.post = MagicMock(return_value=mock_post_context)
+
+    mock_client_session = MagicMock()
+    mock_client_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_client_session.return_value.__aexit__ = AsyncMock()
+
+    with patch("nemoguardrails.library.fiddler.actions.aiohttp.ClientSession", mock_client_session):
+        context = {"bot_message": "I can help you with that."}
+        result = await call_fiddler_safety_bot(config, context)
+
+    # Verify request format
+    assert mock_session.post.called
+    call_args = mock_session.post.call_args
+    request_payload = call_args[1]["json"]
+    assert "data" in request_payload
+    assert request_payload["data"]["input"] == "I can help you with that."
+    assert "prompt" not in request_payload["data"]  # Old format should not be present
+    assert not isinstance(
+        request_payload["data"]["input"], list
+    )  # Should be string, not list
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fiddler_faithfulness_request_format(monkeypatch):
+    """Unit test: Verify faithfulness guardrail sends correct request format."""
+    from nemoguardrails.library.fiddler.actions import call_fiddler_faithfulness
+
+    monkeypatch.setenv("FIDDLER_API_KEY", "test-key")
+
+    config = RailsConfig.from_content(
+        yaml_content="""
+        rails:
+          config:
+            fiddler:
+              fiddler_endpoint: https://testfiddler.ai
+              faithfulness_threshold: 0.3
+        """
+    )
+
+    mock_session = AsyncMock()
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"fdl_faithful_score": 0.2})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock()
+
+    mock_post_context = AsyncMock()
+    mock_post_context.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_post_context.__aexit__ = AsyncMock()
+    mock_session.post = MagicMock(return_value=mock_post_context)
+
+    mock_client_session = MagicMock()
+    mock_client_session.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_client_session.return_value.__aexit__ = AsyncMock()
+
+    with patch("nemoguardrails.library.fiddler.actions.aiohttp.ClientSession", mock_client_session):
+        context = {
+            "bot_message": "Shipping takes 2 days",
+            "relevant_chunks": "Shipping takes at least 3 days. We ship worldwide.",
+        }
+        result = await call_fiddler_faithfulness(config, context)
+
+    # Verify request format
+    assert mock_session.post.called
+    call_args = mock_session.post.call_args
+    request_payload = call_args[1]["json"]
+    assert "data" in request_payload
+    assert request_payload["data"]["response"] == "Shipping takes 2 days"
+    assert (
+        request_payload["data"]["context"]
+        == "Shipping takes at least 3 days. We ship worldwide."
+    )
+    # Verify old format (lists) is not present
+    assert not isinstance(request_payload["data"].get("response"), list)
+    assert not isinstance(request_payload["data"].get("context"), list)

--- a/tests/test_fiddler_rails.py
+++ b/tests/test_fiddler_rails.py
@@ -251,9 +251,7 @@ async def test_fiddler_safety_request_format_user_message(monkeypatch):
     assert "data" in request_payload
     assert request_payload["data"]["input"] == "Hello, how are you?"
     assert "prompt" not in request_payload["data"]  # Old format should not be present
-    assert not isinstance(
-        request_payload["data"]["input"], list
-    )  # Should be string, not list
+    assert not isinstance(request_payload["data"]["input"], list)  # Should be string, not list
 
 
 @pytest.mark.unit
@@ -315,9 +313,7 @@ async def test_fiddler_safety_request_format_bot_message(monkeypatch):
     assert "data" in request_payload
     assert request_payload["data"]["input"] == "I can help you with that."
     assert "prompt" not in request_payload["data"]  # Old format should not be present
-    assert not isinstance(
-        request_payload["data"]["input"], list
-    )  # Should be string, not list
+    assert not isinstance(request_payload["data"]["input"], list)  # Should be string, not list
 
 
 @pytest.mark.unit
@@ -367,10 +363,7 @@ async def test_fiddler_faithfulness_request_format(monkeypatch):
     request_payload = call_args[1]["json"]
     assert "data" in request_payload
     assert request_payload["data"]["response"] == "Shipping takes 2 days"
-    assert (
-        request_payload["data"]["context"]
-        == "Shipping takes at least 3 days. We ship worldwide."
-    )
+    assert request_payload["data"]["context"] == "Shipping takes at least 3 days. We ship worldwide."
     # Verify old format (lists) is not present
     assert not isinstance(request_payload["data"].get("response"), list)
     assert not isinstance(request_payload["data"].get("context"), list)


### PR DESCRIPTION
- Change Safety API from 'prompt' to 'input' field
- Change Faithfulness API to use strings instead of lists
- Add fdl_roleplaying category to safety detection
- Add unit tests to verify request payload format

Signed-off-by: Kevin Truong kevin@fiddler.ai

## Description

Made changes to account for new Fiddler Guardrail API formatting and fdl_roleplaying category

## Related Issue(s)

None

Fiddler Reviewer: @copperstick6 

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ x] I've updated the documentation if applicable.
- [ x] I've added tests if applicable.
- [ x] @mentions of the person or team responsible for reviewing proposed changes.
