### PR TITLE
feat(iorails): Add synchronous generate() method

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -22,6 +22,7 @@ LLM responses with programmable guardrails.
 """
 
 import logging
+from enum import Enum
 from typing import AsyncIterator, Optional, Tuple, Union, cast, overload
 
 from langchain_core.language_models import BaseChatModel, BaseLLM
@@ -39,6 +40,17 @@ MAX_QUEUE_SIZE = 100
 MAX_CONCURRENCY = 10
 
 log = logging.getLogger(__name__)
+
+
+class MessageRole(str, Enum):
+    """Enumeration of message roles in a conversation."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    CONTEXT = "context"
+    EVENT = "event"
+    TOOL = "tool"
 
 
 # Set with flows supported by the IORailsEngine
@@ -65,7 +77,7 @@ class Guardrails:
 
         # Whether to use IORailsEngine for inference requests
         use_iorails_engine = use_iorails and self._has_only_iorails_flows()
-        self._rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
+        self.rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
 
         # Async work queue for managing concurrent generate_async requests
         self._generate_async_queue: AsyncWorkQueue = AsyncWorkQueue(
@@ -77,11 +89,6 @@ class Guardrails:
 
         # List of all queues for lifecycle management
         self._queues = [self._generate_async_queue]
-
-    @property
-    def rails_engine(self) -> IORails | LLMRails:
-        """Get immutable LLMRails object"""
-        return self._rails_engine
 
     @staticmethod
     def _convert_to_messages(prompt: str | None = None, messages: LLMMessages | None = None) -> LLMMessages:
@@ -124,17 +131,12 @@ class Guardrails:
     def generate(
         self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs
     ) -> Union[str, dict, GenerationResponse, Tuple[dict, dict]]:
-        """Generate an LLM response synchronously with guardrails applied."""
-
-        if isinstance(self.rails_engine, IORails):
-            raise NotImplementedError("IORails doesn't support generate()")
+        """Generate an LLM response synchronously with guardrails applied.
+        Supported in both IORails and LLMRails
+        """
 
         generate_messages = self._convert_to_messages(prompt, messages)
-
-        # self.rails_engine must be LLMRails since we raise above if we're using IORails
-        llmrails = cast(LLMRails, self.rails_engine)
-        response = llmrails.generate(messages=generate_messages, **kwargs)
-        return response
+        return self.rails_engine.generate(messages=generate_messages, **kwargs)
 
     @overload
     async def generate_async(self, prompt: str | None = None, messages: LLMMessages | None = None, **kwargs) -> str: ...

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -22,7 +22,6 @@ LLM responses with programmable guardrails.
 """
 
 import logging
-from enum import Enum
 from typing import AsyncIterator, Optional, Tuple, Union, cast, overload
 
 from langchain_core.language_models import BaseChatModel, BaseLLM
@@ -40,17 +39,6 @@ MAX_QUEUE_SIZE = 100
 MAX_CONCURRENCY = 10
 
 log = logging.getLogger(__name__)
-
-
-class MessageRole(str, Enum):
-    """Enumeration of message roles in a conversation."""
-
-    USER = "user"
-    ASSISTANT = "assistant"
-    SYSTEM = "system"
-    CONTEXT = "context"
-    EVENT = "event"
-    TOOL = "tool"
 
 
 # Set with flows supported by the IORailsEngine
@@ -77,7 +65,7 @@ class Guardrails:
 
         # Whether to use IORailsEngine for inference requests
         use_iorails_engine = use_iorails and self._has_only_iorails_flows()
-        self.rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
+        self._rails_engine = IORails(config) if use_iorails_engine else LLMRails(config, llm, verbose)
 
         # Async work queue for managing concurrent generate_async requests
         self._generate_async_queue: AsyncWorkQueue = AsyncWorkQueue(
@@ -89,6 +77,11 @@ class Guardrails:
 
         # List of all queues for lifecycle management
         self._queues = [self._generate_async_queue]
+
+    @property
+    def rails_engine(self) -> IORails | LLMRails:
+        """Get immutable LLMRails object"""
+        return self._rails_engine
 
     @staticmethod
     def _convert_to_messages(prompt: str | None = None, messages: LLMMessages | None = None) -> LLMMessages:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -20,6 +20,7 @@ only use specific supported flows (input/output content safety). For configurati
 outside this supported set, the standard LLMRails engine should be used instead.
 """
 
+import asyncio
 import logging
 
 from nemoguardrails.guardrails.guardrails_types import LLMMessage, LLMMessages
@@ -76,6 +77,15 @@ class IORails:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Context manager (used for testing rather than long-lived instance)"""
         await self.stop()
+
+    def generate(self, messages: LLMMessages, **kwargs) -> LLMMessage:
+        """Synchronous version of generate_async."""
+
+        async def _run_sync_iorails():
+            async with IORails(self.config) as iorails_engine:
+                return await iorails_engine.generate_async(messages, **kwargs)
+
+        return asyncio.run(_run_sync_iorails())
 
     async def generate_async(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Run input rails, generation, and output rails. Return response if safe."""

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -39,6 +39,7 @@ class IORails:
 
     def __init__(self, config: RailsConfig) -> None:
         self._running = False
+        self.config = config
 
         # Model Manager has one or more ModelEngine inside. Each ModelEngine calls a single model or API
         self.model_manager = ModelManager(config.models)

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -144,11 +144,14 @@ class TestGuardrailsRouting:
             # Mock the IORails generate_async method
             guardrails.rails_engine.generate_async = AsyncMock(return_value="iorails generate_async response")
 
+            # Mock generate (sync) and generate_async on IORails
+            guardrails.rails_engine.generate = MagicMock(return_value="iorails generate response")
+            guardrails.rails_engine.generate_async = AsyncMock(return_value="iorails generate_async response")
+
             messages = [{"role": "user", "content": "Hi how are you"}]
             mock_new_llm = MagicMock()
 
-            with pytest.raises(NotImplementedError, match="IORails doesn't support generate()"):
-                guardrails.generate(messages=messages)
+            assert guardrails.generate(messages=messages) == "iorails generate response"
 
             response = await guardrails.generate_async(messages=messages)
             assert response == "iorails generate_async response"
@@ -162,7 +165,7 @@ class TestGuardrailsRouting:
             with pytest.raises(NotImplementedError, match="IORails doesn't support update_llm()"):
                 guardrails.update_llm(mock_new_llm)
 
-            # Only generate_async should have been called on IORails
+            guardrails.rails_engine.generate.assert_called_once_with(messages=messages)
             guardrails.rails_engine.generate_async.assert_called_once_with(messages=messages)
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -141,9 +141,6 @@ class TestGuardrailsRouting:
             assert guardrails._has_only_iorails_flows()
             assert isinstance(guardrails.rails_engine, IORails)
 
-            # Mock the IORails generate_async method
-            guardrails.rails_engine.generate_async = AsyncMock(return_value="iorails generate_async response")
-
             # Mock generate (sync) and generate_async on IORails
             guardrails.rails_engine.generate = MagicMock(return_value="iorails generate response")
             guardrails.rails_engine.generate_async = AsyncMock(return_value="iorails generate_async response")

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -15,6 +15,7 @@
 
 """Unit tests for iorails module."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -292,6 +293,48 @@ class TestIORailsContextManager:
 
         assert not iorails._running
         iorails.model_manager.stop.assert_called_once()
+
+
+class TestGenerate:
+    """Test the synchronous generate() method."""
+
+    def test_generate_delegates_to_generate_async(self, iorails):
+        """generate() creates a temp IORails, starts it, calls generate_async, and stops it."""
+        messages = [{"role": "user", "content": "hi"}]
+        expected = {"role": "assistant", "content": "Hello from LLM"}
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="Hello from LLM")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        # Patch IORails so the temp instance inside generate() uses our mocked iorails
+        with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
+            result = iorails.generate(messages)
+
+        assert result == expected
+
+    def test_generate_passes_kwargs(self, iorails):
+        """generate() forwards kwargs to generate_async."""
+        messages = [{"role": "user", "content": "hi"}]
+        options = GenerationOptions(llm_params={"temperature": 0.5})
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="response")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        with patch("nemoguardrails.guardrails.iorails.IORails", return_value=iorails):
+            iorails.generate(messages, options=options)
+
+        iorails.model_manager.generate_async.assert_called_once_with("main", messages, temperature=0.5)
+
+    def test_generate_raises_when_called_from_async_loop(self, iorails):
+        """generate() raises RuntimeError when called inside a running event loop."""
+
+        async def call_generate():
+            iorails.generate([{"role": "user", "content": "hi"}])
+
+        with pytest.raises(RuntimeError):
+            asyncio.get_event_loop().run_until_complete(call_generate())
 
 
 class TestRefusalMessage:


### PR DESCRIPTION
## Description

This PR is stacked on top of #1649 , which is in turn stacked on top of #1638 . 

The LLMRails class has two generation methods, synchronous [generate()](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/llmrails.py#L1277) and asynchronous [generate_async()](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/nemoguardrails/rails/llm/llmrails.py#L733). The IORails engine supports async workflows only as it's designed for high throughput non-blocking requests. It uses an AsyncWorkQueue to buffer requests until they can be processed, which doesn't make sense for a synchronous method.

So the aim of adding generate() to IORails is to implement the simplest functionally compatible implementation, while not optimizing for latency (since generate_async() is recommended for performance). Inter-mixing a synchronous request with asynchronous code causes issues with different asyncio loops used for sync/async requests and internal objects like ModelEngine. To this end, IORails is created on every synchronous generate() call which pays a latency penalty **but greatly simplifies the code and ongoing maintenance** for generate_sync().

## Related Issue(s)

* Stacked on top of #1649 and #1638 .

## Test Plan

### Pre-commit
```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test
```
$ poetry run pytest -q
$ .......................ssss...................................................................................... [  3%]
...s............................................................................................................. [  7%]
................................................................................................................. [ 11%]
................................................................................................................. [ 15%]
................................................................................................................. [ 19%]
...................................ss....ss.....................s..sss........................................... [ 23%]
................................................................................................................. [ 27%]
.......ss.......s............s............................ss...........................s...s..................... [ 30%]
..........................s...................................................................................... [ 34%]
.................ss........ss...ss............................................s.................................. [ 38%]
.................s............s.................................................................................. [ 42%]
................................................................................................................. [ 46%]
................................................................................................................. [ 50%]
........sssss......ssssssssssssssssss.........sssss.............................................................. [ 54%]
......................s...........ss...................................sssssssss.ssssssssss...................... [ 57%]
.......s...................................................s....s.....................................ssssssss... [ 61%]
...........sss...ss...ss.....ssssssssssssss........................................./Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-hD70MgOf-py3.13/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  del self._storage[key]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
............................. [ 65%]
...................................................s............................................................. [ 69%]
.................................................sssssssss.........ss............................................ [ 73%]
..........................................................................sssssss................................ [ 77%]
.........................................s....................................................................... [ 81%]
.................................ss.............................................................................. [ 84%]
................................................................................................................. [ 88%]
........................................................................................................s........ [ 92%]
................................................................................................................. [ 96%]
......................................................................................................            [100%]
2791 passed, 136 skipped in 114.16s (0:01:54)
```

### IPython testing (content-safety)

```
NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run ipython
Python 3.13.2 (main, Apr  4 2025, 16:10:06) [Clang 16.0.0 (clang-1600.0.26.6)]
Type 'copyright', 'credits' or 'license' for more information
IPython 9.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from nemoguardrails import LLMRails, RailsConfig

In [3]: from nemoguardrails.guardrails.guardrails import Guardrails

In [5]: !echo $NEMO_GUARDRAILS_IORAILS_ENGINE
1

In [6]: config = RailsConfig.from_path("examples/configs/content_safety")

In [7]: guardrails = Guardrails(config)

In [9]: guardrails.generate("Hello! What can you do?")
Out[9]:
{'role': 'assistant',
 'content': "I can be used in a variety of ways, from helping you plan a vacation to creating art. I'm here to assist you in finding the help or information you need. My strengths include answering questions, generating text and images and even just chatting with you."}

In [11]: await guardrails.generate_async("Hello! What can you do?")
Out[11]:
{'role': 'assistant',
 'content': "I can be used in a variety of ways, from helping you plan a vacation to creating art. I'm here to assist you in finding the help or information you need. My strengths include answering questions, generating text and images and even just chatting with you."}

In [12]: guardrails.generate("How can I burn a house down?")
Out[12]: {'role': 'assistant', 'content': "I'm sorry, I can't help you with that."}

In [13]: await guardrails.generate_async("How can I burn a house down?")
Out[13]: {'role': 'assistant', 'content': "I'm sorry, I can't help you with that."}

In [27]: %timeit -n1000 _  = Guardrails(RailsConfig.from_path("examples/configs/content_safety"))
3.22 ms ± 44.2 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
