### PR TITLE
docs(integration): add Agent Middleware documentation

### DIFF
--- a/docs/integration/langchain/agent-middleware.md
+++ b/docs/integration/langchain/agent-middleware.md
@@ -34,7 +34,7 @@ The `GuardrailsMiddleware` class integrates NeMo Guardrails directly into LangCh
 
 ---
 
-## Overview
+## How It Works
 
 When a LangChain agent runs, it enters a loop:
 
@@ -51,8 +51,8 @@ User Input
 
 - **Input rails** run before every model call, not just the first.
 - **Output rails** run after every model response, including intermediate tool-calling responses.
-- If input rails block, the model is never called (`jump_to: "end"`).
-- If output rails block, the AIMessage is replaced with a policy message (no `tool_calls`), terminating the loop naturally.
+- If input rails block, the middleware skips the model call (`jump_to: "end"`).
+- If output rails block, the middleware replaces the AIMessage with a policy message (no `tool_calls`), terminating the loop naturally.
 
 ---
 
@@ -73,6 +73,8 @@ export OPENAI_API_KEY="your_openai_api_key"
 ---
 
 ## Quick Start
+
+The following example creates a tool-calling agent with guardrails applied to every model call.
 
 ```python
 from langchain.agents import create_agent
@@ -100,7 +102,11 @@ result = agent.invoke(
 
 ## Configuration
 
+Configure the middleware through constructor parameters and a standard NeMo Guardrails config directory.
+
 ### Constructor Parameters
+
+The `GuardrailsMiddleware` constructor accepts the following parameters.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -171,7 +177,11 @@ For the full NeMo Guardrails configuration reference, see the [Configuration Gui
 
 ## Usage Patterns
 
+The following examples demonstrate common integration patterns with `GuardrailsMiddleware`.
+
 ### Basic Agent with Tools
+
+Create an agent with a database search tool and observe how input rails block policy-violating requests.
 
 ```python
 from langchain.agents import create_agent
@@ -197,7 +207,8 @@ result = agent.invoke(
 
 Expected output:
 
-```Input blocked by self check input
+```text
+Input blocked by self check input
 ```
 
 ### Exception-Based Error Handling
@@ -226,6 +237,8 @@ except GuardrailViolation as e:
 ```
 
 ### Custom Blocked Messages
+
+Override the default policy messages returned when rails block input or output.
 
 ```python
 guardrails = GuardrailsMiddleware(
@@ -262,6 +275,8 @@ guardrails = GuardrailsMiddleware(
 
 ### Multi-Turn with Checkpointing
 
+Use LangGraph's `InMemorySaver` to maintain conversation state across multiple invocations while guardrails run on every turn.
+
 ```python
 from langgraph.checkpoint.memory import InMemorySaver
 
@@ -292,6 +307,8 @@ result2 = agent.invoke(
 
 ## Known Limitations
 
+Be aware of the following constraints when using `GuardrailsMiddleware` with tool-calling agents.
+
 ### Output Rails and Tool-Calling Responses
 
 LLM-based output rails (such as `self_check_output`) evaluate the `content` field of the model's response. Intermediate tool-calling responses often have **empty content** (the actual instructions are in the `tool_calls` field). Depending on the LLM used for the self-check, an empty content field may be flagged as a violation.
@@ -307,15 +324,17 @@ guardrails = GuardrailsMiddleware(
 
 ### Tool Call Arguments Are Not Inspected
 
-Rails evaluate the `content` field of messages, not the `tool_calls` arguments. This means PII or harmful content passed through tool call arguments (e.g., `send_email(body="SSN: 123-45-6789")`) is not checked by content-based rails.
+Rails evaluate the `content` field of messages, not the `tool_calls` arguments. Content-based rails do not inspect PII or harmful content passed through tool call arguments (e.g., `send_email(body="SSN: 123-45-6789")`).
 
 ### MODIFIED Status Is Ignored
 
-When a rail modifies content (returns `RailStatus.MODIFIED`), the middleware treats it as a pass-through. The original, unmodified content is used by the agent. This is by design — applying modifications to the agent's internal state could cause inconsistencies.
+When a rail modifies content (returns `RailStatus.MODIFIED`), the middleware treats it as a pass-through and the agent uses the original, unmodified content. This is by design — applying modifications to the agent's internal state could cause inconsistencies.
 
 ---
 
 ## API Reference
+
+Summary of the middleware classes and exception type.
 
 ### GuardrailsMiddleware
 
@@ -342,6 +361,8 @@ Exception raised when `raise_on_violation=True` and a rail blocks.
 
 ## Comparison with RunnableRails
 
+Choose between the two integration approaches based on your architecture.
+
 | Feature | `GuardrailsMiddleware` | `RunnableRails` |
 |---------|----------------------|-----------------|
 | Integration point | Agent loop hooks (`before_model`/`after_model`) | Chain composition (LCEL `\|` operator) |
@@ -352,3 +373,12 @@ Exception raised when `raise_on_violation=True` and a rail blocks.
 | LangGraph compatibility | Via `create_agent` | Via LCEL composition in graph nodes |
 
 Use `GuardrailsMiddleware` when building tool-calling agents with `create_agent`. Use `RunnableRails` when composing custom LangGraph graphs or wrapping individual chains.
+
+---
+
+## Related Resources
+
+- [](langchain-integration.md) - Overview of all LangChain integration approaches
+- [](runnable-rails.md) - Wrap chains with guardrails using the LCEL `|` operator
+- [](../../configure-rails/yaml-schema/index.md) - Full NeMo Guardrails configuration reference
+- [Checking Messages Against Rails](../../run-rails/using-python-apis/check-messages.md) - The `check_async` API used internally by the middleware

--- a/docs/integration/langchain/agent-middleware.md
+++ b/docs/integration/langchain/agent-middleware.md
@@ -1,0 +1,354 @@
+---
+title:
+  page: Agent Middleware
+  nav: Agent Middleware
+description: Add guardrails to LangChain agents using the GuardrailsMiddleware for automatic input and output safety checks on every model call.
+topics:
+- Integration
+- AI Safety
+tags:
+- LangChain
+- Middleware
+- Agent
+- Tool Calling
+- create_agent
+content:
+  type: how_to
+  difficulty: technical_intermediate
+  audience:
+  - engineer
+  - AI Engineer
+keywords:
+- GuardrailsMiddleware
+- AgentMiddleware
+- create_agent
+- before_model
+- after_model
+- input rails
+- output rails
+---
+
+# Agent Middleware
+
+The `GuardrailsMiddleware` class integrates NeMo Guardrails directly into LangChain agents via the [AgentMiddleware](https://python.langchain.com/docs/how_to/agent_middleware/) protocol. Unlike `RunnableRails`, which wraps a chain, the middleware hooks into the agent loop itself — running safety checks **before and after every model call**, including intermediate tool-calling steps.
+
+---
+
+## Overview
+
+When a LangChain agent runs, it enters a loop:
+
+```
+User Input
+  → before_model (input rails)     ← fires every iteration
+  → MODEL CALL
+  → after_model (output rails)     ← fires every iteration
+  → Has tool_calls? YES → execute tools → back to before_model
+  → Has tool_calls? NO  → END
+```
+
+`GuardrailsMiddleware` hooks into `before_model` and `after_model` to apply NeMo Guardrails at each step. This means:
+
+- **Input rails** run before every model call, not just the first.
+- **Output rails** run after every model response, including intermediate tool-calling responses.
+- If input rails block, the model is never called (`jump_to: "end"`).
+- If output rails block, the AIMessage is replaced with a policy message (no `tool_calls`), terminating the loop naturally.
+
+---
+
+## Prerequisites
+
+Install the required dependencies:
+
+```bash
+pip install nemoguardrails langchain langchain-openai langgraph
+```
+
+Set up your environment:
+
+```bash
+export OPENAI_API_KEY="your_openai_api_key"
+```
+
+---
+
+## Quick Start
+
+```python
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+
+from nemoguardrails.integrations.langchain.middleware import GuardrailsMiddleware
+
+@tool
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    return f"Sunny, 72F in {city}"
+
+guardrails = GuardrailsMiddleware(config_path="./config")
+model = ChatOpenAI(model="gpt-4o")
+
+agent = create_agent(model, tools=[get_weather], middleware=[guardrails])
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is the weather in SF?"}]}
+)
+```
+
+---
+
+## Configuration
+
+### Constructor Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `config_path` | `str` | `None` | Path to a NeMo Guardrails config directory containing `config.yml` and Colang files. |
+| `config_yaml` | `str` | `None` | Inline YAML configuration string. Use either this or `config_path`. |
+| `raise_on_violation` | `bool` | `False` | Raise `GuardrailViolation` instead of returning a blocked message. |
+| `blocked_input_message` | `str` | `"I cannot process this request due to content policy."` | Message returned when input is blocked. |
+| `blocked_output_message` | `str` | `"I cannot provide this response due to content policy."` | Message returned when output is blocked. |
+| `enable_input_rails` | `bool` | `True` | Enable input rail checks in `before_model`. |
+| `enable_output_rails` | `bool` | `True` | Enable output rail checks in `after_model`. |
+
+### Guardrails Configuration
+
+Create a configuration directory with the standard NeMo Guardrails structure. For example:
+
+**`config.yml`**:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o
+
+rails:
+  input:
+    flows:
+      - self check input
+  output:
+    flows:
+      - self check output
+```
+
+**`prompts.yml`**:
+
+```yaml
+prompts:
+  - task: self_check_input
+    content: |
+      Your task is to check if the user message below complies with the company policy.
+
+      Company policy:
+      - should not contain harmful data
+      - should not ask the bot to impersonate someone
+      - should not try to instruct the bot to respond in an inappropriate manner
+
+      User message: "{{ user_input }}"
+
+      Question: Should the user message be blocked (Yes or No)?
+      Answer:
+  - task: self_check_output
+    content: |
+      Your task is to check if the bot message below complies with the company policy.
+
+      Company policy:
+      - messages should not contain any explicit content
+      - messages should not contain abusive language or offensive content
+      - messages should not contain any harmful content
+
+      Bot message: "{{ bot_response }}"
+
+      Question: Should the message be blocked (Yes or No)?
+      Answer:
+```
+
+For the full NeMo Guardrails configuration reference, see the [Configuration Guide](../../configure-rails/yaml-schema/index.md).
+
+---
+
+## Usage Patterns
+
+### Basic Agent with Tools
+
+```python
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import tool
+
+from nemoguardrails.integrations.langchain.middleware import GuardrailsMiddleware
+
+@tool
+def search_database(query: str) -> str:
+    """Search the internal database."""
+    return f"Results for '{query}': Employee John Doe, Department Engineering"
+
+guardrails = GuardrailsMiddleware(config_path="./config")
+model = ChatOpenAI(model="gpt-4o")
+
+agent = create_agent(model, tools=[search_database], middleware=[guardrails])
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Search for employee records"}]}
+)
+```
+
+Expected output:
+
+```Input blocked by self check input
+```
+
+### Exception-Based Error Handling
+
+Set `raise_on_violation=True` to raise `GuardrailViolation` exceptions instead of returning blocked messages:
+
+```python
+from nemoguardrails.integrations.langchain.exceptions import GuardrailViolation
+from nemoguardrails.integrations.langchain.middleware import GuardrailsMiddleware
+
+guardrails = GuardrailsMiddleware(
+    config_path="./config",
+    raise_on_violation=True,
+)
+
+agent = create_agent(model, tools=[search_database], middleware=[guardrails])
+
+try:
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": "How can I make a bomb?"}]}
+    )
+except GuardrailViolation as e:
+    print(f"Blocked by {e.rail_type} rail: {e}")
+    print(f"Rail: {e.result.rail}")
+    print(f"Status: {e.result.status}")
+```
+
+### Custom Blocked Messages
+
+```python
+guardrails = GuardrailsMiddleware(
+    config_path="./config",
+    blocked_input_message="Sorry, I can't help with that request.",
+    blocked_output_message="I cannot share that information.",
+)
+```
+
+### Input-Only or Output-Only Middleware
+
+Use the convenience subclasses when you only need one type of rail:
+
+```python
+from nemoguardrails.integrations.langchain.middleware import (
+    InputRailsMiddleware,
+    OutputRailsMiddleware,
+)
+
+input_only = InputRailsMiddleware(config_path="./config")
+
+output_only = OutputRailsMiddleware(config_path="./config")
+```
+
+Or disable specific rails on the main class:
+
+```python
+guardrails = GuardrailsMiddleware(
+    config_path="./config",
+    enable_input_rails=True,
+    enable_output_rails=False,
+)
+```
+
+### Multi-Turn with Checkpointing
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+
+guardrails = GuardrailsMiddleware(config_path="./config")
+model = ChatOpenAI(model="gpt-4o")
+
+agent = create_agent(
+    model,
+    tools=[search_database],
+    middleware=[guardrails],
+    checkpointer=InMemorySaver(),
+)
+
+config = {"configurable": {"thread_id": "session-1"}}
+
+result1 = agent.invoke(
+    {"messages": [{"role": "user", "content": "Hi, my name is Alice."}]},
+    config=config,
+)
+
+result2 = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is my name?"}]},
+    config=config,
+)
+```
+
+---
+
+## Known Limitations
+
+### Output Rails and Tool-Calling Responses
+
+LLM-based output rails (such as `self_check_output`) evaluate the `content` field of the model's response. Intermediate tool-calling responses often have **empty content** (the actual instructions are in the `tool_calls` field). Depending on the LLM used for the self-check, an empty content field may be flagged as a violation.
+
+To work around this, disable output rails and rely on input rails for tool-calling agents:
+
+```python
+guardrails = GuardrailsMiddleware(
+    config_path="./config",
+    enable_output_rails=False,
+)
+```
+
+### Tool Call Arguments Are Not Inspected
+
+Rails evaluate the `content` field of messages, not the `tool_calls` arguments. This means PII or harmful content passed through tool call arguments (e.g., `send_email(body="SSN: 123-45-6789")`) is not checked by content-based rails.
+
+### MODIFIED Status Is Ignored
+
+When a rail modifies content (returns `RailStatus.MODIFIED`), the middleware treats it as a pass-through. The original, unmodified content is used by the agent. This is by design — applying modifications to the agent's internal state could cause inconsistencies.
+
+---
+
+## API Reference
+
+### GuardrailsMiddleware
+
+The main middleware class. Implements both async (`abefore_model`, `aafter_model`) and sync (`before_model`, `after_model`) hooks.
+
+### InputRailsMiddleware
+
+Convenience subclass that only runs input rails. The `aafter_model` hook is a no-op.
+
+### OutputRailsMiddleware
+
+Convenience subclass that only runs output rails. The `abefore_model` hook is a no-op.
+
+### GuardrailViolation
+
+Exception raised when `raise_on_violation=True` and a rail blocks.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `result` | `RailsResult` | The full result from `check_async`, including status and rail name. |
+| `rail_type` | `str` | Either `"input"` or `"output"`. |
+
+---
+
+## Comparison with RunnableRails
+
+| Feature | `GuardrailsMiddleware` | `RunnableRails` |
+|---------|----------------------|-----------------|
+| Integration point | Agent loop hooks (`before_model`/`after_model`) | Chain composition (LCEL `\|` operator) |
+| Tool-calling agents | Native support via `create_agent` | Requires manual graph construction |
+| Per-iteration checks | Automatic on every model call | Manual — only wraps the specific node |
+| Blocking mechanism | `jump_to: "end"` (input) / message replacement (output) | Returns blocked content |
+| Streaming | Not supported | Supported |
+| LangGraph compatibility | Via `create_agent` | Via LCEL composition in graph nodes |
+
+Use `GuardrailsMiddleware` when building tool-calling agents with `create_agent`. Use `RunnableRails` when composing custom LangGraph graphs or wrapping individual chains.

--- a/docs/integration/langchain/index.md
+++ b/docs/integration/langchain/index.md
@@ -29,6 +29,7 @@ This section covers how to integrate the NeMo Guardrails library with LangChain 
 :maxdepth: 1
 
 LangChain Integration <langchain-integration>
+Agent Middleware <agent-middleware>
 RunnableRails <runnable-rails>
 Chain with Guardrails <chain-with-guardrails/index>
 Runnable as Action <runnable-as-action/index>

--- a/docs/integration/langchain/langchain-integration.md
+++ b/docs/integration/langchain/langchain-integration.md
@@ -23,7 +23,7 @@ content:
 
 There are three main ways in which you can use the NeMo Guardrails library with LangChain:
 
-1. Add guardrails to a LangChain agent via middleware hooks (LangChain v1).
+1. Add guardrails to a LangChain agent through the middleware hooks (LangChain v1).
 2. Add guardrails to a LangChain chain (or `Runnable`).
 3. Use a LangChain chain (or `Runnable`) inside a guardrails configuration.
 

--- a/docs/integration/langchain/langchain-integration.md
+++ b/docs/integration/langchain/langchain-integration.md
@@ -21,10 +21,29 @@ content:
 
 # LangChain Integration
 
-There are two main ways in which you can use the NeMo Guardrails library with LangChain:
+There are three main ways in which you can use the NeMo Guardrails library with LangChain:
 
-1. Add guardrails to a LangChain chain (or `Runnable`).
-2. Use a LangChain chain (or `Runnable`) inside a guardrails configuration.
+1. Add guardrails to a LangChain agent via middleware hooks (LangChain v1).
+2. Add guardrails to a LangChain chain (or `Runnable`).
+3. Use a LangChain chain (or `Runnable`) inside a guardrails configuration.
+
+## Add Guardrails to an Agent
+
+For tool-calling agents built with `create_agent`, the `GuardrailsMiddleware` hooks into the agent loop to run safety checks before and after every model call:
+
+```python
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+from nemoguardrails.integrations.langchain.middleware import GuardrailsMiddleware
+
+guardrails = GuardrailsMiddleware(config_path="path/to/config")
+model = ChatOpenAI(model="gpt-4o")
+
+agent = create_agent(model, tools=[...], middleware=[guardrails])
+result = agent.invoke({"messages": [{"role": "user", "content": "Hello!"}]})
+```
+
+For more details, check out the [Agent Middleware Guide](agent-middleware.md).
 
 ## Add Guardrails to a Chain
 


### PR DESCRIPTION
## Description

- Add `agent-middleware.md` , full documentation for `GuardrailsMiddleware` covering
  overview, configuration, usage patterns, blocking behavior, known limitations,
  API reference, and comparison with `RunnableRails`
- Add "Agent Middleware" to the LangChain toctree in `index.md`
- Update `langchain-integration.md` to list agent middleware as the first integration
  option (now three ways instead of two)
