### PR TITLE
feat(server): Add OpenAI compatible v1/models endpoint

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -18,13 +18,14 @@ import contextvars
 import importlib.util
 import json
 import logging
-import os.path
+import os
 import re
 import time
 import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Callable, List, Optional, Union
 
+import httpx
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from openai.types.chat.chat_completion import Choice
@@ -40,10 +41,12 @@ from nemoguardrails.server.datastore.datastore import DataStore
 from nemoguardrails.server.schemas.openai import (
     GuardrailsChatCompletion,
     GuardrailsChatCompletionRequest,
+    OpenAIModelsList,
 )
 from nemoguardrails.server.schemas.utils import (
     create_error_chat_completion,
     extract_bot_message_from_response,
+    fetch_models,
     format_streaming_chunk_as_sse,
     generation_response_to_chat_completion,
 )
@@ -226,6 +229,41 @@ async def get_rails_configs():
     ]
 
     return [{"id": config_id} for config_id in config_ids]
+
+
+@app.get(
+    "/v1/models",
+    response_model=OpenAIModelsList,
+    summary="Get list of available models.",
+)
+async def list_models(request: Request):
+    """Return the list of models available from the configured provider."""
+
+    engine = os.environ.get("MAIN_MODEL_ENGINE", "openai")
+
+    # Forward auth headers from the incoming request.
+    request_headers: dict[str, str] = {}
+    auth_header = request.headers.get("authorization")
+    if auth_header:
+        request_headers["Authorization"] = auth_header
+
+    try:
+        # Fetch the list of models from the configured provider
+        models = await fetch_models(engine, request_headers)
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(
+            status_code=exc.response.status_code,
+            detail=f"Error fetching models from upstream: {exc.response.text}",
+        )
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Error connecting to upstream model server: {str(exc)}",
+        )
+
+    return OpenAIModelsList(data=models)
 
 
 # One instance of LLMRails per config id

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -16,7 +16,7 @@
 """OpenAI API schema definitions for the NeMo Guardrails server."""
 
 import os
-from typing import Any, List, Optional, Union
+from typing import Any, List, Literal, Optional, Union
 
 from openai.types.chat.chat_completion import ChatCompletion
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
@@ -150,3 +150,18 @@ class GuardrailsChatCompletionRequest(OpenAIChatCompletionRequest):
         default_factory=GuardrailsDataInput,
         description="Guardrails specific options for the request.",
     )
+
+
+class OpenAIModel(BaseModel):
+    """Standard OpenAI model."""
+
+    id: str = Field(..., description="The model identifier.")
+    created: int = Field(..., description="The unix timestamp in seconds of the model's creation.")
+    object: Literal["model"] = Field("model", description="The object type which is always 'model'.")
+    owned_by: str | None = Field(..., description="The organization that owns the model.")
+
+
+class OpenAIModelsList(BaseModel):
+    """Standard OpenAI models list response."""
+
+    data: list[OpenAIModel] = Field(..., description="List of OpenAI model objects.")

--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -16,15 +16,167 @@
 """Utility functions for converting between Guardrails and OpenAI API formats."""
 
 import json
+import logging
+import os
 import time
 import uuid
-from typing import Any, Dict, Optional, Tuple, Union
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+import httpx
 from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
 from nemoguardrails.rails.llm.options import GenerationResponse
-from nemoguardrails.server.schemas.openai import GuardrailsChatCompletion, GuardrailsDataOutput
+from nemoguardrails.server.schemas.openai import (
+    GuardrailsChatCompletion,
+    GuardrailsDataOutput,
+    OpenAIModel,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _azure_url() -> str:
+    """Build the Azure OpenAI models URL from env vars."""
+    endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").rstrip("/")
+    if not endpoint:
+        raise ValueError("AZURE_OPENAI_ENDPOINT is not set")
+    version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-06-01")
+    return f"{endpoint}/openai/models?api-version={version}"
+
+
+def _parse_timestamp(value: Any, default: int) -> int:
+    """Return an integer epoch from *value* (int, float, ISO-8601 str, or None)."""
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return int(dt.timestamp())
+        except (ValueError, TypeError):
+            pass
+    return default
+
+
+def _openai_compatible_url() -> str:
+    """Build a ``/v1/models`` URL from ``MAIN_MODEL_BASE_URL``."""
+    base = os.environ.get("MAIN_MODEL_BASE_URL", "").rstrip("/")
+    if not base:
+        raise ValueError("MAIN_MODEL_BASE_URL is not set")
+    return f"{base}/models" if base.endswith("/v1") else f"{base}/v1/models"
+
+
+PROVIDERS: Dict[str, dict] = {
+    # OpenAI compatible
+    "openai": {},
+    "vllm": {},
+    "nim": {},
+    "trt_llm": {},
+    "anthropic": {
+        "url": lambda: os.environ.get("MAIN_MODEL_BASE_URL", "https://api.anthropic.com").rstrip("/") + "/v1/models",
+        "api_key_env": "ANTHROPIC_API_KEY",
+        "auth_header": "x-api-key",
+        "bearer": False,
+        "extra_headers": {"anthropic-version": "2023-06-01"},
+        "created_field": "created_at",
+        "owned_by": "anthropic",
+    },
+    "azure": {
+        "url": _azure_url,
+        "api_key_env": "AZURE_OPENAI_API_KEY",
+        "auth_header": "api-key",
+        "bearer": False,
+        "created_field": "created_at",
+        "owned_by": "azure",
+    },
+    "cohere": {
+        "url": lambda: os.environ.get("COHERE_BASE_URL", "https://api.cohere.com").rstrip("/") + "/v2/models",
+        "api_key_env": "COHERE_API_KEY",
+        "extra_headers": {"Accept": "application/json"},
+        "models_key": "models",
+        "id_field": "name",
+        "owned_by": "cohere",
+    },
+}
+PROVIDERS["azure_openai"] = PROVIDERS["azure"]
+
+
+async def fetch_models(
+    engine: str,
+    request_headers: Dict[str, str],
+) -> List[OpenAIModel]:
+    """Fetch the model list for the specified engine and return OpenAIModel objects."""
+    # Look up the provider in the PROVIDERS table
+    provider = PROVIDERS.get(engine)
+
+    if provider is None:
+        if os.environ.get("MAIN_MODEL_BASE_URL"):
+            log.info(
+                "Engine '%s' not in provider table; trying OpenAI-compatible endpoint via MAIN_MODEL_BASE_URL",
+                engine,
+            )
+            provider = {}
+        else:
+            log.warning(
+                "Engine '%s' is not supported and MAIN_MODEL_BASE_URL is not set. Returning empty model list.",
+                engine,
+            )
+            return []
+
+    url_or_fn = provider.get("url")
+    if url_or_fn is not None:
+        processed_url = str(url_or_fn() if callable(url_or_fn) else url_or_fn)
+    else:
+        processed_url = _openai_compatible_url()
+
+    # Build auth headers
+    auth_header_name = provider.get("auth_header", "Authorization")
+    use_bearer = provider.get("bearer", True)
+    api_key_env = provider.get("api_key_env", "OPENAI_API_KEY")
+
+    headers: Dict[str, str] = {}
+    forwarded = request_headers.get("Authorization", "")
+
+    # Check if the auth header is a Bearer token
+    if forwarded and auth_header_name == "Authorization":
+        headers["Authorization"] = forwarded
+    else:
+        # Extract the key from the forwarded header or from the env var.
+        raw_key = forwarded.removeprefix("Bearer ").strip() if forwarded else ""
+        if not raw_key:
+            raw_key = os.environ.get(api_key_env, "")
+        if raw_key:
+            headers[auth_header_name] = f"Bearer {raw_key}" if use_bearer else raw_key
+
+    headers.update(provider.get("extra_headers", {}))
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(processed_url, headers=headers, timeout=30.0)
+        resp.raise_for_status()
+        data = resp.json()
+
+    models_key = provider.get("models_key", "data")
+    model_id = provider.get("id_field", "id")
+    created_field = provider.get("created_field", "created")
+    static_owned_by = provider.get("owned_by")
+    default_owned_by = static_owned_by or os.environ.get("MAIN_MODEL_ENGINE", "system")
+    now = int(time.time())
+
+    models = data.get(models_key, []) if isinstance(data, dict) else []
+
+    return [
+        OpenAIModel(
+            id=m.get(model_id, "unknown"),
+            object="model",
+            created=_parse_timestamp(m.get(created_field), now),
+            owned_by=m.get("owned_by") or default_owned_by,
+        )
+        for m in models
+        if isinstance(m, dict)
+    ]
 
 
 def extract_bot_message_from_response(

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -16,8 +16,9 @@
 import json
 import os
 from typing import AsyncIterator, Union
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 pytest.importorskip("openai", reason="openai is required for server tests")
@@ -705,3 +706,250 @@ def test_chat_completion_with_streaming():
         assert chunk.startswith("data: ")
         assert chunk.endswith("\n\n")
     assert "data: [DONE]\n\n" in response.text
+
+
+def _make_httpx_response(json_data, status_code=200):
+    """Helper to create a mock httpx.Response."""
+    return httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("GET", "http://test/v1/models"),
+    )
+
+
+def test_list_models_no_base_url_known_engine():
+    """Test /v1/models returns 502 for a known engine when MAIN_MODEL_BASE_URL is missing."""
+    with patch.dict(os.environ, {"MAIN_MODEL_ENGINE": "openai"}, clear=False):
+        os.environ.pop("MAIN_MODEL_BASE_URL", None)
+        response = client.get("/v1/models")
+    assert response.status_code == 502
+    assert "MAIN_MODEL_BASE_URL" in response.json()["detail"]
+
+
+def test_list_models_unknown_engine_no_base_url():
+    """Test /v1/models returns empty list for an unknown engine with no base URL."""
+    with patch.dict(os.environ, {"MAIN_MODEL_ENGINE": "custom_llm"}, clear=False):
+        os.environ.pop("MAIN_MODEL_BASE_URL", None)
+        response = client.get("/v1/models")
+    assert response.status_code == 200
+    assert response.json()["data"] == []
+
+
+def test_list_models_success():
+    """Test /v1/models proxies and returns models from upstream."""
+    upstream_response = {
+        "data": [
+            {"id": "llama-3.1-8b", "object": "model", "created": 1700000000, "owned_by": "meta"},
+            {"id": "llama-3.1-70b", "object": "model", "created": 1700000001, "owned_by": "meta"},
+        ]
+    }
+    mock_response = _make_httpx_response(upstream_response)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "data" in data
+    assert len(data["data"]) == 2
+    assert data["data"][0]["id"] == "llama-3.1-8b"
+    assert data["data"][0]["object"] == "model"
+    assert data["data"][0]["created"] == 1700000000
+    assert data["data"][0]["owned_by"] == "meta"
+    assert data["data"][1]["id"] == "llama-3.1-70b"
+
+
+def test_list_models_empty_upstream():
+    """Test /v1/models handles empty model list from upstream."""
+    mock_response = _make_httpx_response({"data": []})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"] == []
+
+
+def test_list_models_upstream_error():
+    """Test /v1/models returns upstream error status on HTTP error."""
+    mock_response = _make_httpx_response({"error": "unauthorized"}, status_code=401)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 401
+    assert "Error fetching models from upstream" in response.json()["detail"]
+
+
+def test_list_models_connection_error():
+    """Test /v1/models returns 502 on connection failure."""
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:9999"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 502
+    assert "Error connecting to upstream" in response.json()["detail"]
+
+
+def test_list_models_forwards_auth_header():
+    """Test /v1/models forwards the Authorization header from the request."""
+    mock_response = _make_httpx_response({"data": []})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get(
+                "/v1/models",
+                headers={"Authorization": "Bearer my-token"},
+            )
+
+    assert response.status_code == 200
+    # Verify the upstream call received the forwarded auth header
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer my-token"
+
+
+def test_list_models_uses_openai_api_key_fallback():
+    """Test /v1/models falls back to OPENAI_API_KEY when no auth header."""
+    mock_response = _make_httpx_response({"data": []})
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(
+        os.environ,
+        {
+            "MAIN_MODEL_BASE_URL": "http://localhost:8000",
+            "OPENAI_API_KEY": "sk-test-key",
+        },
+    ):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    call_kwargs = mock_client.get.call_args
+    assert call_kwargs.kwargs["headers"]["Authorization"] == "Bearer sk-test-key"
+
+
+def test_list_models_owned_by_fallback_to_engine():
+    """Test owned_by falls back to MAIN_MODEL_ENGINE when upstream doesn't provide it."""
+    upstream_response = {
+        "data": [
+            {"id": "my-model", "object": "model", "created": 1700000000},
+        ]
+    }
+    mock_response = _make_httpx_response(upstream_response)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(
+        os.environ,
+        {
+            "MAIN_MODEL_BASE_URL": "http://localhost:8000",
+            "MAIN_MODEL_ENGINE": "nim",
+        },
+    ):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"][0]["owned_by"] == "nim"
+
+
+def test_list_models_owned_by_defaults_to_system():
+    """Test owned_by defaults to 'system' when upstream and env are not set."""
+    upstream_response = {
+        "data": [
+            {"id": "my-model", "object": "model", "created": 1700000000},
+        ]
+    }
+    mock_response = _make_httpx_response(upstream_response)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    env = {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}
+    with patch.dict(os.environ, env, clear=False):
+        os.environ.pop("MAIN_MODEL_ENGINE", None)
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"][0]["owned_by"] == "system"
+
+
+def test_list_models_malformed_upstream_data():
+    """Test /v1/models handles malformed upstream response gracefully."""
+    # Upstream returns data items that aren't dicts — they should be skipped
+    upstream_response = {
+        "data": [
+            {"id": "valid-model", "object": "model", "created": 1700000000, "owned_by": "test"},
+            "not-a-dict",
+            42,
+            None,
+        ]
+    }
+    mock_response = _make_httpx_response(upstream_response)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    # Only the valid dict model should be included
+    assert len(data["data"]) == 1
+    assert data["data"][0]["id"] == "valid-model"
+
+
+def test_list_models_upstream_missing_data_key():
+    """Test /v1/models handles upstream response without 'data' key."""
+    # Some APIs might not return the standard OpenAI format
+    upstream_response = {"models": ["model-a", "model-b"]}
+    mock_response = _make_httpx_response(upstream_response)
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["data"] == []

--- a/tests/server/test_openai_integration.py
+++ b/tests/server/test_openai_integration.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 from openai import OpenAI
 from openai.types.chat.chat_completion import ChatCompletion, Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.model import Model
 
 from nemoguardrails.server import api
 
@@ -309,3 +310,103 @@ def test_openai_client_with_rails_disabled(openai_client):
     assert response.model == "gpt-4o"
     assert response.choices[0].message.content == "hi"
     assert response.guardrails["config_id"] == "with_custom_llm"
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY is required for this test.",
+)
+def test_list_models_openai(openai_client):
+    """List models from the OpenAI API."""
+    os.environ.setdefault("MAIN_MODEL_BASE_URL", "https://api.openai.com")
+    os.environ["MAIN_MODEL_ENGINE"] = "openai"
+
+    models = list(openai_client.models.list())
+
+    assert len(models) > 0
+    assert all(isinstance(m, Model) for m in models)
+    assert all(m.id for m in models)
+    assert all(m.object == "model" for m in models)
+    assert all(isinstance(m.created, int) for m in models)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY is required for this test.",
+)
+def test_list_models_openai_fields(openai_client):
+    """Verify that well-known OpenAI models appear with expected fields."""
+    os.environ.setdefault("MAIN_MODEL_BASE_URL", "https://api.openai.com")
+    os.environ["MAIN_MODEL_ENGINE"] = "openai"
+
+    models = {m.id: m for m in openai_client.models.list()}
+
+    # At least one GPT model should be present
+    gpt_models = [mid for mid in models if "gpt" in mid]
+    assert len(gpt_models) > 0, f"Expected GPT models, got: {list(models.keys())[:10]}"
+
+    sample = models[gpt_models[0]]
+    assert sample.owned_by  # non-empty string
+    assert sample.created > 0
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY is required for this test.",
+)
+def test_list_models_anthropic(openai_client):
+    """List models from the Anthropic API."""
+    os.environ["MAIN_MODEL_ENGINE"] = "anthropic"
+
+    models = list(openai_client.models.list())
+
+    assert len(models) > 0
+    assert all(isinstance(m, Model) for m in models)
+    # Anthropic model IDs typically contain "claude"
+    claude_models = [m for m in models if "claude" in m.id]
+    assert len(claude_models) > 0, f"Expected Claude models, got: {[m.id for m in models[:10]]}"
+    assert all(m.owned_by == "anthropic" for m in models)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("COHERE_API_KEY"),
+    reason="COHERE_API_KEY is required for this test.",
+)
+def test_list_models_cohere(openai_client):
+    """List models from the Cohere API."""
+    os.environ["MAIN_MODEL_ENGINE"] = "cohere"
+
+    models = list(openai_client.models.list())
+
+    assert len(models) > 0
+    assert all(isinstance(m, Model) for m in models)
+    # Cohere model IDs typically contain "command"
+    command_models = [m for m in models if "command" in m.id]
+    assert len(command_models) > 0, f"Expected Command models, got: {[m.id for m in models[:10]]}"
+    assert all(m.owned_by == "cohere" for m in models)
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("AZURE_OPENAI_ENDPOINT") and os.environ.get("AZURE_OPENAI_API_KEY")),
+    reason="AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY are required for this test.",
+)
+def test_list_models_azure(openai_client):
+    """List models from Azure OpenAI."""
+    os.environ["MAIN_MODEL_ENGINE"] = "azure"
+
+    models = list(openai_client.models.list())
+
+    assert len(models) > 0
+    assert all(isinstance(m, Model) for m in models)
+    assert all(m.object == "model" for m in models)
+    assert all(m.owned_by == "azure" for m in models)
+
+
+def test_list_models_unknown_engine_no_url(openai_client):
+    """Unknown engine with no MAIN_MODEL_BASE_URL returns an empty list."""
+    os.environ["MAIN_MODEL_ENGINE"] = "some_custom_llm"
+    os.environ.pop("MAIN_MODEL_BASE_URL", None)
+
+    models = list(openai_client.models.list())
+
+    assert models == []

--- a/tests/server/test_schema_utils.py
+++ b/tests/server/test_schema_utils.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import json
+import os
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 
 pytest.importorskip("openai", reason="openai is required for server tests")
@@ -22,10 +25,18 @@ from openai.types.chat.chat_completion import Choice
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 
 from nemoguardrails.rails.llm.options import GenerationLog, GenerationResponse
-from nemoguardrails.server.schemas.openai import GuardrailsChatCompletion
+from nemoguardrails.server.schemas.openai import (
+    GuardrailsChatCompletion,
+    OpenAIModel,
+    OpenAIModelsList,
+)
 from nemoguardrails.server.schemas.utils import (
+    PROVIDERS,
+    _azure_url,
+    _openai_compatible_url,
     create_error_chat_completion,
     extract_bot_message_from_response,
+    fetch_models,
     format_streaming_chunk,
     format_streaming_chunk_as_sse,
     generation_response_to_chat_completion,
@@ -229,4 +240,286 @@ def test_format_streaming_chunk_as_sse_with_empty_string():
     payload = json.loads(json_str)
     assert payload["choices"][0]["delta"] == {
         "content": "",
+    }
+
+
+# ===== Tests for _openai_compatible_url =====
+
+
+def test_openai_url_basic():
+    """Test building URL when base_url does not end with /v1."""
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        assert _openai_compatible_url() == "http://localhost:8000/v1/models"
+
+
+def test_openai_url_already_has_v1():
+    """Test building URL when base_url already ends with /v1."""
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000/v1"}):
+        assert _openai_compatible_url() == "http://localhost:8000/v1/models"
+
+
+def test_openai_url_strips_trailing_slash():
+    """Test that trailing slashes are stripped from base_url."""
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000/"}):
+        assert _openai_compatible_url() == "http://localhost:8000/v1/models"
+
+
+def test_openai_url_v1_trailing_slash():
+    """Test URL with /v1/ (trailing slash after v1)."""
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000/v1/"}):
+        assert _openai_compatible_url() == "http://localhost:8000/v1/models"
+
+
+def test_openai_url_missing():
+    """Test that missing MAIN_MODEL_BASE_URL raises ValueError."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MAIN_MODEL_BASE_URL", None)
+        with pytest.raises(ValueError, match="MAIN_MODEL_BASE_URL"):
+            _openai_compatible_url()
+
+
+def test_azure_url():
+    """Test building Azure OpenAI URL from env vars."""
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_ENDPOINT": "https://myresource.openai.azure.com",
+        },
+    ):
+        result = _azure_url()
+        assert "myresource.openai.azure.com/openai/models" in result
+        assert "api-version=2024-06-01" in result
+
+
+# ===== Tests for _azure_url =====
+
+
+def test_azure_url_custom_version():
+    """Test Azure URL with custom api-version."""
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_ENDPOINT": "https://res.openai.azure.com",
+            "AZURE_OPENAI_API_VERSION": "2025-01-01",
+        },
+    ):
+        assert "api-version=2025-01-01" in _azure_url()
+
+
+def test_azure_url_missing_endpoint():
+    """Test that missing AZURE_OPENAI_ENDPOINT raises ValueError."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AZURE_OPENAI_ENDPOINT", None)
+        with pytest.raises(ValueError, match="AZURE_OPENAI_ENDPOINT"):
+            _azure_url()
+
+
+# ===== Tests for PROVIDERS table =====
+
+
+def test_known_providers_exist():
+    for engine in ("openai", "vllm", "nim", "trt_llm", "anthropic", "azure", "cohere"):
+        assert engine in PROVIDERS
+
+
+def test_azure_openai_alias():
+    assert PROVIDERS["azure_openai"] is PROVIDERS["azure"]
+
+
+# ===== Tests for fetch_models =====
+
+
+def _mock_httpx(json_data, status_code=200):
+    """Return a mock httpx.AsyncClient context manager."""
+    response = httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("GET", "http://test/v1/models"),
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.mark.asyncio
+async def test_fetch_openai():
+    """Test fetching models from an OpenAI-compatible endpoint."""
+    upstream = {
+        "data": [
+            {
+                "id": "gpt-4o",
+                "object": "model",
+                "created": 1700000000,
+                "owned_by": "openai",
+            },
+        ]
+    }
+    mock = _mock_httpx(upstream)
+    with patch.dict(
+        os.environ,
+        {"MAIN_MODEL_BASE_URL": "http://localhost:8000", "MAIN_MODEL_ENGINE": "openai"},
+    ):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("openai", {})
+    assert len(models) == 1
+    assert models[0].id == "gpt-4o"
+    assert models[0].owned_by == "openai"
+
+
+@pytest.mark.asyncio
+async def test_fetch_anthropic():
+    """Test fetching models from Anthropic."""
+    upstream = {
+        "data": [
+            {"id": "claude-sonnet-4-20250514", "created_at": "2025-05-14T00:00:00Z"},
+        ]
+    }
+    mock = _mock_httpx(upstream)
+    with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-ant-test"}):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("anthropic", {})
+    assert models[0].id == "claude-sonnet-4-20250514"
+    assert models[0].owned_by == "anthropic"
+    call_headers = mock.get.call_args.kwargs["headers"]
+    assert call_headers["x-api-key"] == "sk-ant-test"
+    assert call_headers["anthropic-version"] == "2023-06-01"
+
+
+@pytest.mark.asyncio
+async def test_fetch_cohere():
+    """Test fetching models from Cohere."""
+    upstream = {
+        "models": [
+            {"name": "command-r-plus", "description": "..."},
+            {"name": "command-r", "description": "..."},
+        ]
+    }
+    mock = _mock_httpx(upstream)
+    with patch.dict(os.environ, {"COHERE_API_KEY": "co-key"}):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("cohere", {})
+    assert len(models) == 2
+    assert models[0].id == "command-r-plus"
+    assert models[1].id == "command-r"
+    assert models[0].owned_by == "cohere"
+
+
+@pytest.mark.asyncio
+async def test_fetch_azure():
+    """Test fetching models from Azure OpenAI."""
+    upstream = {"data": [{"id": "gpt-4", "created_at": 1700000000}]}
+    mock = _mock_httpx(upstream)
+    with patch.dict(
+        os.environ,
+        {
+            "AZURE_OPENAI_ENDPOINT": "https://res.openai.azure.com",
+            "AZURE_OPENAI_API_KEY": "az-key",
+        },
+    ):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("azure", {})
+    assert models[0].id == "gpt-4"
+    assert models[0].owned_by == "azure"
+    call_headers = mock.get.call_args.kwargs["headers"]
+    assert call_headers["api-key"] == "az-key"
+
+
+@pytest.mark.asyncio
+async def test_fetch_unknown_engine_with_base_url():
+    """Unknown engines fall back to OpenAI-compatible when MAIN_MODEL_BASE_URL is set."""
+    mock = _mock_httpx({"data": [{"id": "custom-model"}]})
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:5000"}):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("my_custom", {})
+    assert len(models) == 1
+    assert models[0].id == "custom-model"
+
+
+@pytest.mark.asyncio
+async def test_fetch_unknown_engine_no_base_url():
+    """Unknown engines return empty list when no MAIN_MODEL_BASE_URL."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MAIN_MODEL_BASE_URL", None)
+        models = await fetch_models("niche_llm", {})
+    assert models == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_auth_forwarded():
+    """Incoming Authorization header is forwarded for OpenAI-compatible providers."""
+    mock = _mock_httpx({"data": []})
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock):
+            await fetch_models("openai", {"Authorization": "Bearer user-token"})
+    call_headers = mock.get.call_args.kwargs["headers"]
+    assert call_headers["Authorization"] == "Bearer user-token"
+
+
+@pytest.mark.asyncio
+async def test_fetch_non_dict_items_skipped():
+    """Non-dict items in the response data are skipped."""
+    upstream = {"data": [{"id": "good"}, "bad", 42, None]}
+    mock = _mock_httpx(upstream)
+    with patch.dict(os.environ, {"MAIN_MODEL_BASE_URL": "http://localhost:8000"}):
+        with patch("httpx.AsyncClient", return_value=mock):
+            models = await fetch_models("openai", {})
+    assert len(models) == 1
+    assert models[0].id == "good"
+
+
+# ===== Tests for OpenAIModel and OpenAIModelsList schemas =====
+
+
+def test_openai_model_schema():
+    """Test OpenAIModel schema creation."""
+    model = OpenAIModel(
+        id="llama-3.1-8b",
+        object="model",
+        created=1700000000,
+        owned_by="system",
+    )
+    assert model.id == "llama-3.1-8b"
+    assert model.object == "model"
+    assert model.created == 1700000000
+    assert model.owned_by == "system"
+
+
+def test_openai_models_list_schema():
+    """Test OpenAIModelsList schema with multiple models."""
+    models = OpenAIModelsList(
+        data=[
+            OpenAIModel(id="test-model-1", object="model", created=1700000000, owned_by="org-a"),
+            OpenAIModel(id="test-model-2", object="model", created=1700000001, owned_by="org-b"),
+        ]
+    )
+    assert len(models.data) == 2
+    assert models.data[0].id == "test-model-1"
+    assert models.data[1].id == "test-model-2"
+
+
+def test_openai_models_list_schema_empty():
+    """Test OpenAIModelsList schema with empty list."""
+    models = OpenAIModelsList(data=[])
+    assert len(models.data) == 0
+
+
+def test_openai_models_list_serialization():
+    """Test OpenAIModelsList serializes to expected JSON structure."""
+    models = OpenAIModelsList(
+        data=[
+            OpenAIModel(id="test-model", object="model", created=1700000000, owned_by="system"),
+        ]
+    )
+    result = models.model_dump()
+    assert result == {
+        "data": [
+            {
+                "id": "test-model",
+                "object": "model",
+                "created": 1700000000,
+                "owned_by": "system",
+            }
+        ]
     }


### PR DESCRIPTION
## Description
Adds support to return the list of models available at MAIN_BASE_MODEL_URL via v1/models. 

### Features
1. Support for both OpenAI compatible and non-compatible providers
2. We parse the incoming request to the Guardrails v1/models endpoint and format it to be OpenAI compatible by looking up the provider in a table according to the engine. It adds the necessary API keys, headers,  and additional fields for each provider before sending off the request
3. Similarly, we also reformat the raw list of models before returning the final list of models so it adheres to the OpenAI standard ModelsList

## Usage 
```
# ==== OpenAI compat providers ====
export MAIN_MODEL_ENGINE=openai          # or vllm, nim, trt_llm
export MAIN_MODEL_BASE_URL=http://localhost:8000
export OPENAI_API_KEY=..

curl http://localhost:9000/v1/models

# ==== Anthropic ====
export MAIN_MODEL_ENGINE=anthropic
export ANTHROPIC_API_KEY=...

curl http://localhost:9000/v1/models

# ==== Azure =====
export MAIN_MODEL_ENGINE=azure           # or azure_openai
export AZURE_OPENAI_ENDPOINT=https://myresource.openai.azure.com
export AZURE_OPENAI_API_KEY=...
# optional: AZURE_OPENAI_API_VERSION

curl http://localhost:9000/v1/models

# ==== Cohere ====
export MAIN_MODEL_ENGINE=cohere
export COHERE_API_KEY=...

curl http://localhost:9000/v1/models

# ==== Unknown engine ====
export MAIN_MODEL_ENGINE=my_custom_llm      # defaults to openai
export MAIN_MODEL_BASE_URL=http://my-server:8080

curl http://localhost:9000/v1/models
```

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
