### PR TITLE
docs(custom-init): fix env var handling, embedding kwargs and LLM

### DIFF
--- a/docs/configure-rails/custom-initialization/custom-data.md
+++ b/docs/configure-rails/custom-initialization/custom-data.md
@@ -9,7 +9,6 @@ topics:
 tags:
 - custom_data
 - config.yml
-- Environment Variables
 - Python
 content:
   type: how_to
@@ -35,7 +34,6 @@ models:
 
 custom_data:
   api_endpoint: "https://api.example.com"
-  api_key: "${API_KEY}"  # Environment variable
   max_retries: 3
   timeout_seconds: 30
   feature_flags:
@@ -56,12 +54,15 @@ def init(app: LLMRails):
 
     # Get individual values
     api_endpoint = custom_data.get("api_endpoint")
-    api_key = custom_data.get("api_key")
     max_retries = custom_data.get("max_retries", 3)  # with default
 
     # Access nested values
     feature_flags = custom_data.get("feature_flags", {})
     enable_caching = feature_flags.get("enable_caching", False)
+
+    # Load sensitive values from environment variables
+    import os
+    api_key = os.environ.get("API_KEY")
 
     # Use to configure your providers
     client = APIClient(
@@ -90,79 +91,32 @@ async def my_action(config=None):
     return await do_something(timeout=timeout)
 ```
 
-## Environment Variables
+## Sensitive Configuration
 
-Use environment variable substitution for sensitive values:
-
-**config.yml:**
-
-```yaml
-custom_data:
-  database_url: "${DATABASE_URL}"
-  api_key: "${API_KEY}"
-  secret_key: "${SECRET_KEY:-default_value}"  # with default
-```
-
-**Shell:**
-
-```bash
-export DATABASE_URL="postgresql://user:pass@localhost/db"
-export API_KEY="sk-..."
-```
-
-## Example: Multi-Environment Configuration
-
-**config.yml:**
-
-```yaml
-custom_data:
-  environment: "${ENV:-development}"
-
-  # Database configuration
-  database:
-    host: "${DB_HOST:-localhost}"
-    port: "${DB_PORT:-5432}"
-    name: "${DB_NAME:-myapp}"
-
-  # API configuration
-  api:
-    base_url: "${API_BASE_URL:-http://localhost:8000}"
-    timeout: 30
-
-  # Feature toggles
-  features:
-    rate_limiting: "${ENABLE_RATE_LIMIT:-false}"
-    caching: true
-```
+For sensitive values like API keys, use the `api_key_env_var` field on model configurations or load environment variables in your `init()` function:
 
 **config.py:**
 
 ```python
+import os
 from nemoguardrails import LLMRails
 
 def init(app: LLMRails):
     custom_data = app.config.custom_data
 
-    env = custom_data.get("environment")
-    db_config = custom_data.get("database", {})
-    api_config = custom_data.get("api", {})
+    api_key = os.environ.get("API_KEY")
+    db_url = os.environ.get("DATABASE_URL", "postgresql://localhost/myapp")
 
-    # Configure based on environment
-    if env == "production":
-        # Production-specific setup
-        pass
-    else:
-        # Development setup
-        pass
-
-    # Initialize database
-    db = Database(
-        host=db_config.get("host"),
-        port=db_config.get("port"),
-        name=db_config.get("name")
+    client = APIClient(
+        endpoint=custom_data.get("api_endpoint"),
+        api_key=api_key,
     )
 
-    app.register_action_param("db", db)
+    app.register_action_param("api_client", client)
+```
+
+```{note}
+The `custom_data` field in `config.yml` uses standard YAML parsing and does **not** support inline environment variable substitution (e.g., `${VAR}`). Load sensitive values from environment variables in your `init()` function instead.
 ```
 
 ## Best Practices

--- a/docs/configure-rails/custom-initialization/custom-embedding-providers.md
+++ b/docs/configure-rails/custom-initialization/custom-embedding-providers.md
@@ -39,11 +39,12 @@ class CustomEmbedding(EmbeddingModel):
 
     engine_name = "custom_embedding"
 
-    def __init__(self, embedding_model: str):
+    def __init__(self, embedding_model: str, **kwargs):
         """Initialize the embedding model.
 
         Args:
             embedding_model: The model name from config.yml
+            **kwargs: Additional parameters from config.yml
         """
         self.model_name = embedding_model
         # Initialize your model here
@@ -111,7 +112,7 @@ class SentenceTransformerEmbedding(EmbeddingModel):
 
     engine_name = "sentence_transformers"
 
-    def __init__(self, embedding_model: str):
+    def __init__(self, embedding_model: str, **kwargs):
         self.model = SentenceTransformer(embedding_model)
 
     def encode(self, documents: List[str]) -> List[List[float]]:
@@ -156,9 +157,9 @@ class OpenAICompatibleEmbedding(EmbeddingModel):
 
     engine_name = "openai_compatible"
 
-    def __init__(self, embedding_model: str):
+    def __init__(self, embedding_model: str, **kwargs):
         self.model = embedding_model
-        self.api_url = "http://localhost:8080/v1/embeddings"
+        self.api_url = kwargs.get("api_url", "http://localhost:8080/v1/embeddings")
 
     def encode(self, documents: List[str]) -> List[List[float]]:
         response = httpx.post(
@@ -182,7 +183,7 @@ class OpenAICompatibleEmbedding(EmbeddingModel):
 
 | Method | Description |
 |--------|-------------|
-| `__init__(embedding_model: str)` | Initialize with model name from config |
+| `__init__(embedding_model: str, **kwargs)` | Initialize with model name and additional parameters from config |
 | `encode(documents: List[str])` | Synchronous encoding |
 | `encode_async(documents: List[str])` | Asynchronous encoding |
 

--- a/docs/configure-rails/custom-initialization/custom-llm-providers.md
+++ b/docs/configure-rails/custom-initialization/custom-llm-providers.md
@@ -153,7 +153,7 @@ models:
 |--------|----------|-------------|
 | `_call` | Yes | Synchronous text completion |
 | `_llm_type` | Yes | Returns the LLM type identifier |
-| `_acall` | Recommended | Asynchronous text completion |
+| `_acall` | Yes | Asynchronous text completion |
 | `_stream` | Optional | Streaming text completion |
 | `_astream` | Optional | Async streaming text completion |
 


### PR DESCRIPTION
## Description

- Remove incorrect ${VAR} env var substitution examples from custom_data docs
- Add note that custom_data does not support inline env var substitution
- Add **kwargs to EmbeddingModel.__init__ signature to match actual interface
- Change _acall from "Recommended" to "Yes" (required) in LLM provider interface

