### PR TITLE
docs(colang): update tutorials with current models and fix links

### DIFF
--- a/docs/configure-rails/colang/colang-1/tutorials/1-hello-world/README.md
+++ b/docs/configure-rails/colang/colang-1/tutorials/1-hello-world/README.md
@@ -9,7 +9,7 @@ This guide shows you how to create a "Hello World" guardrails configuration that
 
 ## Prerequisites
 
-This "Hello World" guardrails configuration uses the OpenAI `gpt-3.5-turbo-instruct` model.
+This "Hello World" guardrails configuration uses the OpenAI `gpt-4o-mini` model.
 
 1. Install the `openai` package:
 
@@ -45,7 +45,7 @@ Every guardrails configuration must be stored in a folder. The standard folder s
 │   ├── ...
 ```
 
-See the [Configuration Guide](../../user-guides/configuration-guide.md) for information about the contents of these files.
+See the [Configuration Reference](../../../../configuration-reference.md) for information about the contents of these files.
 
 1. Create a folder, such as *config*, for your configuration:
 
@@ -59,10 +59,10 @@ mkdir config
 models:
  - type: main
    engine: openai
-   model: gpt-3.5-turbo-instruct
+   model: gpt-4o-mini
 ```
 
-The `models` key in the *config.yml* file configures the LLM model. For a complete list of supported LLM models, see [Supported LLM Models](../../user-guides/configuration-guide.md#supported-llm-models).
+The `models` key in the *config.yml* file configures the LLM model. For a complete list of supported LLM models, see [Supported LLM Models](../../../../../about/supported-llms.md).
 
 ## Step 2: load the guardrails configuration
 

--- a/docs/configure-rails/colang/colang-1/tutorials/2-core-colang-concepts/README.md
+++ b/docs/configure-rails/colang/colang-1/tutorials/2-core-colang-concepts/README.md
@@ -9,7 +9,7 @@ This guide builds on the [Hello World guide](../1-hello-world/README.md) and int
 
 ## Prerequisites
 
-This "Hello World" guardrails configuration uses the OpenAI `gpt-3.5-turbo-instruct` model.
+This "Hello World" guardrails configuration uses the OpenAI `gpt-4o-mini` model.
 
 1. Install the `openai` package:
 
@@ -168,7 +168,7 @@ Once an input message is received from the user, a multi-step process begins.
 After an utterance, such as  "Hello!" in the previous example, is received from the user, the guardrails instance uses the LLM to compute the corresponding canonical form.
 
 ```{note}
-NeMo Guardrails uses a task-oriented interaction model with the LLM. Every time the LLM is called, it uses a specific task prompt template, such as `generate_user_intent`, `generate_next_step`, `generate_bot_message`. See the [default template prompts](../../../nemoguardrails/llm/prompts/general.yml) for details.
+NeMo Guardrails uses a task-oriented interaction model with the LLM. Every time the LLM is called, it uses a specific task prompt template, such as `generate_user_intent`, `generate_next_step`, `generate_bot_message`. See the [default template prompts](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/llm/prompts/general.yml) for details.
 ```
 
 In the case of the "Hello!" message, a single LLM call is made using the `generate_user_intent` task prompt template. The prompt looks like the following:
@@ -229,11 +229,11 @@ user "Hello!"
 
 The prompt has four logical sections:
 
-1. A set of general instructions. These can be [configured](../../user-guides/configuration-guide.md#general-instructions) using the `instructions` key in *config.yml*.
+1. A set of general instructions. These can be [configured](../../../../configuration-reference.md#instructions) using the `instructions` key in *config.yml*.
 
-2. A sample conversation, which can also be [configured](../../user-guides/configuration-guide.md#sample-conversation) using the `sample_conversation` key in *config.yml*.
+2. A sample conversation, which can also be [configured](../../../../configuration-reference.md#sample-conversation) using the `sample_conversation` key in *config.yml*.
 
-3. A set of examples for converting user utterances to canonical forms. The top five most relevant examples are chosen by performing a vector search against all the user message examples. For more details see [ABC Bot](../../../examples/bots/abc/README.md).
+3. A set of examples for converting user utterances to canonical forms. The top five most relevant examples are chosen by performing a vector search against all the user message examples. For more details see [ABC Bot](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/examples/bots/abc/README.md).
 
 4. The current conversation preceded by the first two turns from the sample conversation.
 
@@ -336,7 +336,7 @@ Based on these steps, we can see that the `ask general question` canonical form 
 
 ## Wrapping up
 
-This guide provides a detailed overview of two core Colang concepts: *messages* and *flows*. It also looked at how the message and flow definitions are used under the hood and how the LLM is prompted. For more details, see the reference documentation for the [Python API](../../user-guides/python-api.md) and the [Colang Language Syntax](../../user-guides/colang-language-syntax-guide.md).
+This guide provides a detailed overview of two core Colang concepts: *messages* and *flows*. It also looked at how the message and flow definitions are used under the hood and how the LLM is prompted. For more details, see the reference documentation for the [Python API](../../../../../reference/python-api/index.md) and the [Colang Language Syntax](../../colang-language-syntax-guide.md).
 
 ## Next
 

--- a/docs/configure-rails/colang/colang-1/tutorials/4-input-rails/README.md
+++ b/docs/configure-rails/colang/colang-1/tutorials/4-input-rails/README.md
@@ -31,18 +31,18 @@ nest_asyncio.apply()
 
 ## Config Folder
 
-Create a *config* folder with a *config.yml* file with the following content that uses the `gpt-3.5-turbo-instruct` model:
+Create a *config* folder with a *config.yml* file with the following content that uses the `gpt-4o-mini` model:
 
 ```yaml
 models:
  - type: main
    engine: openai
-   model: gpt-3.5-turbo-instruct
+   model: gpt-4o-mini
 ```
 
 ## General Instructions
 
-Configure the **general instructions** for the bot. You can think of them as the system prompt. For details, see the [Configuration Guide](../../user-guides/configuration-guide.md#general-instructions). These instructions configure the bot to answer questions about the employee handbook and the company's policies.
+Configure the **general instructions** for the bot. You can think of them as the system prompt. For details, see the [Configuration Reference](../../../../configuration-reference.md#instructions). These instructions configure the bot to answer questions about the employee handbook and the company's policies.
 
 Add the following content to *config.yml* to create a **general instruction**:
 
@@ -60,7 +60,7 @@ In the snippet above, we instruct the bot to answer questions about the employee
 
 ## Sample Conversation
 
-Another option to influence how the LLM responds to a sample conversation. The sample conversation sets the tone for the conversation between the user and the bot. The sample conversation is included in the prompts, which are shown in a subsequent section. For details, see the [Configuration Guide](../../user-guides/configuration-guide.md#sample-conversation).
+Another option to influence how the LLM responds to a sample conversation. The sample conversation sets the tone for the conversation between the user and the bot. The sample conversation is included in the prompts, which are shown in a subsequent section. For details, see the [Configuration Reference](../../../../configuration-reference.md#sample-conversation).
 
 Add the following to *config.yml* to create a **sample conversation**:
 
@@ -157,7 +157,7 @@ If the bot does not know the answer to a question, it truthfully says it does no
 
 > **NOTE**: this jailbreak attempt does not work 100% of the time. If you're running this and getting a different result, try a few times, and you should get a response similar to the previous.
 
-Allowing the LLM to comply with this type of request is something we don't want. To prevent jailbreak attempts like this, you can add an input rail that can process the user input before it is sent to the LLM. NeMo Guardrails comes with a built-in [self check input](../../user-guides/guardrails-library.md#input-checking) rail that uses a separate LLM query to detect a jailbreak attempt. To use it, you have to:
+Allowing the LLM to comply with this type of request is something we don't want. To prevent jailbreak attempts like this, you can add an input rail that can process the user input before it is sent to the LLM. NeMo Guardrails comes with a built-in [self check input](../../../../guardrail-catalog.md#self-check-input) rail that uses a separate LLM query to detect a jailbreak attempt. To use it, you have to:
 
 1. Activate the `self check input` rail in *config.yml*.
 2. Add a `self_check_input` prompt in *prompts.yml*.
@@ -178,7 +178,7 @@ rails:
 - The `flows` keys contains the name of the flows that is used as input rails.
 - `self check input` is the name of a pre-defined flow that implements self-check input checking.
 
-All the rails in NeMo Guardrails are implemented as flows. For example, you can find the `self_check_input` flow [here](../../../nemoguardrails/library/self_check/input_check/flows.co).
+All the rails in NeMo Guardrails are implemented as flows. For example, you can find the `self_check_input` flow [here](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/library/self_check/input_check/flows.co).
 
 ```colang
 define flow self check input
@@ -369,7 +369,7 @@ Feel free to experiment with various inputs that should or should not trigger th
 
 ## More on Input Rails
 
-Input rails also have the ability to alter the message from the user. By changing the value for the `$user_message` variable, the subsequent input rails and dialog rails work with the updated value. This can be useful, for example, to mask sensitive information. For an example of this behavior, checkout the [Sensitive Data Detection rails](../../user-guides/guardrails-library.md#presidio-based-sensitive-data-detection).
+Input rails also have the ability to alter the message from the user. By changing the value for the `$user_message` variable, the subsequent input rails and dialog rails work with the updated value. This can be useful, for example, to mask sensitive information. For an example of this behavior, checkout the [Sensitive Data Detection rails](../../../../guardrail-catalog.md#presidio-based-sensitive-data-detection).
 
 ## Next
 

--- a/docs/configure-rails/colang/colang-1/tutorials/5-output-rails/README.md
+++ b/docs/configure-rails/colang/colang-1/tutorials/5-output-rails/README.md
@@ -31,7 +31,7 @@ nest_asyncio.apply()
 
 ## Output Moderation
 
-NeMo Guardrails comes with a built-in [output self-checking rail](../../user-guides/guardrails-library.md#output-checking). This rail uses a separate LLM call to make sure that the bot's response should be allowed.
+NeMo Guardrails comes with a built-in [output self-checking rail](../../../../guardrail-catalog.md#self-check-output). This rail uses a separate LLM call to make sure that the bot's response should be allowed.
 
 Activating the `self check output` rail is similar to the `self check input` rail:
 
@@ -191,11 +191,9 @@ You can enable streaming to provide asynchronous responses and reduce the time t
           enabled: True
           chunk_size: 200
           context_size: 50
-
-   streaming: True
    ```
 
-  The `enabled: True` field is required to enable streaming output rails while the `streaming: True` field is needed to enable streaming generation.
+  The `enabled: True` field is required to enable streaming output rails.
 
 1. Call the `stream_async` method and handle the chunked response:
 
@@ -224,7 +222,7 @@ You can enable streaming to provide asynchronous responses and reduce the time t
    ```
 
 For reference information about the related `config.yaml` file fields,
-refer to [](../../user-guides/configuration-guide.md#output-rails).
+refer to the [Configuration Reference](../../../../configuration-reference.md#output-rails).
 
 ## Custom Output Rail
 

--- a/docs/configure-rails/colang/colang-1/tutorials/7-rag/README.md
+++ b/docs/configure-rails/colang/colang-1/tutorials/7-rag/README.md
@@ -116,5 +116,5 @@ This guide introduced how a guardrails configuration can be used in the context 
 
 To continue learning about NeMo Guardrails, check out:
 
-1. [Guardrails Library](../../../docs/user-guides/guardrails-library.md).
-2. [Configuration Guide](../../../docs/user-guides/configuration-guide.md).
+1. [Guardrails Catalog](../../../../guardrail-catalog.md).
+2. [Configuration Reference](../../../../configuration-reference.md).

--- a/examples/bots/hello_world/config.yml
+++ b/examples/bots/hello_world/config.yml
@@ -1,4 +1,4 @@
 models:
   - type: main
     engine: openai
-    model: gpt-3.5-turbo-instruct
+    model: gpt-4o-mini


### PR DESCRIPTION
## Description

- Update gpt-3.5-turbo-instruct to gpt-4o-mini across all tutorials
- Fix broken relative links to configuration guide, guardrails library, and Python API
- Remove deprecated top-level streaming: True from output rails tutorial
- Link to GitHub for source code references that moved in doc restructure

