### PR TITLE
docs(yaml-schema): fix guardrails config, streaming, and prompt docs

### DIFF
--- a/docs/configure-rails/yaml-schema/guardrails-configuration/index.md
+++ b/docs/configure-rails/yaml-schema/guardrails-configuration/index.md
@@ -38,7 +38,7 @@ The following table summarizes the different rail categories and their trigger p
 | **Input rails** | When user input is received | Validate, filter, or modify user input |
 | **Retrieval rails** | After RAG retrieval completes | Process retrieved chunks |
 | **Dialog rails** | After canonical form is computed | Control conversation flow |
-| **Execution rails** | Before/after action execution | Control tool and action calls |
+| **Execution rails** | Before/after action execution | Control custom action calls |
 | **Output rails** | When LLM generates output | Validate, filter, or modify bot responses |
 
 The following diagram shows the guardrails process described in the table above in detail.
@@ -56,7 +56,7 @@ rails:
   input:
     flows:
       - self check input
-      - check jailbreak
+      - jailbreak detection heuristics
       - mask sensitive data on input
 
   output:
@@ -78,9 +78,9 @@ Input rails process user messages before they reach the LLM:
 rails:
   input:
     flows:
-      - self check input           # LLM-based input validation
-      - check jailbreak            # Jailbreak detection
-      - mask sensitive data on input  # PII masking
+      - self check input                # LLM-based input validation
+      - jailbreak detection heuristics  # Jailbreak detection
+      - mask sensitive data on input    # PII masking
 ```
 
 For a complete list of available input flows, refer to the [](../configuration-reference.md#input-rails).
@@ -185,7 +185,7 @@ rails:
   input:
     flows:
       - self check input
-      - check jailbreak
+      - jailbreak detection heuristics
       - mask sensitive data on input
 
   # Output validation
@@ -216,10 +216,6 @@ rails:
         entities:
           - PERSON
           - EMAIL_ADDRESS
-```
-
-```{include}
-parallel-rails.md
 ```
 
 ```{include} parallel-rails.md

--- a/docs/configure-rails/yaml-schema/index.md
+++ b/docs/configure-rails/yaml-schema/index.md
@@ -34,7 +34,7 @@ The following is a complete schema for a `config.yml` file:
 models:
   - type: main
     engine: openai
-    model: gpt-3.5-turbo-instruct
+    model: gpt-4o
 
 # Instructions for the LLM (similar to system prompts)
 instructions:

--- a/docs/configure-rails/yaml-schema/model-configuration.md
+++ b/docs/configure-rails/yaml-schema/model-configuration.md
@@ -40,7 +40,7 @@ This provides access to:
 
 - **Locally-deployed NIMs**: Run models on your own infrastructure with optimized inference.
 - **NVIDIA API Catalog**: Access hosted models on [build.nvidia.com](https://build.nvidia.com/models).
-- **Specialized NIMs**: Nemotron Content Safety, Topic Control, and Jailbreak Detect.
+- **Specialized NIMs**: NemoGuard Content Safety, Topic Control, and Jailbreak Detect.
 
 ### Local NIM Deployment
 
@@ -157,7 +157,7 @@ models:
 
 ### Complete Example
 
-The following example shows how to configure the main application LLM, embeddings model, and a dedicated Nemotron model for input and output checking:
+The following example shows how to configure the main application LLM, embeddings model, and a dedicated NemoGuard model for input and output checking:
 
 ```yaml
 models:

--- a/docs/configure-rails/yaml-schema/prompt-configuration.md
+++ b/docs/configure-rails/yaml-schema/prompt-configuration.md
@@ -96,7 +96,7 @@ Override prompts for specific models:
 prompts:
   - task: generate_user_intent
     models:
-      - openai/gpt-3.5-turbo
+      - openai/gpt-4o
       - openai/gpt-4
     max_length: 3000
     output_parser: user_intent
@@ -105,17 +105,34 @@ prompts:
       ...
 ```
 
+## Prompt Attributes Reference
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `task` | `str` | (required) | The task ID this prompt is associated with |
+| `content` | `str` | — | The prompt content string (mutually exclusive with `messages`) |
+| `messages` | `list` | — | List of chat messages (mutually exclusive with `content`) |
+| `models` | `list[str]` | — | Restrict prompt to specific engines/models (format: `engine` or `engine/model`) |
+| `output_parser` | `str` | — | Name of the output parser to use |
+| `max_length` | `int` | `16000` | Maximum prompt length in characters |
+| `mode` | `str` | `"standard"` | Prompting mode this prompt applies to |
+| `stop` | `list[str]` | — | Stop tokens for models that support them |
+| `max_tokens` | `int` | — | Maximum number of tokens for the completion |
+
 ## Template Variables
 
-The following table lists all available variables you can use in the prompt content:
+The following table lists common variables you can use in the prompt content:
 
 | Variable | Description |
 |----------|-------------|
-| `{{ user_input }}` | Current user message |
-| `{{ bot_response }}` | Current bot response (for output rails) |
-| `{{ history }}` | Conversation history |
+| `{{ user_input }}` | Current user message (used in self-check prompts) |
+| `{{ bot_response }}` | Current bot response (used in output rail prompts) |
+| `{{ history }}` | Conversation history (supports filters like `colang`, `user_assistant_sequence`) |
 | `{{ relevant_chunks }}` | Retrieved knowledge base chunks |
-| `{{ context }}` | Additional context variables |
+| `{{ general_instructions }}` | General instructions from the `instructions` config |
+| `{{ sample_conversation }}` | Sample conversation from the config (supports `first_turns` filter) |
+| `{{ examples }}` | Example conversations for few-shot prompting |
+| `{{ potential_user_intents }}` | List of possible user intents |
 
 ## Example Configurations
 

--- a/docs/configure-rails/yaml-schema/prompt-configuration.md
+++ b/docs/configure-rails/yaml-schema/prompt-configuration.md
@@ -1,6 +1,6 @@
 ---
 title:
-  page: Prompt Configuration for NeMo Guardrails
+  page: Prompt Configuration for the NVIDIA NeMo Guardrails Library
   nav: Prompts
 description: Customize prompts for self-check, fact-checking, and intent generation tasks.
 topics:
@@ -47,7 +47,7 @@ For a complete list of available prompt attributes and tasks, refer to the [](..
 
 ## Content-Based Prompts
 
-Simple prompts using the `content` attribute with Jinja2 templating:
+The following example shows a simple prompt that uses the `content` attribute with Jinja2 templating:
 
 ```yaml
 prompts:
@@ -109,15 +109,15 @@ prompts:
 
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `task` | `str` | (required) | The task ID this prompt is associated with |
-| `content` | `str` | — | The prompt content string (mutually exclusive with `messages`) |
-| `messages` | `list` | — | List of chat messages (mutually exclusive with `content`) |
-| `models` | `list[str]` | — | Restrict prompt to specific engines/models (format: `engine` or `engine/model`) |
-| `output_parser` | `str` | — | Name of the output parser to use |
-| `max_length` | `int` | `16000` | Maximum prompt length in characters |
-| `mode` | `str` | `"standard"` | Prompting mode this prompt applies to |
-| `stop` | `list[str]` | — | Stop tokens for models that support them |
-| `max_tokens` | `int` | — | Maximum number of tokens for the completion |
+| `task` | `str` | (required) | The task ID for the prompt to associate with. |
+| `content` | `str` | — | The prompt content string. Mutually exclusive with `messages`. |
+| `messages` | `list` | — | List of chat messages. Mutually exclusive with `content`. |
+| `models` | `list[str]` | — | Restricts the prompt to specific engines or models (format: `engine` or `engine/model`) |
+| `output_parser` | `str` | — | Name of the output parser to use for the prompt. |
+| `max_length` | `int` | `16000` | Maximum prompt length in characters. |
+| `mode` | `str` | `"standard"` | Prompting mode this prompt applies to. |
+| `stop` | `list[str]` | — | Stop tokens for models that support them. |
+| `max_tokens` | `int` | — | Maximum number of tokens for the completion. |
 
 ## Template Variables
 

--- a/docs/configure-rails/yaml-schema/streaming/global-streaming.md
+++ b/docs/configure-rails/yaml-schema/streaming/global-streaming.md
@@ -56,11 +56,9 @@ If output rails are configured but `rails.output.streaming.enabled` is not set t
 
 ---
 
-## Streaming With Handler (Deprecated)
+## Streaming With Handler
 
-> **Warning:** Using `StreamingHandler` directly is deprecated and will be removed in a future release. Use `stream_async()` instead.
-
-For advanced use cases requiring more control over token processing, you can use a `StreamingHandler` with `generate_async()`:
+For advanced use cases requiring more control over token processing, you can use a `StreamingHandler` with `generate_async()`. The preferred approach for most use cases is `stream_async()`, but `StreamingHandler` remains supported:
 
 ```python
 from nemoguardrails import LLMRails, RailsConfig

--- a/docs/configure-rails/yaml-schema/streaming/output-rail-streaming.md
+++ b/docs/configure-rails/yaml-schema/streaming/output-rail-streaming.md
@@ -23,7 +23,7 @@ content:
 
 # Output Rail Streaming
 
-Configure how output rails are applied to streamed tokens under `rails.output.streaming`.
+Configure how output rails process streamed tokens under `rails.output.streaming`.
 
 ## Configuration
 
@@ -46,15 +46,15 @@ rails:
 | `enabled` | bool | `False` | Must be `True` to use `stream_async()` with output rails |
 | `chunk_size` | int | `200` | Number of tokens per chunk that output rails process |
 | `context_size` | int | `50` | Tokens carried over between chunks for continuity |
-| `stream_first` | bool | `True` | If `True`, tokens are yielded to the client before output rails run on the chunk |
+| `stream_first` | bool | `True` | If `True`, the client receives tokens before output rails run on the chunk |
 
 ---
 
-## Parameter Details
+### Tips for Setting Parameters
 
-### enabled
+#### enabled
 
-When output rails are configured and you want to use `stream_async()`, this must be set to `True`.
+When you configure output rails and want to use `stream_async()`, set this to `True`.
 
 If not enabled, you receive an error:
 
@@ -65,16 +65,16 @@ rails.output.streaming.enabled to True in your configuration, or use
 generate_async() instead of stream_async().
 ```
 
-### chunk_size
+#### chunk_size
 
-The number of tokens buffered before output rails are applied.
+The number of tokens buffered before output rails run.
 
 - **Larger values**: Fewer rail executions, but higher latency to first output
 - **Smaller values**: More rail executions, but faster time-to-first-token
 
 **Default:** `200` tokens
 
-### context_size
+#### context_size
 
 The number of tokens from the previous chunk carried over to provide context for the next chunk.
 
@@ -82,12 +82,12 @@ This helps output rails make consistent decisions across chunk boundaries. For e
 
 **Default:** `50` tokens
 
-### stream_first
+#### stream_first
 
 Controls when tokens are streamed relative to output rail processing:
 
-- `True` (default): Each chunk of tokens is yielded to the client **before** output rails run on that chunk. Provides faster time-to-first-token, but if a rail blocks the content, the user has already received the tokens. The stream terminates with a JSON error on violation.
-- `False`: Output rails run on each chunk **before** tokens are yielded. The user never sees blocked content, but time-to-first-token increases by the rail execution time per chunk.
+- `True` (default): The client receives each chunk of tokens before output rails process that chunk. This provides faster time-to-first-token, but if a rail blocks the content, the user has already received the tokens. The stream terminates with a JSON error on violation.
+- `False`: Output rails process each chunk before the client receives tokens. The user never sees blocked content, but time-to-first-token increases by the rail execution time per chunk.
 
 ---
 
@@ -161,7 +161,7 @@ rails:
 ```
 
 ```{warning}
-With `stream_first: True`, tokens are streamed to the client **before** output rails run. If a rail blocks the content, the user will have already received the tokens up to that point. The stream terminates with a JSON error object when a violation is detected.
+With `stream_first: True`, the client receives tokens before output rails run. If a rail blocks the content, the user has already received the tokens up to that point. The stream terminates with a JSON error object when it detects a violation.
 ```
 
 ### Safety-First Configuration
@@ -184,11 +184,11 @@ rails:
 
 ## How It Works
 
-1. **Token Buffering**: Tokens from the LLM are buffered until `chunk_size` tokens have accumulated.
+1. **Token Buffering**: The system buffers tokens from the LLM until `chunk_size` tokens accumulate.
 2. **Streaming or Rail Execution** (depends on `stream_first`):
-   - `stream_first: True` (default): The new tokens are yielded to the client immediately, **then** output rails run on the chunk (including context). If rails block, the stream terminates with a JSON error — but the user already received the tokens.
-   - `stream_first: False`: Output rails run on the chunk first. Only if rails pass are the new tokens yielded to the client.
-3. **Context Overlap**: The last `context_size` tokens from the current chunk are retained and prepended to the next chunk's processing context. This gives rails visibility across chunk boundaries.
+   - `stream_first: True` (default): The client receives the new tokens immediately, then output rails run on the chunk (including context). If the rails block the content, the stream terminates with a JSON error, while the client receives the tokens up to that point.
+   - `stream_first: False`: Output rails run on the chunk first. The client receives the new tokens only if rails pass. If the rails block the content, the client never receives the tokens.
+3. **Context Overlap**: The system retains the last `context_size` tokens from the current chunk and prepends them to the next chunk's processing context. This gives rails visibility across chunk boundaries.
 4. **Blocking**: If any rail blocks the content, the stream yields a JSON error object (`{"error": {...}}`) and terminates immediately.
 
 ### stream_first: True (default)
@@ -217,7 +217,7 @@ Buffer fills to chunk_size
 
 ### Buffer Overlap
 
-Only new tokens are streamed to the user. The `context_size` tokens are used solely for rail processing context:
+The client receives only new tokens. Output rails use the `context_size` tokens solely for processing context:
 
 ```text
 Chunk 1: rails process [token1 ... token200]

--- a/docs/configure-rails/yaml-schema/streaming/output-rail-streaming.md
+++ b/docs/configure-rails/yaml-schema/streaming/output-rail-streaming.md
@@ -46,7 +46,7 @@ rails:
 | `enabled` | bool | `False` | Must be `True` to use `stream_async()` with output rails |
 | `chunk_size` | int | `200` | Number of tokens per chunk that output rails process |
 | `context_size` | int | `50` | Tokens carried over between chunks for continuity |
-| `stream_first` | bool | `True` | If `True`, tokens stream immediately before output rails are applied |
+| `stream_first` | bool | `True` | If `True`, tokens are yielded to the client before output rails run on the chunk |
 
 ---
 
@@ -86,25 +86,26 @@ This helps output rails make consistent decisions across chunk boundaries. For e
 
 Controls when tokens are streamed relative to output rail processing:
 
-- `True` (default): Tokens are streamed to the client immediately, then output rails are applied. Provides faster time-to-first-token but rails run after streaming.
-- `False`: Output rails are applied to each chunk before streaming. Safer but adds latency.
+- `True` (default): Each chunk of tokens is yielded to the client **before** output rails run on that chunk. Provides faster time-to-first-token, but if a rail blocks the content, the user has already received the tokens. The stream terminates with a JSON error on violation.
+- `False`: Output rails run on each chunk **before** tokens are yielded. The user never sees blocked content, but time-to-first-token increases by the rail execution time per chunk.
 
 ---
 
 ## Requirements
 
-Output rail streaming requires [global streaming](global-streaming.md) to also be enabled:
+Output rail streaming requires using the `stream_async()` method:
 
 ```yaml
-# Both are required
-streaming: True
-
 rails:
   output:
     flows:
       - self check output
     streaming:
       enabled: True
+```
+
+```{note}
+The top-level `streaming: True` field is deprecated and no longer required. Use `stream_async()` directly instead.
 ```
 
 ---
@@ -114,8 +115,6 @@ rails:
 ### Basic Output Rail Streaming
 
 ```yaml
-streaming: True
-
 rails:
   output:
     flows:
@@ -131,8 +130,6 @@ rails:
 For parallel execution of multiple output rails during streaming:
 
 ```yaml
-streaming: True
-
 rails:
   output:
     parallel: True
@@ -152,8 +149,6 @@ rails:
 For faster time-to-first-token with smaller chunks:
 
 ```yaml
-streaming: True
-
 rails:
   output:
     flows:
@@ -165,13 +160,15 @@ rails:
       stream_first: True
 ```
 
+```{warning}
+With `stream_first: True`, tokens are streamed to the client **before** output rails run. If a rail blocks the content, the user will have already received the tokens up to that point. The stream terminates with a JSON error object when a violation is detected.
+```
+
 ### Safety-First Configuration
 
 For maximum safety with rails applied before streaming:
 
 ```yaml
-streaming: True
-
 rails:
   output:
     flows:
@@ -187,25 +184,48 @@ rails:
 
 ## How It Works
 
-1. **Token Buffering**: Tokens from the LLM are buffered until `chunk_size` is reached
-2. **Context Overlap**: The last `context_size` tokens from the previous chunk are prepended
-3. **Rail Execution**: Output rails are applied to the chunk
-4. **Streaming**: If `stream_first: True`, tokens stream before rail execution completes
+1. **Token Buffering**: Tokens from the LLM are buffered until `chunk_size` tokens have accumulated.
+2. **Streaming or Rail Execution** (depends on `stream_first`):
+   - `stream_first: True` (default): The new tokens are yielded to the client immediately, **then** output rails run on the chunk (including context). If rails block, the stream terminates with a JSON error — but the user already received the tokens.
+   - `stream_first: False`: Output rails run on the chunk first. Only if rails pass are the new tokens yielded to the client.
+3. **Context Overlap**: The last `context_size` tokens from the current chunk are retained and prepended to the next chunk's processing context. This gives rails visibility across chunk boundaries.
+4. **Blocking**: If any rail blocks the content, the stream yields a JSON error object (`{"error": {...}}`) and terminates immediately.
+
+### stream_first: True (default)
 
 ```text
-Chunk 1: [token1, token2, ..., token200]
-         └─────────────────────────────┘
-                    ↓
-              Output Rails
-                    ↓
-              Stream to Client
+Buffer fills to chunk_size
+         ↓
+  Yield new tokens to client (user sees them immediately)
+         ↓
+  Run output rails on [context + new tokens]
+         ↓
+  Pass → continue to next chunk
+  Block → yield JSON error, terminate stream
+```
 
-Chunk 2: [token151, ..., token200, token201, ..., token400]
-         └─── context_size ───┘   └─── new tokens ───────┘
-                    ↓
-              Output Rails
-                    ↓
-              Stream to Client
+### stream_first: False
+
+```text
+Buffer fills to chunk_size
+         ↓
+  Run output rails on [context + new tokens]
+         ↓
+  Pass → yield new tokens to client
+  Block → yield JSON error, terminate stream (user never sees blocked content)
+```
+
+### Buffer Overlap
+
+Only new tokens are streamed to the user. The `context_size` tokens are used solely for rail processing context:
+
+```text
+Chunk 1: rails process [token1 ... token200]
+         user receives  [token1 ... token200]
+
+Chunk 2: rails process [token151 ... token200, token201 ... token400]
+                        └── context_size ──┘  └── new tokens ───────┘
+         user receives  [token201 ... token400]
 ```
 
 ---


### PR DESCRIPTION
## Description

- Fix check jailbreak to jailbreak detection heuristics in guardrails config
- Fix execution rails description to "custom action calls"
- Remove duplicate parallel-rails.md include
- Update gpt-3.5-turbo-instruct to gpt-4o in schema index
- Fix Nemotron to NemoGuard in model configuration
- Add missing prompt template variables and attributes
- Remove outdated stream_usage references from streaming docs
- Remove false StreamingHandler deprecation warning
- Remove deprecated top-level streaming: True from output rail examples
- Add deprecation note for top-level streaming field