### PR TITLE
fix(server): make openai an optional server-only dependency

### DIFF
--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -104,7 +104,8 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install poetry==1.8.2
-          pip install ./*.whl
+          WHEEL=$(ls nemoguardrails-*.whl)
+          pip install "${WHEEL}[server]"
 
       - name: Start server in the background
         run: |

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -1,6 +1,7 @@
 name: Build and Test Distribution
 
 on:
+  pull_request: # TODO: remove after verifying the fix
   push:
     branches:
       - main

--- a/nemoguardrails/cli/__init__.py
+++ b/nemoguardrails/cli/__init__.py
@@ -148,7 +148,14 @@ def server(
 ):
     """Start a NeMo Guardrails server."""
 
-    from nemoguardrails.server import api
+    try:
+        from nemoguardrails.server import api
+    except ImportError:
+        typer.secho(
+            "The 'openai' package is required to run the server. Install it with: pip install nemoguardrails[server]",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
 
     if config:
         # We make sure there is no trailing separator, as that might break things in

--- a/poetry.lock
+++ b/poetry.lock
@@ -935,7 +935,7 @@ files = [
 name = "distro"
 version = "1.9.0"
 description = "Distro - an OS platform information API"
-optional = true
+optional = false
 python-versions = ">=3.6"
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
@@ -1841,7 +1841,7 @@ i18n = ["Babel (>=2.7)"]
 name = "jiter"
 version = "0.10.0"
 description = "Fast iterable JSON parser."
-optional = true
+optional = false
 python-versions = ">=3.9"
 files = [
     {file = "jiter-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:cd2fb72b02478f06a900a5782de2ef47e0396b3e1f7d5aba30daeb1fce66f303"},
@@ -3041,7 +3041,7 @@ sympy = "*"
 name = "openai"
 version = "2.15.0"
 description = "The official Python library for the openai API"
-optional = true
+optional = false
 python-versions = ">=3.9"
 files = [
     {file = "openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3"},
@@ -6642,4 +6642,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "ad9330eed607f0fe11b9143663657b65e2b0957b63213fd06210b5ae1ceec7c3"
+content-hash = "095bfe5df1e2f0090df62d769e7beb893efd526ec485b46d49ba9ad7b90b12af"

--- a/poetry.lock
+++ b/poetry.lock
@@ -935,7 +935,7 @@ files = [
 name = "distro"
 version = "1.9.0"
 description = "Distro - an OS platform information API"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"},
@@ -1841,7 +1841,7 @@ i18n = ["Babel (>=2.7)"]
 name = "jiter"
 version = "0.10.0"
 description = "Fast iterable JSON parser."
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "jiter-0.10.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:cd2fb72b02478f06a900a5782de2ef47e0396b3e1f7d5aba30daeb1fce66f303"},
@@ -3041,7 +3041,7 @@ sympy = "*"
 name = "openai"
 version = "2.15.0"
 description = "The official Python library for the openai API"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3"},
@@ -6642,4 +6642,4 @@ tracing = ["aiofiles", "opentelemetry-api"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.14"
-content-hash = "7edfc2eeeb8036c96a42642c47b0752600d86cacf4a6d9b9be53ca68cfd7f673"
+content-hash = "ad9330eed607f0fe11b9143663657b65e2b0957b63213fd06210b5ae1ceec7c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ starlette = ">=0.49.1"
 typer = ">=0.8"
 uvicorn = ">=0.23"
 watchdog = ">=3.0.0,"
-openai = ">=1.0.0,<3.0.0"
+openai = { version = ">=1.0.0,<3.0.0", optional = true }
 
 # tracing
 opentelemetry-api = { version = ">=1.27.0,<2.0.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ yara-python = "^4.5.1"
 opentelemetry-api = "^1.34.1"
 opentelemetry-sdk = "^1.34.1"
 fast-langdetect = ">=1.0.0"
+openai = ">=1.0.0,<3.0.0"
 pyright = "^1.1.405"
 ruff = "0.14.6"
 

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -19,6 +19,8 @@ from typing import AsyncIterator, Union
 from unittest.mock import patch
 
 import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
 from nemoguardrails.server import api

--- a/tests/server/test_openai_integration.py
+++ b/tests/server/test_openai_integration.py
@@ -15,6 +15,8 @@
 import os
 
 import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 from openai import OpenAI
 from openai.types.chat.chat_completion import ChatCompletion, Choice

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -15,6 +15,9 @@
 
 import json
 
+import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 

--- a/tests/server/test_server_calls_with_state.py
+++ b/tests/server/test_server_calls_with_state.py
@@ -15,6 +15,8 @@
 import os
 
 import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
 from nemoguardrails.server import api

--- a/tests/server/test_threads.py
+++ b/tests/server/test_threads.py
@@ -15,6 +15,8 @@
 import os
 
 import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
 from fastapi.testclient import TestClient
 
 from nemoguardrails.server import api


### PR DESCRIPTION
## Description
Resolves some minor issues due to https://github.com/NVIDIA-NeMo/Guardrails/pull/1340 ‪that causes a [job failure](https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/21721394197/job/62651896021).

- Mark `openai` as an optional dependency in `pyproject.toml` (already included in the `server` extras group)
- Install wheel with `[server]` extra in the CI test-wheel job since it starts a server
- Guard the server import in the CLI with a helpful error message when `openai` is missing
- Add `openai` to dev dependencies so server tests pass locally (consistent with `yara-python`, `opentelemetry-api`, etc.)
- Add `pytest.importorskip("openai")` guards to all server test files as a defensive measure


