### PR TITLE
feat(benchmark): Add Locust stress-test

### DIFF
--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -20,54 +20,22 @@ These steps have been tested with Python 3.11.11.
    $ python -m venv ~/env/benchmark_env
    ```
 
-2. **Install dependencies in the virtual environment**
+2. **Activate environment and install dependencies in the virtual environment**
 
    ```bash
-   $ pip install -r benchmark/requirements.txt
+   $ source ~/env/benchmark_env/bin/activate
+   (benchmark_env) $ pip install -r benchmark/requirements.txt
    ```
 
 ## Running Benchmarks
 
-### Run with YAML Configuration (Required)
+The Locust benchmarks uses YAML configuration file to configure load-testing parameters.
+To get started and load-test a model hosted at `http://localhost:8000`, use the following command.
+Set `headless: false` in your YAML config to use Locust's interactive web UI. Then open http://localhost:8089 to control the test and view real-time metrics.
 
-Create a YAML configuration file (see `benchmark/locust/configs/local.yaml` for a complete example):
-
-```yaml
-host: "http://localhost:8000"
-config_id: "my-guardrails-config"
-model: "mock-llm"
-users: 256
-spawn_rate: 10
-run_time: 60
-message: "Hello, what can you do?"
-headless: true
-output_base_dir: "locust_results"
-```
-
-Then run:
-
-```bash
-python -m benchmark.locust benchmark/locust/configs/local.yaml
-```
-
-### Web UI Mode
-
-Set `headless: false` in your YAML config to use Locust's interactive web UI:
-
-```yaml
-host: "http://localhost:8000"
-config_id: "my-config"
-model: "mock-llm"
-users: 100
-spawn_rate: 10
-headless: false
-```
-
-```bash
-python -m benchmark.locust my-config.yaml
-```
-
-Then open http://localhost:8089 to control the test and view real-time metrics.
+   ```bash
+   (benchmark_env) $ python -m benchmark.locust benchmark/locust/configs/local.yaml
+   ```
 
 ### CLI Options
 

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -2,29 +2,35 @@
 
 This directory contains a Locust-based load testing framework for the NeMo Guardrails OpenAI-compatible server.
 
-## Overview
+## Introduction
 
-The load tester simulates concurrent users making API calls to the `/v1/chat/completions` endpoint with configurable parameters. It's designed to test the performance of guardrails processing including input rails, generation, and output rails.
+The [Locust](https://locust.io/) stress-testing tool ramps up concurrent users making API calls to the `/v1/chat/completions` endpoint of an OpenAI-compatible LLM with configurable parameters.
+This complements [ai-perf](https://github.com/ai-dynamo/aiperf), which measures steady-state performance.  Locust instead focuses on ramping up load potentially beyond what a system can handle, and measure how gracefully it degrades under higher-than-expected load.
 
-## Installation
+## Getting Started
 
-Install the required dependencies:
+### Prerequisites
 
-```bash
-pip install locust pyyaml httpx
-```
+These steps have been tested with Python 3.11.11.
 
-Or install from the benchmark requirements:
+1. **Create a virtual environment in which to install Locust and other benchmarking tools**
 
-```bash
-pip install -r benchmark/requirements.txt
-```
+   ```bash
+   $ mkdir ~/env
+   $ python -m venv ~/env/benchmark_env
+   ```
 
-## Usage
+2. **Install dependencies in the virtual environment**
+
+   ```bash
+   $ pip install -r benchmark/requirements.txt
+   ```
+
+## Running Benchmarks
 
 ### Run with YAML Configuration (Required)
 
-Create a YAML configuration file (see `configs/local.yaml` for a complete example):
+Create a YAML configuration file (see `benchmark/locust/configs/local.yaml` for a complete example):
 
 ```yaml
 host: "http://localhost:8000"
@@ -39,12 +45,6 @@ output_base_dir: "locust_results"
 ```
 
 Then run:
-
-```bash
-python -m benchmark.locust my-config.yaml
-```
-
-Or use the provided example:
 
 ```bash
 python -m benchmark.locust benchmark/locust/configs/local.yaml
@@ -68,23 +68,6 @@ python -m benchmark.locust my-config.yaml
 ```
 
 Then open http://localhost:8089 to control the test and view real-time metrics.
-
-### Direct Locust Invocation
-
-You can also run the locustfile directly with Locust CLI:
-
-```bash
-export LOCUST_CONFIG_ID=my-config
-export LOCUST_MODEL=mock-llm
-export LOCUST_MESSAGE="Hello, what can you do?"
-
-locust -f benchmark/locust/locustfile.py \
-  --host http://localhost:8000 \
-  --users 100 \
-  --spawn-rate 10 \
-  --run-time 60s \
-  --headless
-```
 
 ### CLI Options
 
@@ -137,10 +120,10 @@ When run in headless mode, results are saved to timestamped directories:
 locust_results/
 └── YYYYMMDD_HHMMSS/
     ├── report.html          # HTML report with charts
+    ├── run_metadata.json    # Test configuration metadata
     ├── stats.csv            # Request statistics
-    ├── stats_history.csv    # Statistics over time
     ├── stats_failures.csv   # Failure statistics
-    └── run_metadata.json    # Test configuration metadata
+    └── stats_history.csv    # Statistics over time
 ```
 
 ### Web UI Mode
@@ -151,108 +134,10 @@ Real-time metrics are displayed in the web interface at http://localhost:8089, i
 - Failure rate
 - Number of users
 
-## Testing with Mock LLM Server
-
-The load tests are designed to work with the Mock LLM server in `benchmark/mock_llm_server`. The mock server returns stock responses without actual LLM calls, allowing you to test guardrails processing performance.
-
-1. Start the Mock LLM server (see `benchmark/mock_llm_server/README.md`)
-2. Start the NeMo Guardrails server with a config that uses the mock LLM
-3. Run the load test pointing to the Guardrails server
-
-## Examples
-
-### Quick Test (10 users, 30 seconds)
-
-Create `quick-test.yaml`:
-```yaml
-host: "http://localhost:8000"
-config_id: "test-config"
-model: "mock-llm"
-users: 10
-spawn_rate: 2
-run_time: 30
-headless: true
-```
-
-Run:
-```bash
-python -m benchmark.locust quick-test.yaml
-```
-
-### Full Load Test (256 users, 5 minutes)
-
-Create `full-load-test.yaml`:
-```yaml
-host: "http://localhost:8000"
-config_id: "production-config"
-model: "mock-llm"
-users: 256
-spawn_rate: 10
-run_time: 300
-headless: true
-```
-
-Run:
-```bash
-python -m benchmark.locust full-load-test.yaml
-```
-
-### Interactive Testing
-
-Create `interactive-test.yaml`:
-```yaml
-host: "http://localhost:8000"
-config_id: "my-config"
-model: "mock-llm"
-headless: false
-```
-
-Run:
-```bash
-python -m benchmark.locust interactive-test.yaml
-```
-
-Then navigate to http://localhost:8089 to start and control the test interactively.
-
-## Troubleshooting
-
-### Server Connection Issues
-
-If you see "Can't connect to http://localhost:8000":
-- Ensure the NeMo Guardrails server is running
-- Verify the `host` URL is correct in your YAML config
-- Check that the `config_id` exists on the server
-
-### Import Errors
-
-If you see import errors for `locust`:
-```bash
-pip install locust
-```
-
-### Configuration Errors
+### Troubleshooting
 
 If you see validation errors:
 - Ensure all required fields (`config_id`, `model`) are present in your YAML config
 - Check that the `config_id` matches a configuration on your server
 - Verify that numeric values meet minimum requirements (e.g., `users >= 1`, `spawn_rate >= 0.1`)
 - Ensure `host` starts with `http://` or `https://`
-
-## Architecture
-
-The load tester consists of:
-
-- **`locust_models.py`**: Pydantic `LocustConfig` model for YAML configuration validation with field validators for host, users, spawn_rate, and run_time
-- **`locustfile.py`**: Locust `GuardrailsUser` class defining load test behavior (can be run standalone with environment variables)
-- **`run_locust.py`**: Typer CLI application (`LocustRunner` class) that loads YAML configs, validates server connectivity, builds Locust commands, and manages test execution
-- **`__main__.py`**: Module entry point for `python -m benchmark.locust`
-
-This follows the same YAML-first configuration pattern as `benchmark/aiperf` for consistency.
-
-### Key Design Choices
-
-- **YAML-first**: All configuration through YAML files rather than CLI flags for reproducibility
-- **Pydantic validation**: Configuration validated at load time with clear error messages
-- **Environment variables**: The locustfile receives configuration via environment variables, allowing standalone execution
-- **Service health check**: Validates server connectivity before starting load tests
-- **Timestamped results**: Headless mode saves results to timestamped directories with metadata

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -1,0 +1,217 @@
+# Locust Load Testing for NeMo Guardrails
+
+This directory contains a Locust-based load testing framework for the NeMo Guardrails OpenAI-compatible server.
+
+## Overview
+
+The load tester simulates concurrent users making API calls to the `/v1/chat/completions` endpoint with configurable parameters. It's designed to test the performance of guardrails processing including input rails, generation, and output rails.
+
+## Installation
+
+Install the required dependencies:
+
+```bash
+pip install locust pyyaml httpx
+```
+
+Or install from the benchmark requirements:
+
+```bash
+pip install -r benchmark/requirements.txt
+```
+
+## Usage
+
+### Option 1: Run with YAML Configuration (Recommended)
+
+Create a YAML configuration file (see `configs/example.yaml`):
+
+```yaml
+batch_name: my_load_test
+output_base_dir: locust_results
+
+base_config:
+  host: "http://localhost:8000"
+  config_id: "my-config"
+  model: "mock-llm"
+  users: 256
+  spawn_rate: 10
+  run_time: 60
+  message: "Hello, what can you do?"
+  headless: true
+```
+
+Then run:
+
+```bash
+python -m benchmark.locust run --config-file benchmark/locust/configs/example.yaml
+```
+
+### Option 2: Run with CLI Arguments
+
+```bash
+python -m benchmark.locust run \
+  --host http://localhost:8000 \
+  --config-id my-config \
+  --model mock-llm \
+  --users 100 \
+  --spawn-rate 10 \
+  --run-time 60 \
+  --headless
+```
+
+### Option 3: Web UI Mode
+
+Run without `--headless` flag to use Locust's interactive web UI:
+
+```bash
+python -m benchmark.locust run \
+  --config-id my-config \
+  --model mock-llm \
+  --users 100 \
+  --spawn-rate 10
+```
+
+Then open http://localhost:8089 to control the test and view real-time metrics.
+
+### Option 4: Direct Locust Invocation
+
+You can also run the locustfile directly:
+
+```bash
+export LOCUST_CONFIG_ID=my-config
+export LOCUST_MODEL=mock-llm
+export LOCUST_MESSAGE="Hello, what can you do?"
+
+locust -f benchmark/locust/locustfile.py \
+  --host http://localhost:8000 \
+  --users 100 \
+  --spawn-rate 10 \
+  --run-time 60s \
+  --headless
+```
+
+## Configuration Options
+
+### Required Parameters
+
+- `config_id`: Guardrails configuration ID to use
+- `model`: Model name to send in requests
+
+### Optional Parameters
+
+- `host`: Server base URL (default: `http://localhost:8000`)
+- `users`: Maximum concurrent users (default: `256`, max: `256`)
+- `spawn_rate`: Users spawned per second (default: `10`)
+- `run_time`: Test duration in seconds (default: `60`, `0` for unlimited)
+- `message`: Message content to send (default: `"Hello, what can you do?"`)
+- `headless`: Run without web UI (default: `false`)
+- `verbose`: Enable verbose logging (default: `false`)
+
+## Load Test Behavior
+
+- **Request Distribution**: 99% chat completions, 1% models endpoint (currently only chat completions)
+- **Wait Time**: Zero wait time between requests (continuous hammering)
+- **Ramp-up**: Users spawn gradually at the specified `spawn_rate`
+- **Message Content**: Static message content (configurable)
+
+## Output
+
+### Headless Mode
+
+When run in headless mode, results are saved to timestamped directories:
+
+```
+locust_results/
+└── YYYYMMDD_HHMMSS/
+    ├── report.html          # HTML report with charts
+    ├── stats.csv            # Request statistics
+    ├── stats_history.csv    # Statistics over time
+    ├── stats_failures.csv   # Failure statistics
+    └── run_metadata.json    # Test configuration metadata
+```
+
+### Web UI Mode
+
+Real-time metrics are displayed in the web interface at http://localhost:8089, including:
+- Requests per second (RPS)
+- Response time percentiles (50th, 95th, 99th)
+- Failure rate
+- Number of users
+
+## Testing with Mock LLM Server
+
+The load tests are designed to work with the Mock LLM server in `benchmark/mock_llm_server`. The mock server returns stock responses without actual LLM calls, allowing you to test guardrails processing performance.
+
+1. Start the Mock LLM server (see `benchmark/mock_llm_server/README.md`)
+2. Start the NeMo Guardrails server with a config that uses the mock LLM
+3. Run the load test pointing to the Guardrails server
+
+## Examples
+
+### Quick Test (10 users, 30 seconds)
+
+```bash
+python -m benchmark.locust run \
+  --config-id test-config \
+  --model mock-llm \
+  --users 10 \
+  --spawn-rate 2 \
+  --run-time 30 \
+  --headless
+```
+
+### Full Load Test (256 users, 5 minutes)
+
+```bash
+python -m benchmark.locust run \
+  --config-id production-config \
+  --model mock-llm \
+  --users 256 \
+  --spawn-rate 10 \
+  --run-time 300 \
+  --headless
+```
+
+### Interactive Testing
+
+```bash
+python -m benchmark.locust run \
+  --config-id my-config \
+  --model mock-llm
+```
+
+Then navigate to http://localhost:8089 to start and control the test interactively.
+
+## Troubleshooting
+
+### Server Connection Issues
+
+If you see "Can't connect to http://localhost:8000":
+- Ensure the NeMo Guardrails server is running
+- Verify the host URL is correct
+- Check that the config_id exists on the server
+
+### Import Errors
+
+If you see import errors for `locust`:
+```bash
+pip install locust
+```
+
+### Configuration Errors
+
+If you see "config_id is required":
+- Ensure you've provided `--config-id` via CLI or in the YAML config
+- Check that the config_id matches a configuration on your server
+
+## Architecture
+
+The load tester consists of:
+
+- `locust_models.py`: Pydantic models for configuration validation
+- `locustfile.py`: Locust user behavior definition (can be run standalone)
+- `run_locust.py`: Typer CLI wrapper with YAML support
+- `__main__.py`: Module entry point
+
+This follows the same pattern as `benchmark/aiperf` for consistency.

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -22,61 +22,56 @@ pip install -r benchmark/requirements.txt
 
 ## Usage
 
-### Option 1: Run with YAML Configuration (Recommended)
+### Run with YAML Configuration (Required)
 
-Create a YAML configuration file (see `configs/example.yaml`):
+Create a YAML configuration file (see `configs/local.yaml` for a complete example):
 
 ```yaml
-batch_name: my_load_test
-output_base_dir: locust_results
-
-base_config:
-  host: "http://localhost:8000"
-  config_id: "my-config"
-  model: "mock-llm"
-  users: 256
-  spawn_rate: 10
-  run_time: 60
-  message: "Hello, what can you do?"
-  headless: true
+host: "http://localhost:8000"
+config_id: "my-guardrails-config"
+model: "mock-llm"
+users: 256
+spawn_rate: 10
+run_time: 60
+message: "Hello, what can you do?"
+headless: true
+output_base_dir: "locust_results"
 ```
 
 Then run:
 
 ```bash
-python -m benchmark.locust run --config-file benchmark/locust/configs/example.yaml
+python -m benchmark.locust my-config.yaml
 ```
 
-### Option 2: Run with CLI Arguments
+Or use the provided example:
 
 ```bash
-python -m benchmark.locust run \
-  --host http://localhost:8000 \
-  --config-id my-config \
-  --model mock-llm \
-  --users 100 \
-  --spawn-rate 10 \
-  --run-time 60 \
-  --headless
+python -m benchmark.locust benchmark/locust/configs/local.yaml
 ```
 
-### Option 3: Web UI Mode
+### Web UI Mode
 
-Run without `--headless` flag to use Locust's interactive web UI:
+Set `headless: false` in your YAML config to use Locust's interactive web UI:
+
+```yaml
+host: "http://localhost:8000"
+config_id: "my-config"
+model: "mock-llm"
+users: 100
+spawn_rate: 10
+headless: false
+```
 
 ```bash
-python -m benchmark.locust run \
-  --config-id my-config \
-  --model mock-llm \
-  --users 100 \
-  --spawn-rate 10
+python -m benchmark.locust my-config.yaml
 ```
 
 Then open http://localhost:8089 to control the test and view real-time metrics.
 
-### Option 4: Direct Locust Invocation
+### Direct Locust Invocation
 
-You can also run the locustfile directly:
+You can also run the locustfile directly with Locust CLI:
 
 ```bash
 export LOCUST_CONFIG_ID=my-config
@@ -91,29 +86,46 @@ locust -f benchmark/locust/locustfile.py \
   --headless
 ```
 
+### CLI Options
+
+The `benchmark.locust` CLI supports the following options:
+
+```bash
+python -m benchmark.locust [OPTIONS] CONFIG_FILE
+```
+
+**Arguments:**
+- `CONFIG_FILE`: Path to YAML configuration file (required)
+
+**Options:**
+- `--dry-run`: Print commands without executing them
+- `--verbose`: Enable verbose logging and debugging information
+
 ## Configuration Options
 
-### Required Parameters
+All configuration is done via YAML files. The following fields are supported:
+
+### Required Fields
 
 - `config_id`: Guardrails configuration ID to use
 - `model`: Model name to send in requests
 
-### Optional Parameters
+### Optional Fields
 
 - `host`: Server base URL (default: `http://localhost:8000`)
-- `users`: Maximum concurrent users (default: `256`, max: `256`)
-- `spawn_rate`: Users spawned per second (default: `10`)
-- `run_time`: Test duration in seconds (default: `60`, `0` for unlimited)
+- `users`: Maximum concurrent users (default: `256`, minimum: `1`)
+- `spawn_rate`: Users spawned per second (default: `10`, minimum: `0.1`)
+- `run_time`: Test duration in seconds (default: `60`, minimum: `1`, or `null` for unlimited)
 - `message`: Message content to send (default: `"Hello, what can you do?"`)
-- `headless`: Run without web UI (default: `false`)
-- `verbose`: Enable verbose logging (default: `false`)
+- `headless`: Run without web UI (default: `true`)
+- `output_base_dir`: Directory for test results (default: `"locust_results"`)
 
 ## Load Test Behavior
 
-- **Request Distribution**: 99% chat completions, 1% models endpoint (currently only chat completions)
+- **Request Type**: 100% POST `/v1/chat/completions` requests
 - **Wait Time**: Zero wait time between requests (continuous hammering)
 - **Ramp-up**: Users spawn gradually at the specified `spawn_rate`
-- **Message Content**: Static message content (configurable)
+- **Message Content**: Static message content (configurable via `message` field)
 
 ## Output
 
@@ -151,34 +163,53 @@ The load tests are designed to work with the Mock LLM server in `benchmark/mock_
 
 ### Quick Test (10 users, 30 seconds)
 
+Create `quick-test.yaml`:
+```yaml
+host: "http://localhost:8000"
+config_id: "test-config"
+model: "mock-llm"
+users: 10
+spawn_rate: 2
+run_time: 30
+headless: true
+```
+
+Run:
 ```bash
-python -m benchmark.locust run \
-  --config-id test-config \
-  --model mock-llm \
-  --users 10 \
-  --spawn-rate 2 \
-  --run-time 30 \
-  --headless
+python -m benchmark.locust quick-test.yaml
 ```
 
 ### Full Load Test (256 users, 5 minutes)
 
+Create `full-load-test.yaml`:
+```yaml
+host: "http://localhost:8000"
+config_id: "production-config"
+model: "mock-llm"
+users: 256
+spawn_rate: 10
+run_time: 300
+headless: true
+```
+
+Run:
 ```bash
-python -m benchmark.locust run \
-  --config-id production-config \
-  --model mock-llm \
-  --users 256 \
-  --spawn-rate 10 \
-  --run-time 300 \
-  --headless
+python -m benchmark.locust full-load-test.yaml
 ```
 
 ### Interactive Testing
 
+Create `interactive-test.yaml`:
+```yaml
+host: "http://localhost:8000"
+config_id: "my-config"
+model: "mock-llm"
+headless: false
+```
+
+Run:
 ```bash
-python -m benchmark.locust run \
-  --config-id my-config \
-  --model mock-llm
+python -m benchmark.locust interactive-test.yaml
 ```
 
 Then navigate to http://localhost:8089 to start and control the test interactively.
@@ -189,8 +220,8 @@ Then navigate to http://localhost:8089 to start and control the test interactive
 
 If you see "Can't connect to http://localhost:8000":
 - Ensure the NeMo Guardrails server is running
-- Verify the host URL is correct
-- Check that the config_id exists on the server
+- Verify the `host` URL is correct in your YAML config
+- Check that the `config_id` exists on the server
 
 ### Import Errors
 
@@ -201,17 +232,27 @@ pip install locust
 
 ### Configuration Errors
 
-If you see "config_id is required":
-- Ensure you've provided `--config-id` via CLI or in the YAML config
-- Check that the config_id matches a configuration on your server
+If you see validation errors:
+- Ensure all required fields (`config_id`, `model`) are present in your YAML config
+- Check that the `config_id` matches a configuration on your server
+- Verify that numeric values meet minimum requirements (e.g., `users >= 1`, `spawn_rate >= 0.1`)
+- Ensure `host` starts with `http://` or `https://`
 
 ## Architecture
 
 The load tester consists of:
 
-- `locust_models.py`: Pydantic models for configuration validation
-- `locustfile.py`: Locust user behavior definition (can be run standalone)
-- `run_locust.py`: Typer CLI wrapper with YAML support
-- `__main__.py`: Module entry point
+- **`locust_models.py`**: Pydantic `LocustConfig` model for YAML configuration validation with field validators for host, users, spawn_rate, and run_time
+- **`locustfile.py`**: Locust `GuardrailsUser` class defining load test behavior (can be run standalone with environment variables)
+- **`run_locust.py`**: Typer CLI application (`LocustRunner` class) that loads YAML configs, validates server connectivity, builds Locust commands, and manages test execution
+- **`__main__.py`**: Module entry point for `python -m benchmark.locust`
 
-This follows the same pattern as `benchmark/aiperf` for consistency.
+This follows the same YAML-first configuration pattern as `benchmark/aiperf` for consistency.
+
+### Key Design Choices
+
+- **YAML-first**: All configuration through YAML files rather than CLI flags for reproducibility
+- **Pydantic validation**: Configuration validated at load time with clear error messages
+- **Environment variables**: The locustfile receives configuration via environment variables, allowing standalone execution
+- **Service health check**: Validates server connectivity before starting load tests
+- **Timestamped results**: Headless mode saves results to timestamped directories with metadata

--- a/benchmark/locust/README.md
+++ b/benchmark/locust/README.md
@@ -66,7 +66,7 @@ All configuration is done via YAML files. The following fields are supported:
 - `host`: Server base URL (default: `http://localhost:8000`)
 - `users`: Maximum concurrent users (default: `256`, minimum: `1`)
 - `spawn_rate`: Users spawned per second (default: `10`, minimum: `0.1`)
-- `run_time`: Test duration in seconds (default: `60`, minimum: `1`, or `null` for unlimited)
+- `run_time`: Test duration in seconds (default: `60`, minimum: `1`)
 - `message`: Message content to send (default: `"Hello, what can you do?"`)
 - `headless`: Run without web UI (default: `true`)
 - `output_base_dir`: Directory for test results (default: `"locust_results"`)

--- a/benchmark/locust/__init__.py
+++ b/benchmark/locust/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/benchmark/locust/__main__.py
+++ b/benchmark/locust/__main__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entry point for running the Locust load test CLI as a module: python -m benchmark.locust"""
+
+from benchmark.locust.run_locust import app
+
+if __name__ == "__main__":
+    app()

--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -8,7 +8,7 @@ model: "meta/llama-3.3-70b-instruct"
 # Load test parameters
 users: 1024             # Maximum number of concurrent users
 spawn_rate: 16           # Users spawned per second
-run_time: 120            # Test duration in seconds (or null for unlimited)
+run_time: 120            # Test duration in seconds
 
 # Request configuration
 message: "Hello, what can you do?"

--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -1,0 +1,17 @@
+# Example Locust load test configuration for NeMo Guardrails
+
+# Server details
+host: "http://localhost:8000"
+config_id: "my-guardrails-config"
+model: "meta/llama-3.3-70b-instruct"
+
+# Load test parameters
+users: 1024             # Maximum number of concurrent users
+spawn_rate: 16           # Users spawned per second
+run_time: 120            # Test duration in seconds
+
+# Request configuration
+message: "Hello, what can you do?"
+
+# Run mode
+headless: false          # Set to false for web UI mode

--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -8,10 +8,11 @@ model: "meta/llama-3.3-70b-instruct"
 # Load test parameters
 users: 1024             # Maximum number of concurrent users
 spawn_rate: 16           # Users spawned per second
-run_time: 120            # Test duration in seconds
+run_time: 120            # Test duration in seconds (or null for unlimited)
 
 # Request configuration
 message: "Hello, what can you do?"
 
-# Run mode
-headless: false          # Set to false for web UI mode
+# Output configuration
+headless: false          # Set to true for headless mode, false for web UI
+output_base_dir: "locust_results"  # Directory for test results

--- a/benchmark/locust/configs/local.yaml
+++ b/benchmark/locust/configs/local.yaml
@@ -14,5 +14,5 @@ run_time: 120            # Test duration in seconds (or null for unlimited)
 message: "Hello, what can you do?"
 
 # Output configuration
-headless: false          # Set to true for headless mode, false for web UI
+headless: true          # Set to true for headless mode, false for web UI
 output_base_dir: "locust_results"  # Directory for test results

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pydantic models for Locust load test configuration validation.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LocustConfig(BaseModel):
+    """Configuration for a Locust load-test run"""
+
+    # Server details
+    host: str = Field(
+        default="http://localhost:8000",
+        description="Base URL of the NeMo Guardrails server to test",
+    )
+    config_id: str = Field(..., description="Guardrails configuration ID to use")
+    model: str = Field(..., description="Model name to use in requests")
+
+    # Load test parameters
+    users: int = Field(
+        default=256,
+        ge=1,
+        description="Maximum number of concurrent users",
+    )
+    spawn_rate: float = Field(
+        default=10,
+        ge=0.1,
+        description="Rate at which users are spawned (users/second)",
+    )
+    run_time: Optional[int] = Field(
+        default=60,
+        ge=1,
+        description="Test duration in seconds (None for unlimited)",
+    )
+
+    # Request configuration
+    message: str = Field(
+        default="Hello, what can you do?",
+        description="Message content to send in chat completion requests",
+    )
+
+    # Output configuration
+    headless: bool = Field(
+        default=True,
+        description="Run in headless mode without web UI",
+    )
+
+    output_base_dir: str = Field(
+        default="locust_results",
+        description="Base directory for load test results",
+    )
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Ensure host starts with http:// or https://"""
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("Host must start with http:// or https://")
+        # Remove trailing slash if present
+        return v.rstrip("/")
+
+    def get_output_base_path(self) -> Path:
+        """Get the base output directory as a Path object."""
+        return Path(self.output_base_dir)

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -18,11 +18,13 @@
 Pydantic models for Locust load test configuration validation.
 """
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class LocustConfig(BaseModel):
     """Configuration for a Locust load-test run"""
+
+    model_config = ConfigDict(extra="forbid")
 
     # Server details
     host: str = Field(

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -18,8 +18,6 @@
 Pydantic models for Locust load test configuration validation.
 """
 
-from pathlib import Path
-
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -76,7 +74,3 @@ class LocustConfig(BaseModel):
             raise ValueError("Host must start with http:// or https://")
         # Remove trailing slash if present
         return v.rstrip("/")
-
-    def get_output_base_path(self) -> Path:
-        """Get the base output directory as a Path object."""
-        return Path(self.output_base_dir)

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -64,7 +64,7 @@ class LocustConfig(BaseModel):
         description="Run in headless mode without web UI",
     )
 
-    output_base_dir: str = Field(
+    output_base_dir: Path = Field(
         default="locust_results",
         description="Base directory for load test results",
     )

--- a/benchmark/locust/locust_models.py
+++ b/benchmark/locust/locust_models.py
@@ -19,7 +19,6 @@ Pydantic models for Locust load test configuration validation.
 """
 
 from pathlib import Path
-from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -46,10 +45,10 @@ class LocustConfig(BaseModel):
         ge=0.1,
         description="Rate at which users are spawned (users/second)",
     )
-    run_time: Optional[int] = Field(
+    run_time: int = Field(
         default=60,
         ge=1,
-        description="Test duration in seconds (None for unlimited)",
+        description="Test duration in seconds",
     )
 
     # Request configuration
@@ -64,7 +63,7 @@ class LocustConfig(BaseModel):
         description="Run in headless mode without web UI",
     )
 
-    output_base_dir: Path = Field(
+    output_base_dir: str = Field(
         default="locust_results",
         description="Base directory for load test results",
     )

--- a/benchmark/locust/locustfile.py
+++ b/benchmark/locust/locustfile.py
@@ -35,8 +35,7 @@ class GuardrailsUser(HttpUser):
     NeMo Guardrails server.
 
     Each user will continuously send requests with no wait time between them
-    (continuous hammering). The load is distributed such that 99% of requests
-    go to chat completions.
+    (continuous load).
     """
 
     # No wait time between requests (continuous hammering)

--- a/benchmark/locust/locustfile.py
+++ b/benchmark/locust/locustfile.py
@@ -21,7 +21,7 @@ This file defines the load test behavior. It can be run directly with:
     locust -f locustfile.py --host http://localhost:8000
 
 Or via the Typer CLI wrapper:
-    python -m benchmark.locust run --config-file config.yaml
+    python -m benchmark.locust config.yaml
 """
 
 import os
@@ -63,6 +63,7 @@ class GuardrailsUser(HttpUser):
         with self.client.post(
             "/v1/chat/completions",
             json=payload,
+            timeout=60,
             catch_response=True,
             name="/v1/chat/completions",
         ) as response:

--- a/benchmark/locust/locustfile.py
+++ b/benchmark/locust/locustfile.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Locust load test file for NeMo Guardrails OpenAI-compatible server.
+
+This file defines the load test behavior. It can be run directly with:
+    locust -f locustfile.py --host http://localhost:8000
+
+Or via the Typer CLI wrapper:
+    python -m benchmark.locust run --config-file config.yaml
+"""
+
+import os
+
+from locust import HttpUser, constant, task
+
+
+class GuardrailsUser(HttpUser):
+    """
+    Simulated user that continuously sends chat completion requests to the
+    NeMo Guardrails server.
+
+    Each user will continuously send requests with no wait time between them
+    (continuous hammering). The load is distributed such that 99% of requests
+    go to chat completions.
+    """
+
+    # No wait time between requests (continuous hammering)
+    wait_time = constant(0)
+
+    def on_start(self):
+        """Called when a simulated user starts.
+        Uses environment variables to pass the Guardrails config_id, model, and message"""
+        # Get configuration from environment variables set by the CLI wrapper
+        self.config_id = os.getenv("LOCUST_CONFIG_ID", "default")
+        self.model = os.getenv("LOCUST_MODEL", "mock-llm")
+        self.message = os.getenv("LOCUST_MESSAGE", "Hello, what can you do?")
+
+    @task
+    def chat_completion(self):
+        """
+        Send a Guardrails chat completion request (/v1/chat/completions)
+        """
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": self.message}],
+            "guardrails": {"config_id": self.config_id},
+        }
+
+        with self.client.post(
+            "/v1/chat/completions",
+            json=payload,
+            catch_response=True,
+            name="/v1/chat/completions",
+        ) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                response.failure(f"Got status code {response.status_code}: {response.text}")

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -141,7 +141,13 @@ class LocustRunner:
             log.error(str(e))
             return 1
 
-        # Build command
+        # For dry-run, print command without creating directories or metadata
+        if dry_run:
+            command = self._build_locust_command()
+            log.info("Dry run mode. Command: %s", " ".join(command))
+            return 0
+
+        # Build command with output directory
         output_path = self._create_output_path(self.config.output_base_dir)
         command = self._build_locust_command(output_path)
 
@@ -168,17 +174,11 @@ class LocustRunner:
             log.info("Web UI will be available at: http://localhost:8089")
 
         try:
-            # For dry-run, just print out the command
-            if dry_run:
-                log.info("Dry run mode. Command: %s", " ".join(command))
-                return 0
-
             result = subprocess.run(command, env=env, check=False)
 
             if result.returncode == 0:
                 log.info("Load test completed successfully")
-                if output_path:
-                    log.info("Results saved to: %s", output_path)
+                log.info("Results saved to: %s", output_path)
             else:
                 log.error("Load test failed with exit code %s", result.returncode)
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -134,18 +134,19 @@ class LocustRunner:
 
     def run(self, dry_run: bool) -> int:
         """Run the Locust load test."""
-        # Check service availability
-        try:
-            self._check_service()
-        except RuntimeError as e:
-            log.error(str(e))
-            return 1
 
         # For dry-run, print command without creating directories or metadata
         if dry_run:
             command = self._build_locust_command()
             log.info("Dry run mode. Command: %s", " ".join(command))
             return 0
+
+        # Check service availability
+        try:
+            self._check_service()
+        except RuntimeError as e:
+            log.error(str(e))
+            return 1
 
         # Build command with output directory
         output_path = self._create_output_path(self.config.output_base_dir)

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -198,6 +198,9 @@ def _load_config_from_yaml(config_file: Path) -> LocustConfig:
         with open(config_file, "r", encoding="utf-8") as f:
             config_data = yaml.safe_load(f)
 
+        if config_data is None:
+            config_data = {}
+
         config = LocustConfig(**config_data)
         return config
 
@@ -209,9 +212,6 @@ def _load_config_from_yaml(config_file: Path) -> LocustConfig:
         sys.exit(1)
     except ValidationError as e:
         log.error("Configuration validation error:\n%s", e)
-        sys.exit(1)
-    except Exception as e:
-        log.error("Unexpected error loading configuration: %s", e)
         sys.exit(1)
 
 
@@ -241,9 +241,7 @@ def run(
     if verbose:
         log.setLevel(logging.DEBUG)
 
-    # Load config from file if provided
-    if config_file:
-        locust_config = _load_config_from_yaml(config_file)
+    locust_config = _load_config_from_yaml(config_file)
 
     # Create and run the test
     runner = LocustRunner(locust_config)

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Typer CLI wrapper for running Locust load tests against NeMo Guardrails server.
+
+This module provides a command-line interface for running load tests, supporting
+both direct CLI arguments and YAML configuration files.
+"""
+
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import typer
+import yaml
+from pydantic import ValidationError
+
+from benchmark.locust.locust_models import LocustConfig
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.DEBUG)
+console_handler.setFormatter(formatter)
+
+log.addHandler(console_handler)
+
+app = typer.Typer(
+    help="Locust load testing application for NeMo Guardrails",
+    add_completion=False,
+)
+
+
+class LocustRunner:
+    """Run Locust load tests against NeMo Guardrails server."""
+
+    def __init__(self, config: LocustConfig):
+        self.config = config
+        self.locustfile_path = Path(__file__).parent / "locustfile.py"
+
+    def _check_service(self) -> None:
+        """Check if the NeMo Guardrails server is up before running tests."""
+        url = f"{self.config.host}/v1/chat/completions"
+        log.debug("Checking service is up at %s", url)
+
+        try:
+            # Try a simple request to verify the server is accessible
+            response = httpx.get(self.config.host, timeout=5)
+        except httpx.ConnectError as e:
+            raise RuntimeError(
+                f"Can't connect to {self.config.host}: {e}\nPlease ensure the NeMo Guardrails server is running."
+            )
+
+        log.info("Successfully connected to server at %s", self.config.host)
+
+    def _build_locust_command(self, output_dir: Optional[Path] = None) -> list[str]:
+        """Build the Locust command with all parameters."""
+        cmd = ["locust", "-f", str(self.locustfile_path)]
+
+        # Host
+        cmd.extend(["--host", self.config.host])
+
+        # User and spawn rate
+        cmd.extend(["--users", str(self.config.users)])
+        cmd.extend(["--spawn-rate", str(self.config.spawn_rate)])
+
+        # Run time
+        if self.config.run_time:
+            cmd.extend(["--run-time", f"{self.config.run_time}s"])
+
+        # Headless mode
+        if self.config.headless:
+            cmd.append("--headless")
+
+            # Add output files for headless mode
+            if output_dir:
+                html_file = output_dir / "report.html"
+                csv_prefix = output_dir / "stats"
+                cmd.extend(["--html", str(html_file)])
+                cmd.extend(["--csv", str(csv_prefix)])
+
+        log.debug("Locust command: %s", " ".join(cmd))
+        return cmd
+
+    def _save_run_metadata(self, output_dir: Path, command: list[str], start_time: datetime) -> None:
+        """Save metadata about the load test run."""
+        metadata = {
+            "start_time": start_time.isoformat(),
+            "config": self.config.model_dump(),
+            "command": " ".join(command),
+        }
+
+        metadata_file = output_dir / "run_metadata.json"
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            json.dump(metadata, f, indent=2)
+
+        log.debug("Saved run metadata to %s", metadata_file)
+
+    def _create_output_dir(self, base_dir: Path) -> Path:
+        """Create timestamped output directory for test results."""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_dir = base_dir / timestamp
+        output_dir.mkdir(parents=True, exist_ok=True)
+        return output_dir
+
+    def run(self, dry_run: bool) -> int:
+        """Run the Locust load test."""
+        # Check service availability
+        try:
+            self._check_service()
+        except RuntimeError as e:
+            log.error(str(e))
+            return 1
+
+        # Create output directory if in headless mode
+        output_dir = None
+        if self.config.headless:
+            base_dir = Path("locust_results")
+            output_dir = self._create_output_dir(base_dir)
+            log.info("Results will be saved to: %s", output_dir)
+
+        # Build command
+        command = self._build_locust_command(output_dir)
+
+        # Save metadata
+        start_time = datetime.now()
+        if output_dir:
+            self._save_run_metadata(output_dir, command, start_time)
+
+        # Set environment variables for the locustfile
+        env = os.environ.copy()
+        env["LOCUST_CONFIG_ID"] = self.config.config_id
+        env["LOCUST_MODEL"] = self.config.model
+        env["LOCUST_MESSAGE"] = self.config.message
+
+        # Log test configuration
+        log.info("Starting Locust load test")
+        log.info("Host: %s", self.config.host)
+        log.info("Config ID: %s", self.config.config_id)
+        log.info("Model: %s", self.config.model)
+        log.info("Users: %s", self.config.users)
+        log.info("Spawn rate: %s users/second", self.config.spawn_rate)
+        log.info("Run time: %s seconds", self.config.run_time or "unlimited")
+        log.info("Mode: %s", "headless" if self.config.headless else "web UI")
+
+        rampup_seconds = round(self.config.users / self.config.spawn_rate, 2)
+        steady_state_seconds = self.config.run_time - rampup_seconds
+        log.info("Duration: rampup: %fs, steady-state %fs", rampup_seconds, steady_state_seconds)
+
+        if not self.config.headless:
+            log.info("Web UI will be available at: http://localhost:8089")
+
+        try:
+            # For dry-run, just print out the command
+            if dry_run:
+                log.info("Dry run mode. Command: %s", " ".join(command))
+                return 0
+
+            result = subprocess.run(command, env=env, check=False)
+
+            if result.returncode == 0:
+                log.info("Load test completed successfully")
+                if output_dir:
+                    log.info("Results saved to: %s", output_dir)
+            else:
+                log.error("Load test failed with exit code %s", result.returncode)
+
+            return result.returncode
+
+        except KeyboardInterrupt:
+            log.warning("Load test interrupted by user")
+            return 130
+        except Exception as e:
+            log.error("Error running load test: %s", e)
+            return 1
+
+
+def _load_config_from_yaml(config_file: Path) -> LocustConfig:
+    """Load and validate configuration from YAML file."""
+    try:
+        with open(config_file, "r", encoding="utf-8") as f:
+            config_data = yaml.safe_load(f)
+
+        config = LocustConfig(**config_data)
+        return config
+
+    except FileNotFoundError:
+        log.error("Configuration file not found: %s", config_file)
+        sys.exit(1)
+    except yaml.YAMLError as e:
+        log.error("Error parsing YAML configuration: %s", e)
+        sys.exit(1)
+    except ValidationError as e:
+        log.error("Configuration validation error:\n%s", e)
+        sys.exit(1)
+    except Exception as e:
+        log.error("Unexpected error loading configuration: %s", e)
+        sys.exit(1)
+
+
+@app.command()
+def run(
+    config_file: Path = typer.Argument(
+        help="Path to YAML configuration file",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print commands without executing them",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="Print additional debugging information during run",
+    ),
+):
+    """
+    Run Locust load test using provided config file
+    """
+    if verbose:
+        log.setLevel(logging.DEBUG)
+
+    # Load config from file if provided
+    if config_file:
+        locust_config = _load_config_from_yaml(config_file)
+
+    # Create and run the test
+    runner = LocustRunner(locust_config)
+    exit_code = runner.run(dry_run)
+
+    raise typer.Exit(code=exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -89,14 +89,12 @@ class LocustRunner:
         # User and spawn rate
         cmd.extend(["--users", str(self.config.users)])
         cmd.extend(["--spawn-rate", str(self.config.spawn_rate)])
-
-        # Run time
-        if self.config.run_time:
-            cmd.extend(["--run-time", f"{self.config.run_time}s"])
+        cmd.extend(["--run-time", f"{self.config.run_time}s"])
 
         # Headless mode
         if self.config.headless:
             cmd.append("--headless")
+            cmd.append("--only-summary")  # only print last latency table
 
             # Add output files for headless mode
             if output_dir:
@@ -113,7 +111,7 @@ class LocustRunner:
         metadata = {
             "start_time": start_time.isoformat(),
             "config": self.config.model_dump(),
-            "command": " ".join(command),
+            "command": " ".join([str(c) for c in command]),
         }
 
         metadata_file = output_dir / "run_metadata.json"
@@ -122,12 +120,12 @@ class LocustRunner:
 
         log.debug("Saved run metadata to %s", metadata_file)
 
-    def _create_output_dir(self, base_dir: Path) -> Path:
+    def _create_output_path(self, base_dir: str) -> Path:
         """Create timestamped output directory for test results."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_dir = base_dir / Path(timestamp)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        return output_dir
+        output_path = Path(base_dir) / Path(timestamp)
+        output_path.mkdir(parents=True, exist_ok=True)
+        return output_path
 
     def run(self, dry_run: bool) -> int:
         """Run the Locust load test."""
@@ -139,7 +137,7 @@ class LocustRunner:
             return 1
 
         # Build command
-        output_path = self._create_output_dir(self.config.output_base_dir)
+        output_path = self._create_output_path(self.config.output_base_dir)
         command = self._build_locust_command(output_path)
 
         # Save metadata
@@ -157,9 +155,9 @@ class LocustRunner:
         log.info("Starting Locust load test")
         log.info("Config: %s", self.config.model_dump_json())
 
-        rampup_seconds = int(self.config.users / self.config.spawn_rate)
+        rampup_seconds = min(int(self.config.users / self.config.spawn_rate), self.config.run_time)
         steady_state_seconds = self.config.run_time - rampup_seconds
-        log.info("Duration: rampup: %fs, steady-state %fs", rampup_seconds, steady_state_seconds)
+        log.info("Duration: rampup: %is, steady-state %is", rampup_seconds, steady_state_seconds)
 
         if not self.config.headless:
             log.info("Web UI will be available at: http://localhost:8089")

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -62,16 +62,20 @@ class LocustRunner:
 
     def _check_service(self) -> None:
         """Check if the NeMo Guardrails server is up before running tests."""
-        url = f"{self.config.host}/v1/chat/completions"
+        url = f"{self.config.host}/health"
         log.debug("Checking service is up at %s", url)
 
         try:
             # Try a simple request to verify the server is accessible
-            response = httpx.get(self.config.host, timeout=5)
+            response = httpx.get(url)
         except httpx.ConnectError as e:
-            raise RuntimeError(
-                f"Can't connect to {self.config.host}: {e}\nPlease ensure the NeMo Guardrails server is running."
-            )
+            raise RuntimeError(f"ConnectError accessing {url}: {e}")
+
+        if response.is_error:
+            raise RuntimeError(f"Error {response.status_code} connecting to {url}: {response.text}")
+
+        if response.json().get("status") != "healthy":
+            raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
 
         log.info("Successfully connected to server at %s", self.config.host)
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -157,15 +157,9 @@ class LocustRunner:
 
         # Log test configuration
         log.info("Starting Locust load test")
-        log.info("Host: %s", self.config.host)
-        log.info("Config ID: %s", self.config.config_id)
-        log.info("Model: %s", self.config.model)
-        log.info("Users: %s", self.config.users)
-        log.info("Spawn rate: %s users/second", self.config.spawn_rate)
-        log.info("Run time: %s seconds", self.config.run_time or "unlimited")
-        log.info("Mode: %s", "headless" if self.config.headless else "web UI")
+        log.info("Config: %s", self.config.model_dump_json())
 
-        rampup_seconds = round(self.config.users / self.config.spawn_rate, 2)
+        rampup_seconds = int(self.config.users / self.config.spawn_rate)
         steady_state_seconds = self.config.run_time - rampup_seconds
         log.info("Duration: rampup: %fs, steady-state %fs", rampup_seconds, steady_state_seconds)
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -138,7 +138,12 @@ class LocustRunner:
         # For dry-run, print command without creating directories or metadata
         if dry_run:
             command = self._build_locust_command()
-            log.info("Dry run mode. Command: %s", " ".join(command))
+            env_vars = (
+                f"LOCUST_CONFIG_ID={self.config.config_id} "
+                f"LOCUST_MODEL={self.config.model} "
+                f"LOCUST_MESSAGE='{self.config.message}'"
+            )
+            log.info("Dry run mode. Command: %s %s", env_vars, " ".join(command))
             return 0
 
         # Check service availability

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -125,7 +125,7 @@ class LocustRunner:
     def _create_output_dir(self, base_dir: Path) -> Path:
         """Create timestamped output directory for test results."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        output_dir = base_dir / timestamp
+        output_dir = base_dir / Path(timestamp)
         output_dir.mkdir(parents=True, exist_ok=True)
         return output_dir
 
@@ -138,20 +138,14 @@ class LocustRunner:
             log.error(str(e))
             return 1
 
-        # Create output directory if in headless mode
-        output_dir = None
-        if self.config.headless:
-            base_dir = Path("locust_results")
-            output_dir = self._create_output_dir(base_dir)
-            log.info("Results will be saved to: %s", output_dir)
-
         # Build command
-        command = self._build_locust_command(output_dir)
+        output_path = self._create_output_dir(self.config.output_base_dir)
+        command = self._build_locust_command(output_path)
 
         # Save metadata
         start_time = datetime.now()
-        if output_dir:
-            self._save_run_metadata(output_dir, command, start_time)
+        self._save_run_metadata(output_path, command, start_time)
+        log.info("Saving metadata to: %s", output_path)
 
         # Set environment variables for the locustfile
         env = os.environ.copy()
@@ -180,8 +174,8 @@ class LocustRunner:
 
             if result.returncode == 0:
                 log.info("Load test completed successfully")
-                if output_dir:
-                    log.info("Results saved to: %s", output_dir)
+                if output_path:
+                    log.info("Results saved to: %s", output_path)
             else:
                 log.error("Load test failed with exit code %s", result.returncode)
 

--- a/benchmark/locust/run_locust.py
+++ b/benchmark/locust/run_locust.py
@@ -67,15 +67,20 @@ class LocustRunner:
 
         try:
             # Try a simple request to verify the server is accessible
-            response = httpx.get(url)
+            response = httpx.get(url, timeout=5)
         except httpx.ConnectError as e:
             raise RuntimeError(f"ConnectError accessing {url}: {e}")
+        except httpx.TimeoutException as e:
+            raise RuntimeError(f"HTTP Timeout accessing {url}: {e}")
 
         if response.is_error:
             raise RuntimeError(f"Error {response.status_code} connecting to {url}: {response.text}")
 
-        if response.json().get("status") != "healthy":
-            raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
+        try:
+            if response.json().get("status") != "healthy":
+                raise RuntimeError(f"Service at {url} is unhealthy: {response.text}")
+        except json.decoder.JSONDecodeError as e:
+            raise RuntimeError(f"Error: response {response.text} couldn't be parsed as JSON: {e}")
 
         log.info("Successfully connected to server at %s", self.config.host)
 

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -19,3 +19,6 @@ numpy>=2.3.2
 httpx>=0.24.1
 typer>=0.8
 pyyaml>=6.0
+
+# --- locust load testing dependencies ---
+locust>=2.0.0

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Locust load test configuration models.
+"""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from benchmark.locust.locust_models import LocustConfig
+
+
+class TestLocustConfig:
+    """Test the LocustConfig model."""
+
+    def test_config_minimal_valid_with_defaults(self):
+        """Test creating LocustConfig with minimal required fields and verify all defaults."""
+        config = LocustConfig(
+            config_id="test-config",
+            model="test-model",
+        )
+
+        # Verify required fields
+        assert config.config_id == "test-config"
+        assert config.model == "test-model"
+
+        # Verify all defaults
+        assert config.host == "http://localhost:8000"
+        assert config.users == 256
+        assert config.spawn_rate == 10
+        assert config.run_time == 60
+        assert config.message == "Hello, what can you do?"
+        assert config.headless is True
+        assert config.output_base_dir == "locust_results"
+
+    def test_config_with_all_fields(self):
+        """Test creating LocustBaseConfig with all fields specified."""
+        config = LocustConfig(
+            host="http://example.com:9000",
+            config_id="my-config",
+            model="my-model",
+            users=100,
+            spawn_rate=5.5,
+            run_time=120,
+            message="Custom message",
+            headless=True,
+            output_base_dir="/tmp/locust",
+        )
+        assert config.host == "http://example.com:9000"
+        assert config.config_id == "my-config"
+        assert config.model == "my-model"
+        assert config.users == 100
+        assert config.spawn_rate == 5.5
+        assert config.run_time == 120
+        assert config.message == "Custom message"
+        assert config.headless is True
+
+    def test_config_missing_required_fields(self):
+        """Test that missing required fields raise validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            LocustConfig(
+                host="http://localhost:8000",
+                # Missing config_id and model
+            )
+        errors = exc_info.value.errors()
+        error_fields = {err["loc"][0] for err in errors}
+        assert "config_id" in error_fields
+        assert "model" in error_fields
+
+    def test_config_host_without_protocol(self):
+        """Test that host without http:// or https:// raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            LocustConfig(
+                host="localhost:8000",  # Missing http://
+                config_id="test-config",
+                model="test-model",
+            )
+        error_msg = str(exc_info.value)
+        assert "Host must start with http:// or https://" in error_msg
+
+    def test_config_host_with_https(self):
+        """Test that host with https:// is valid."""
+        config = LocustConfig(
+            host="https://secure.example.com",
+            config_id="test-config",
+            model="test-model",
+        )
+        assert config.host == "https://secure.example.com"
+
+    def test_config_host_trailing_slash_removed(self):
+        """Test that trailing slash in host is removed."""
+        config = LocustConfig(
+            host="http://localhost:8000/",
+            config_id="test-config",
+            model="test-model",
+        )
+        assert config.host == "http://localhost:8000"
+
+    def test_config_host_multiple_trailing_slashes(self):
+        """Test that multiple trailing slashes are removed."""
+        config = LocustConfig(
+            host="http://localhost:8000///",
+            config_id="test-config",
+            model="test-model",
+        )
+        assert config.host == "http://localhost:8000"
+
+
+class TestLocustConfigHelpers:
+    """Test helper methods on LocustConfig model."""
+
+    @pytest.fixture
+    def config(self) -> LocustConfig:
+        """Helper to get a valid base config."""
+        return LocustConfig(
+            config_id="test-config",
+            model="test-model",
+        )
+
+    def test_locust_config_get_output_base_path(self, config):
+        """Test get_output_base_path method."""
+        config.output_base_dir = "custom_results"
+
+        path = config.get_output_base_path()
+        assert isinstance(path, Path)
+        assert str(path) == "custom_results"
+
+    def test_locust_config_get_output_base_path_default(self, config):
+        """Test get_output_base_path method with default output_base_dir."""
+        path = config.get_output_base_path()
+        assert isinstance(path, Path)
+        assert str(path) == "locust_results"
+
+    def test_locust_config_with_dict(self):
+        """Test creating LocustConfig with dict base_config."""
+        config = LocustConfig(
+            **{
+                "config_id": "test-config",
+                "model": "test-model",
+                "users": 100,
+            }
+        )
+        assert config.config_id == "test-config"
+        assert config.model == "test-model"
+        assert config.users == 100

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -18,8 +18,6 @@
 Tests for Locust load test configuration models.
 """
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -124,28 +122,6 @@ class TestLocustConfig:
 
 class TestLocustConfigHelpers:
     """Test helper methods on LocustConfig model."""
-
-    @pytest.fixture
-    def config(self) -> LocustConfig:
-        """Helper to get a valid base config."""
-        return LocustConfig(
-            config_id="test-config",
-            model="test-model",
-        )
-
-    def test_locust_config_get_output_base_path(self, config):
-        """Test get_output_base_path method."""
-        config.output_base_dir = "custom_results"
-
-        path = config.get_output_base_path()
-        assert isinstance(path, Path)
-        assert str(path) == "custom_results"
-
-    def test_locust_config_get_output_base_path_default(self, config):
-        """Test get_output_base_path method with default output_base_dir."""
-        path = config.get_output_base_path()
-        assert isinstance(path, Path)
-        assert str(path) == "locust_results"
 
     def test_locust_config_with_dict(self):
         """Test creating LocustConfig with dict base_config."""

--- a/benchmark/tests/test_locust_models.py
+++ b/benchmark/tests/test_locust_models.py
@@ -68,6 +68,18 @@ class TestLocustConfig:
         assert config.run_time == 120
         assert config.message == "Custom message"
         assert config.headless is True
+        assert config.output_base_dir == "/tmp/locust"
+
+    def test_config_extra_fields_forbidden(self):
+        """Test that extra/unknown fields raise validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            LocustConfig(
+                config_id="test-config",
+                model="test-model",
+                spawn_rats=5,  # typo of spawn_rate
+            )
+        error_msg = str(exc_info.value)
+        assert "spawn_rats" in error_msg
 
     def test_config_missing_required_fields(self):
         """Test that missing required fields raise validation error."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -24,7 +24,6 @@ from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
-from urllib.parse import urljoin
 
 import httpx
 import pytest
@@ -117,8 +116,8 @@ class TestLocustRunner:
         return LocustRunner(valid_config)
 
     def _service_health_endpoint(self, runner: LocustRunner):
-        """The endpoint used ot check if the service is healthy"""
-        return urljoin(runner.config.host, "health")
+        """The endpoint used to check if the service is healthy"""
+        return f"{runner.config.host}/health"
 
     def test_runner_init(self, valid_config):
         """Test LocustRunner initialization."""
@@ -414,17 +413,15 @@ class TestLoadConfigFromYaml:
         assert exc_info.value.code == 1
 
     def test_load_config_unexpected_error(self, tmp_path):
-        """Test loading config with unexpected error."""
+        """Test that unexpected errors propagate instead of being silently swallowed."""
         config_file = tmp_path / "config.yml"
         config_file.write_text("valid_yaml: true")
 
         with patch("yaml.safe_load") as mock_load:
             mock_load.side_effect = Exception("Unexpected error")
 
-            with pytest.raises(SystemExit) as exc_info:
+            with pytest.raises(Exception, match="Unexpected error"):
                 _load_config_from_yaml(config_file)
-
-            assert exc_info.value.code == 1
 
 
 class TestCLI:

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -212,13 +212,6 @@ class TestLocustRunner:
         assert "--html" in cmd
         assert "--csv" in cmd
 
-    def test_build_locust_command_without_run_time(self, runner):
-        """Test building Locust command without run_time (unlimited)."""
-        runner.config.run_time = None
-        cmd = runner._build_locust_command()
-
-        assert "--run-time" not in cmd
-
     def test_save_run_metadata(self, runner, tmp_path):
         """Test saving run metadata to file."""
         output_dir = tmp_path / "output"
@@ -242,13 +235,13 @@ class TestLocustRunner:
 
     def test_create_output_dir(self, runner, tmp_path):
         """Test creating timestamped output directory."""
-        base_dir = tmp_path / "results"
+        base_dir = str(tmp_path) + "results"
 
-        output_dir = runner._create_output_dir(base_dir)
+        output_dir = runner._create_output_path(base_dir)
 
         assert output_dir.exists()
         assert output_dir.is_dir()
-        assert output_dir.parent == base_dir
+        assert output_dir.parent == Path(base_dir)
         # Check that directory name looks like a timestamp
         assert len(output_dir.name) == len("20250101_120000")
 

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -174,7 +174,7 @@ class TestLocustRunner:
             mock_response.is_error = True
             mock_response.status_code = 404
             mock_response.text = '{"detail":"Not Found"}'
-            mock_response.json.return_value = json.dumps(mock_response.text)
+            mock_response.json.return_value = json.loads(mock_response.text)
             mock_get.return_value = mock_response
 
             with pytest.raises(RuntimeError) as exc_info:

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -99,7 +99,7 @@ class TestLocustRunner:
     """Test LocustRunner class."""
 
     @pytest.fixture
-    def valid_config(self):
+    def valid_config(self, tmp_path):
         """Get a valid LocustConfig for testing."""
         return LocustConfig(
             host="http://localhost:8000",
@@ -108,6 +108,7 @@ class TestLocustRunner:
             users=10,
             spawn_rate=2,
             run_time=30,
+            output_base_dir=str(tmp_path / "locust_results"),
         )
 
     @pytest.fixture

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -108,6 +108,7 @@ class TestLocustRunner:
             users=10,
             spawn_rate=2,
             run_time=30,
+            headless=True,
             output_base_dir=str(tmp_path / "locust_results"),
         )
 
@@ -214,9 +215,8 @@ class TestLocustRunner:
             mock_response.is_error = False
             mock_response.status_code = 200
             mock_response.text = "{'key': 'value'}"
-            mock_response.json.side_effect = JSONDecodeError(
-                "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)", "{'key': 'value'}", 1
-            )
+            json_error = JSONDecodeError("Expecting property name enclosed in double quotes", "{'key': 'value'}", 1)
+            mock_response.json.side_effect = json_error
             mock_get.return_value = mock_response
 
             with pytest.raises(RuntimeError) as exc_info:
@@ -225,7 +225,7 @@ class TestLocustRunner:
             mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
             assert (
                 exc_info.value.args[0]
-                == "Error: response {'key': 'value'} couldn't be parsed as JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1): line 1 column 2 (char 1)"
+                == f"Error: response {mock_response.text} couldn't be parsed as JSON: {json_error}"
             )
 
     def test_build_locust_command_basic(self, runner):
@@ -245,8 +245,20 @@ class TestLocustRunner:
         cmd = runner._build_locust_command(output_dir)
 
         assert "--headless" in cmd
+        assert "--only-summary" in cmd
         assert "--html" in cmd
         assert "--csv" in cmd
+
+    def test_build_locust_command_non_headless(self, runner):
+        """Test building Locust command in web UI mode (non-headless)."""
+        runner.config.headless = False
+
+        cmd = runner._build_locust_command()
+
+        assert "--headless" not in cmd
+        assert "--only-summary" not in cmd
+        assert "--html" not in cmd
+        assert "--csv" not in cmd
 
     def test_save_run_metadata(self, runner, tmp_path):
         """Test saving run metadata to file."""
@@ -479,3 +491,21 @@ class TestCLI:
             assert config.model == "test-model"
             # Verify run was called with dry_run parameter
             mock_runner.run.assert_called_once_with(False)
+
+    def test_run_command_with_dry_run(self, cli_runner, create_config_file):
+        """Test run command with --dry-run CLI option."""
+        config_file = create_config_file()
+
+        with patch("benchmark.locust.run_locust.LocustRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner.run.return_value = 0
+            mock_runner_class.return_value = mock_runner
+
+            result = cli_runner.invoke(
+                app,
+                [str(config_file), "--dry-run"],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, f"Output: {result.stdout}"
+            mock_runner.run.assert_called_once_with(True)

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -363,6 +363,15 @@ class TestLocustRunner:
 
             assert exit_code == 1
 
+    def test_run_dry_run(self, runner):
+        """Test dry-run mode prints command without executing subprocess or checking service."""
+        with patch.object(runner, "_check_service") as mock_check, patch("subprocess.run") as mock_run:
+            exit_code = runner.run(dry_run=True)
+
+            assert exit_code == 0
+            mock_check.assert_not_called()
+            mock_run.assert_not_called()
+
 
 class TestLoadConfigFromYaml:
     """Test _load_config_from_yaml function."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
+from urllib.parse import urljoin
 
 import httpx
 import pytest
@@ -114,6 +115,10 @@ class TestLocustRunner:
         """Get a LocustRunner instance for testing."""
         return LocustRunner(valid_config)
 
+    def _service_health_endpoint(self, runner: LocustRunner):
+        """The endpoint used ot check if the service is healthy"""
+        return urljoin(runner.config.host, "health")
+
     def test_runner_init(self, valid_config):
         """Test LocustRunner initialization."""
         runner = LocustRunner(valid_config)
@@ -125,23 +130,67 @@ class TestLocustRunner:
         """Test _check_service with successful connection."""
         with patch("httpx.get") as mock_get:
             mock_response = Mock()
-            mock_response.status_code = 200
+            mock_response.is_error = False
+            mock_response.json.return_value = {"status": "healthy", "timestamp": 1770675471}
             mock_get.return_value = mock_response
 
             # Should not raise
             runner._check_service()
-            mock_get.assert_called_once()
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
 
     def test_check_service_connection_error(self, runner):
-        """Test _check_service with connection error."""
+        """Test _check_service with httpx.ConnectError"""
         with patch("httpx.get") as mock_get:
             mock_get.side_effect = httpx.ConnectError("Connection refused")
 
             with pytest.raises(RuntimeError) as exc_info:
                 runner._check_service()
 
-            assert "Can't connect to" in str(exc_info.value)
-            assert "http://localhost:8000" in str(exc_info.value)
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            assert (
+                exc_info.value.args[0]
+                == f"ConnectError accessing {self._service_health_endpoint(runner)}: Connection refused"
+            )
+
+    def test_check_service_error_response(self, runner):
+        """Test _check_service with non-200 response code"""
+        with patch("httpx.get") as mock_get:
+            mock_response = Mock()
+            mock_response.is_error = True
+            mock_response.status_code = 404
+            mock_response.text = '{"detail":"Not Found"}'
+            mock_response.json.return_value = json.dumps(mock_response.text)
+            mock_get.return_value = mock_response
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            assert (
+                exc_info.value.args[0]
+                == f"Error {mock_response.status_code} connecting to {self._service_health_endpoint(runner)}: {mock_response.text}"
+            )
+
+    def test_check_service_uinhealthy_response(self, runner):
+        """Test _check_service with 200 response from an unhealthy service"""
+        with patch("httpx.get") as mock_get:
+            mock_response = Mock()
+            mock_response.is_error = False
+            mock_response.status_code = 200  # Successful HTTP request ..
+            mock_response.text = (
+                '{"status":"unhealthy","timestamp":1770677847}'  # .. but the application itself is unhealthy
+            )
+            mock_response.json.return_value = json.loads(mock_response.text)
+            mock_get.return_value = mock_response
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            assert (
+                exc_info.value.args[0]
+                == f"Service at {self._service_health_endpoint(runner)} is unhealthy: {mock_response.text}"
+            )
 
     def test_build_locust_command_basic(self, runner):
         """Test building basic Locust command."""

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -20,6 +20,7 @@ Tests for Locust load test CLI runner.
 
 import json
 from datetime import datetime
+from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
@@ -136,7 +137,7 @@ class TestLocustRunner:
 
             # Should not raise
             runner._check_service()
-            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
 
     def test_check_service_connection_error(self, runner):
         """Test _check_service with httpx.ConnectError"""
@@ -146,10 +147,24 @@ class TestLocustRunner:
             with pytest.raises(RuntimeError) as exc_info:
                 runner._check_service()
 
-            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
             assert (
                 exc_info.value.args[0]
                 == f"ConnectError accessing {self._service_health_endpoint(runner)}: Connection refused"
+            )
+
+    def test_check_service_timeout_error(self, runner):
+        """Test _check_service when httpx.get times out"""
+        with patch("httpx.get") as mock_get:
+            mock_get.side_effect = httpx.TimeoutException("httpx.ConnectTimeout: The connection operation timed out")
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
+            assert (
+                exc_info.value.args[0]
+                == f"HTTP Timeout accessing {self._service_health_endpoint(runner)}: httpx.ConnectTimeout: The connection operation timed out"
             )
 
     def test_check_service_error_response(self, runner):
@@ -165,13 +180,13 @@ class TestLocustRunner:
             with pytest.raises(RuntimeError) as exc_info:
                 runner._check_service()
 
-            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
             assert (
                 exc_info.value.args[0]
                 == f"Error {mock_response.status_code} connecting to {self._service_health_endpoint(runner)}: {mock_response.text}"
             )
 
-    def test_check_service_uinhealthy_response(self, runner):
+    def test_check_service_unhealthy_response(self, runner):
         """Test _check_service with 200 response from an unhealthy service"""
         with patch("httpx.get") as mock_get:
             mock_response = Mock()
@@ -186,10 +201,31 @@ class TestLocustRunner:
             with pytest.raises(RuntimeError) as exc_info:
                 runner._check_service()
 
-            mock_get.assert_called_once_with(self._service_health_endpoint(runner))
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
             assert (
                 exc_info.value.args[0]
                 == f"Service at {self._service_health_endpoint(runner)} is unhealthy: {mock_response.text}"
+            )
+
+    def test_check_service_invalid_json(self, runner):
+        """Test _check_service with an invalid JSON response"""
+        with patch("httpx.get") as mock_get:
+            mock_response = Mock()
+            mock_response.is_error = False
+            mock_response.status_code = 200
+            mock_response.text = "{'key': 'value'}"
+            mock_response.json.side_effect = JSONDecodeError(
+                "Expecting property name enclosed in double quotes: line 1 column 2 (char 1)", "{'key': 'value'}", 1
+            )
+            mock_get.return_value = mock_response
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            mock_get.assert_called_once_with(self._service_health_endpoint(runner), timeout=5)
+            assert (
+                exc_info.value.args[0]
+                == "Error: response {'key': 'value'} couldn't be parsed as JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1): line 1 column 2 (char 1)"
             )
 
     def test_build_locust_command_basic(self, runner):

--- a/benchmark/tests/test_run_locust.py
+++ b/benchmark/tests/test_run_locust.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for Locust load test CLI runner.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from benchmark.locust.locust_models import LocustConfig
+from benchmark.locust.run_locust import LocustRunner, _load_config_from_yaml, app
+
+
+@pytest.fixture
+def create_config_data(tmp_path):
+    """Returns a function with sample basic config, and allows mutation of fields to cover
+    more cases or add extra fields"""
+
+    def _create_config(
+        config_id="test-config",
+        model="test-model",
+        host="http://localhost:8000",
+        users=256,
+        spawn_rate=10,
+        run_time=60,
+        message="Hello, what can you do?",
+        headless=False,
+        output_base_dir=str(tmp_path),
+        **extra_config,
+    ):
+        config_data = {
+            "host": host,
+            "config_id": config_id,
+            "model": model,
+            "users": users,
+            "spawn_rate": spawn_rate,
+            "run_time": run_time,
+            "message": message,
+            "headless": headless,
+            "output_base_dir": output_base_dir,
+        }
+
+        # Merge any extra config parameters
+        if extra_config:
+            config_data.update(extra_config)
+
+        return config_data
+
+    return _create_config
+
+
+@pytest.fixture
+def create_config_file(tmp_path, create_config_data):
+    """Fixture to write config data to a file and return the path."""
+
+    def _write_config_file(
+        extra_base_config: Optional[Dict[str, Any]] = None,
+        filename: Optional[str] = "config.yml",
+    ) -> Path:
+        """Apply extra base config to config data, write to file and return the path."""
+
+        # Unpack extra_base_config as kwargs if provided
+        if extra_base_config:
+            config_data = create_config_data(**extra_base_config)
+        else:
+            config_data = create_config_data()
+
+        config_file = tmp_path / filename
+        config_file.write_text(yaml.dump(config_data))
+        return config_file
+
+    return _write_config_file
+
+
+class TestLocustRunner:
+    """Test LocustRunner class."""
+
+    @pytest.fixture
+    def valid_config(self):
+        """Get a valid LocustConfig for testing."""
+        return LocustConfig(
+            host="http://localhost:8000",
+            config_id="test-config",
+            model="test-model",
+            users=10,
+            spawn_rate=2,
+            run_time=30,
+        )
+
+    @pytest.fixture
+    def runner(self, valid_config):
+        """Get a LocustRunner instance for testing."""
+        return LocustRunner(valid_config)
+
+    def test_runner_init(self, valid_config):
+        """Test LocustRunner initialization."""
+        runner = LocustRunner(valid_config)
+        assert runner.config == valid_config
+        assert runner.locustfile_path.exists()
+        assert runner.locustfile_path.name == "locustfile.py"
+
+    def test_check_service_success(self, runner):
+        """Test _check_service with successful connection."""
+        with patch("httpx.get") as mock_get:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_get.return_value = mock_response
+
+            # Should not raise
+            runner._check_service()
+            mock_get.assert_called_once()
+
+    def test_check_service_connection_error(self, runner):
+        """Test _check_service with connection error."""
+        with patch("httpx.get") as mock_get:
+            mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+            with pytest.raises(RuntimeError) as exc_info:
+                runner._check_service()
+
+            assert "Can't connect to" in str(exc_info.value)
+            assert "http://localhost:8000" in str(exc_info.value)
+
+    def test_build_locust_command_basic(self, runner):
+        """Test building basic Locust command."""
+        cmd = runner._build_locust_command()
+        assert cmd[0] == "locust"
+
+        cmd_string = " ".join(cmd)
+        assert "--host http://localhost:8000 --users 10 --spawn-rate 2.0 --run-time 30s --headless" in cmd_string
+
+    def test_build_locust_command_headless(self, runner, tmp_path):
+        """Test building Locust command in headless mode."""
+        runner.config.headless = True
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        cmd = runner._build_locust_command(output_dir)
+
+        assert "--headless" in cmd
+        assert "--html" in cmd
+        assert "--csv" in cmd
+
+    def test_build_locust_command_without_run_time(self, runner):
+        """Test building Locust command without run_time (unlimited)."""
+        runner.config.run_time = None
+        cmd = runner._build_locust_command()
+
+        assert "--run-time" not in cmd
+
+    def test_save_run_metadata(self, runner, tmp_path):
+        """Test saving run metadata to file."""
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+        start_time = datetime.now()
+        command = ["locust", "-f", "locustfile.py"]
+
+        runner._save_run_metadata(output_dir, command, start_time)
+
+        metadata_file = output_dir / "run_metadata.json"
+        assert metadata_file.exists()
+
+        with open(metadata_file) as f:
+            metadata = json.load(f)
+
+        assert "start_time" in metadata
+        assert "config" in metadata
+        assert "command" in metadata
+        assert metadata["config"]["config_id"] == "test-config"
+        assert metadata["config"]["model"] == "test-model"
+
+    def test_create_output_dir(self, runner, tmp_path):
+        """Test creating timestamped output directory."""
+        base_dir = tmp_path / "results"
+
+        output_dir = runner._create_output_dir(base_dir)
+
+        assert output_dir.exists()
+        assert output_dir.is_dir()
+        assert output_dir.parent == base_dir
+        # Check that directory name looks like a timestamp
+        assert len(output_dir.name) == len("20250101_120000")
+
+    def test_run_success_headless(self, runner, tmp_path):
+        """Test successful run in headless mode."""
+        runner.config.headless = True
+
+        with patch.object(runner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_result = Mock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 0
+            mock_run.assert_called_once()
+
+            # Check that command was built correctly
+            call_args = mock_run.call_args
+            assert call_args[0][0][0] == "locust"
+            assert "--headless" in call_args[0][0]
+
+            # Check that env variables were set
+            env = call_args[1]["env"]
+            assert env["LOCUST_CONFIG_ID"] == "test-config"
+            assert env["LOCUST_MODEL"] == "test-model"
+            assert env["LOCUST_MESSAGE"] == "Hello, what can you do?"
+
+    def test_run_success_web_ui(self, runner):
+        """Test successful run in web UI mode."""
+        runner.config.headless = False
+
+        with patch.object(runner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_result = Mock()
+            mock_result.returncode = 0
+            mock_run.return_value = mock_result
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 0
+            mock_run.assert_called_once()
+
+            # Check that command was built correctly
+            call_args = mock_run.call_args
+            assert call_args[0][0][0] == "locust"
+            assert "--headless" not in call_args[0][0]
+
+    def test_run_failure(self, runner):
+        """Test run with command failure."""
+        with patch.object(runner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_result = Mock()
+            mock_result.returncode = 1
+            mock_run.return_value = mock_result
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 1
+
+    def test_run_keyboard_interrupt(self, runner):
+        """Test run interrupted by user."""
+        with patch.object(runner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.side_effect = KeyboardInterrupt()
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 130
+
+    def test_run_service_check_failure(self, runner):
+        """Test run when service check fails."""
+        with patch.object(runner, "_check_service") as mock_check:
+            mock_check.side_effect = RuntimeError("Service unavailable")
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 1
+
+    def test_run_exception(self, runner):
+        """Test run with unexpected exception."""
+        with patch.object(runner, "_check_service"), patch("subprocess.run") as mock_run:
+            mock_run.side_effect = Exception("Unexpected error")
+
+            exit_code = runner.run(dry_run=False)
+
+            assert exit_code == 1
+
+
+class TestLoadConfigFromYaml:
+    """Test _load_config_from_yaml function."""
+
+    def test_load_valid_config(self, create_config_file):
+        """Test loading a valid config file."""
+        config_file = create_config_file()
+
+        config = _load_config_from_yaml(config_file)
+
+        assert isinstance(config, LocustConfig)
+        assert config.config_id == "test-config"
+        assert config.model == "test-model"
+
+    def test_load_config_file_not_found(self, tmp_path):
+        """Test loading non-existent config file."""
+        config_file = tmp_path / "nonexistent.yml"
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_config_from_yaml(config_file)
+
+        assert exc_info.value.code == 1
+
+    def test_load_config_invalid_yaml(self, tmp_path):
+        """Test loading file with invalid YAML."""
+        config_file = tmp_path / "invalid.yml"
+        config_file.write_text("invalid: yaml: content: [")
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_config_from_yaml(config_file)
+
+        assert exc_info.value.code == 1
+
+    def test_load_config_validation_error(self, tmp_path):
+        """Test loading file with validation errors."""
+        config_file = tmp_path / "invalid.yml"
+        config_data = {
+            "batch_name": "test",
+            "base_config": {
+                "config_id": "test-config",
+                # Missing required model field
+            },
+        }
+        config_file.write_text(yaml.dump(config_data))
+
+        with pytest.raises(SystemExit) as exc_info:
+            _load_config_from_yaml(config_file)
+
+        assert exc_info.value.code == 1
+
+    def test_load_config_unexpected_error(self, tmp_path):
+        """Test loading config with unexpected error."""
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("valid_yaml: true")
+
+        with patch("yaml.safe_load") as mock_load:
+            mock_load.side_effect = Exception("Unexpected error")
+
+            with pytest.raises(SystemExit) as exc_info:
+                _load_config_from_yaml(config_file)
+
+            assert exc_info.value.code == 1
+
+
+class TestCLI:
+    """Test CLI commands."""
+
+    @pytest.fixture
+    def cli_runner(self):
+        """Get a Typer CLI test runner."""
+        return CliRunner()
+
+    def test_run_command_missing_config_file(self, cli_runner):
+        """Test run command without required config file."""
+        result = cli_runner.invoke(app, [])
+
+        assert result.exit_code != 0  # Should fail
+        # Check that error message mentions missing argument
+        assert "missing" in result.stdout.lower() or result.exit_code == 2
+
+    def test_run_command_config_file_not_found(self, cli_runner, tmp_path):
+        """Test run command with non-existent config file."""
+        nonexistent_file = tmp_path / "nonexistent.yaml"
+        result = cli_runner.invoke(app, [str(nonexistent_file)])
+
+        assert result.exit_code != 0  # Should fail
+
+    def test_run_command_with_config_file(self, cli_runner, create_config_file):
+        """Test run command with YAML config file."""
+        config_file = create_config_file()
+
+        with patch("benchmark.locust.run_locust.LocustRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner.run.return_value = 0
+            mock_runner_class.return_value = mock_runner
+
+            result = cli_runner.invoke(
+                app,
+                [str(config_file)],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0, f"Output: {result.stdout}"
+            mock_runner_class.assert_called_once()
+            config = mock_runner_class.call_args[0][0]
+            assert config.config_id == "test-config"
+            assert config.model == "test-model"
+            # Verify run was called with dry_run parameter
+            mock_runner.run.assert_called_once_with(False)

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -33,8 +33,8 @@ from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
 
 # Queue configuration constants
-MAX_QUEUE_SIZE = 100
-MAX_CONCURRENCY = 10
+MAX_QUEUE_SIZE = 10000
+MAX_CONCURRENCY = 256
 
 log = logging.getLogger(__name__)
 

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -33,8 +33,8 @@ from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
 
 # Queue configuration constants
-MAX_QUEUE_SIZE = 10000
-MAX_CONCURRENCY = 256
+MAX_QUEUE_SIZE = 100
+MAX_CONCURRENCY = 10
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

[Locust](https://locust.io/) is a general-purpose tool to stress-test HTTP servers. While [AI-Perf](https://github.com/ai-dynamo/aiperf) focuses on steady-state performance, Locust ramps up users and concurrency to the point where a system may break. This tests whether a service can gracefully degrade and recover, or fall over and be unstable. Locust doesn't handle SSE streaming workflows with TTFT and ITL measurements, only end-to-end latency.

The PR code uses a similar YAML config file approach to the AIPerf benchmarking code. The example config included can be used with a [Mock LLM Server](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/benchmark/mock_llm_server) as an example workflow. 

## Test Plan

### Pre-commit

```bash
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-tests

```bash
$ poetry run pytest -q
.......................ssss................................................................................... [  4%]
......s....................................................................................................... [  8%]
.............................................................................................................. [ 12%]
....................ss........................................................................................ [ 16%]
.............................................................................................................. [ 20%]
s.........................................ss...........................s...s.................................. [ 24%]
.............s................................................................................................ [ 28%]
.......ss........ss...ss............................................s......................................... [ 32%]
..........s............s...................................................................................... [ 36%]
.............................................................................................................. [ 41%]
.............................................................................................................. [ 45%]
.....................ssssssssssssssssss.........sssss......................................................... [ 49%]
........................s...........ss.................................ssssssss.ssssssssss.................... [ 53%]
.........s..............................................................................................ssssss [ 57%]
ss..............sss...ss...ss.....ssssssssssssss........................................../Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-5Qi8Qhx1-py3.13/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  del self._storage[key]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
.................... [ 61%]
............................................s................................................................. [ 65%]
.............................................sssssssss.........ss............................................. [ 69%]
.........................................................................sssssss.............................. [ 73%]
.............................................................................................................. [ 78%]
...................................ss......................................................................... [ 82%]
.............................................................................................................. [ 86%]
.............................................................................................................. [ 90%]
..s........................................................................................................... [ 94%]
.............................................................................................................. [ 98%]
......................................                                                                         [100%]
2560 passed, 118 skipped in 116.35s (0:01:56)
```


### Local integration test

#### LLM Server

```bash
$ PYTHONPATH=.. python mock_llm_server/run_server.py --workers 4 --port 8000 --config-file mock_llm_server/configs/meta-llama-3.3-70b-instruct.env
2026-02-09 15:37:37 INFO: Using config file: mock_llm_server/configs/meta-llama-3.3-70b-instruct.env
2026-02-09 15:37:37 INFO: Starting Mock LLM Server on 0.0.0.0:8000
2026-02-09 15:37:37 INFO: OpenAPI docs available at: http://0.0.0.0:8000/docs
2026-02-09 15:37:37 INFO: Health check at: http://0.0.0.0:8000/health
2026-02-09 15:37:37 INFO: Serving model with config mock_llm_server/configs/meta-llama-3.3-70b-instruct.env
2026-02-09 15:37:37 INFO: Press Ctrl+C to stop the server
INFO:     Loading environment from 'mock_llm_server/configs/meta-llama-3.3-70b-instruct.env'
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:     Started parent process [65985]
INFO:     Started server process [65989]
INFO:     Started server process [65987]
INFO:     Waiting for application startup.
INFO:     Waiting for application startup.
INFO:     Started server process [65990]
INFO:     Started server process [65988]
INFO:     Waiting for application startup.
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Application startup complete.
INFO:     Application startup complete.
INFO:     Application startup complete.


``` 

#### Locust load-tester

```
$ python -m benchmark.locust benchmark/locust/configs/local.yaml

2026-02-09 15:38:37 INFO: Successfully connected to server at http://localhost:8000
2026-02-09 15:38:37 INFO: Starting Locust load test
2026-02-09 15:38:37 INFO: Config: {"host":"http://localhost:8000","config_id":"my-guardrails-config","model":"meta/llama-3.3-70b-instruct","users":1024,"spawn_rate":16.0,"run_time":120,"message":"Hello, what can you do?","headless":false,"output_base_dir":"locust_results"}
2026-02-09 15:38:37 INFO: Duration: rampup: 64.000000s, steady-state 56.000000s
2026-02-09 15:38:37 INFO: Web UI will be available at: http://localhost:8089
[2026-02-09 15:38:39,925] ---------------/INFO/locust.main: Starting Locust 2.43.2
[2026-02-09 15:38:39,945] ---------------/INFO/locust.main: Starting web interface at http://0.0.0.0:8089, press enter to open your default browser.
```

#### Locust plots

<img width="1498" height="1037" alt="image" src="https://github.com/user-attachments/assets/66214d22-ca04-4027-9434-698775f9b94c" />


### Locust CSV output (stats_stats_history.csv)

This shows the Mock LLM with 4 FastAPI workers can meet the demands of 768 concurrent users (the highest user count before failures becomes non-zero). 

<img width="603" height="1177" alt="image" src="https://github.com/user-attachments/assets/e00b7229-68a9-4777-89aa-e0e1af89aa15" />

## Related Issue(s)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
