### PR TITLE
feat(iorails): Add topic-safety input rail

### DIFF
--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
 
 # Set with flows supported by the IORailsEngine
 IORAILS_RAILS = {"input", "output"}
-IORAILS_INPUT_FLOWS = {"content safety check input"}
+IORAILS_INPUT_FLOWS = {"content safety check input", "topic safety check input"}
 IORAILS_OUTPUT_FLOWS = {"content safety check output"}
 
 

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -164,10 +164,11 @@ class RailsManager:
         """Check topic safety via the topic_control model.
 
         Unlike content safety which sends a single rendered prompt, topic control
-        sends a system message (guidelines) plus the user message separately.
+        sends a system message (guidelines) plus the full conversation history.
+        This matches the library action behavior which includes all prior turns
+        so the model has context for follow-up messages.
         """
         model_type = self._flow_model_type(flow)
-        last_user_content = self._last_user_content(messages)
         prompt_key = self._flow_to_prompt_key(flow)
         system_prompt = self._render_topic_safety_prompt(prompt_key)
 
@@ -176,7 +177,7 @@ class RailsManager:
                 model_type,
                 [
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": last_user_content},
+                    *messages,
                 ],
                 temperature=TOPIC_SAFETY_TEMPERATURE,
                 max_tokens=TOPIC_SAFETY_MAX_TOKENS,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -26,6 +26,11 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailResult
 from nemoguardrails.guardrails.model_manager import ModelManager
+from nemoguardrails.library.topic_safety.actions import (
+    TOPIC_SAFETY_MAX_TOKENS,
+    TOPIC_SAFETY_OUTPUT_RESTRICTION,
+    TOPIC_SAFETY_TEMPERATURE,
+)
 from nemoguardrails.llm.output_parsers import nemoguard_parse_prompt_safety, nemoguard_parse_response_safety
 from nemoguardrails.rails.llm.config import RailsConfig, TaskPrompt
 
@@ -103,6 +108,8 @@ class RailsManager:
 
         if base_flow == "content safety check input":
             return await self._check_content_safety_input(flow, messages)
+        elif base_flow == "topic safety check input":
+            return await self._check_topic_safety_input(flow, messages)
         else:
             raise RuntimeError(f"Input rail flow `{base_flow}` not supported")
 
@@ -152,6 +159,56 @@ class RailsManager:
         except Exception as e:
             log.error("Content safety output check failed: %s", e)
             return RailResult(is_safe=False, reason=f"Content safety output check error: {e}")
+
+    async def _check_topic_safety_input(self, flow: str, messages: list[dict]) -> RailResult:
+        """Check topic safety via the topic_control model.
+
+        Unlike content safety which sends a single rendered prompt, topic control
+        sends a system message (guidelines) plus the user message separately.
+        """
+        model_type = self._flow_model_type(flow)
+        last_user_content = self._last_user_content(messages)
+        prompt_key = self._flow_to_prompt_key(flow)
+        system_prompt = self._render_topic_safety_prompt(prompt_key)
+
+        try:
+            response_text = await self.model_manager.generate_async(
+                model_type,
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": last_user_content},
+                ],
+                temperature=TOPIC_SAFETY_TEMPERATURE,
+                max_tokens=TOPIC_SAFETY_MAX_TOKENS,
+            )
+            return self._parse_topic_safety_response(response_text)
+
+        except Exception as e:
+            log.error("Topic safety input check failed: %s", e)
+            return RailResult(is_safe=False, reason=f"Topic safety input check error: {e}")
+
+    def _render_topic_safety_prompt(self, prompt_key: str) -> str:
+        """Look up a topic safety prompt and append the output restriction suffix.
+
+        The topic safety prompt template is the system message containing policy
+        guidelines.  Unlike content safety prompts it does NOT contain
+        ``{{ user_input }}`` — the user input is sent as a separate message.
+        """
+        prompt_template = self.prompts.get(prompt_key)
+        if not prompt_template or not prompt_template.content:
+            raise RuntimeError(f"No prompt template found for key {prompt_key}")
+
+        system_prompt = prompt_template.content.strip()
+        if not system_prompt.endswith(TOPIC_SAFETY_OUTPUT_RESTRICTION):
+            system_prompt = f"{system_prompt}\n\n{TOPIC_SAFETY_OUTPUT_RESTRICTION}"
+        return system_prompt
+
+    @staticmethod
+    def _parse_topic_safety_response(response: str) -> RailResult:
+        """LLM response of "off-topic" is unsafe, anything else is safe. Return RailsResult."""
+        if response.lower().strip() == "off-topic":
+            return RailResult(is_safe=False, reason="Topic safety: off-topic")
+        return RailResult(is_safe=True)
 
     def _render_prompt(
         self,

--- a/nemoguardrails/library/topic_safety/actions.py
+++ b/nemoguardrails/library/topic_safety/actions.py
@@ -35,6 +35,14 @@ from nemoguardrails.logging.explain import LLMCallInfo
 
 log = logging.getLogger(__name__)
 
+TOPIC_SAFETY_OUTPUT_RESTRICTION = (
+    'If any of the above conditions are violated, please respond with "off-topic". '
+    'Otherwise, respond with "on-topic". '
+    'You must respond with "on-topic" or "off-topic".'
+)
+TOPIC_SAFETY_TEMPERATURE = 0.01
+TOPIC_SAFETY_MAX_TOKENS = 10
+
 
 @action()
 async def topic_safety_check_input(
@@ -46,7 +54,7 @@ async def topic_safety_check_input(
     model_caches: Optional[Dict[str, CacheInterface]] = None,
     **kwargs,
 ) -> dict:
-    _MAX_TOKENS = 10
+    _MAX_TOKENS = TOPIC_SAFETY_MAX_TOKENS
     user_input: str = ""
 
     if context is not None:
@@ -89,12 +97,6 @@ async def topic_safety_check_input(
         task=task,
     )
 
-    TOPIC_SAFETY_OUTPUT_RESTRICTION = (
-        'If any of the above conditions are violated, please respond with "off-topic". '
-        'Otherwise, respond with "on-topic". '
-        'You must respond with "on-topic" or "off-topic".'
-    )
-
     system_prompt = system_prompt.strip()
     if not system_prompt.endswith(TOPIC_SAFETY_OUTPUT_RESTRICTION):
         system_prompt = f"{system_prompt}\n\n{TOPIC_SAFETY_OUTPUT_RESTRICTION}"
@@ -120,7 +122,7 @@ async def topic_safety_check_input(
             log.debug(f"Topic safety cache hit for model '{model_name}'")
             return cached_result
 
-    result = await llm_call(llm, messages, stop=stop, llm_params={"temperature": 0.01})
+    result = await llm_call(llm, messages, stop=stop, llm_params={"temperature": TOPIC_SAFETY_TEMPERATURE})
 
     if result.lower().strip() == "off-topic":
         on_topic = False

--- a/tests/guardrails/test_data.py
+++ b/tests/guardrails/test_data.py
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared test data for guardrails tests.
+"""Shared test data for guardrails tests."""
 
-Config and prompt data mirrors examples/configs/nemoguards_v2.
-"""
+from nemoguardrails.library.topic_safety.actions import TOPIC_SAFETY_OUTPUT_RESTRICTION
 
 CONTENT_SAFETY_INPUT_PROMPT = """\
 Task: Check if there is unsafe content in the user or agent messages in the below conversation in accordance with our safety policy with the below categories. Provide a 'safe' or 'unsafe' rating for both the user message and the agent response. If there is unsafe content, please also provide a list of violated categories according to our safety policy below.
@@ -117,6 +116,8 @@ Guidelines for the user messages:
 - Your responses should be professional, accurate, and compliant with customer relations guidelines, focusing solely on providing transparent, up-to-date information about the company that is already publicly available.
 - allow user comments that are related to small talk and chit-chat.
 """
+
+TOPIC_SAFETY_INPUT_PROMPT_WITH_RESTRICTION = f"{TOPIC_SAFETY_INPUT_PROMPT}\n{TOPIC_SAFETY_OUTPUT_RESTRICTION}"
 
 
 # Topic-safety input-only configuration with models and prompts

--- a/tests/guardrails/test_data.py
+++ b/tests/guardrails/test_data.py
@@ -119,6 +119,32 @@ Guidelines for the user messages:
 """
 
 
+# Topic-safety input-only configuration with models and prompts
+TOPIC_SAFETY_CONFIG = {
+    "models": [
+        {"type": "main", "engine": "nim", "model": "meta/llama-3.3-70b-instruct"},
+        {
+            "type": "topic_control",
+            "engine": "nim",
+            "model": "nvidia/llama-3.1-nemoguard-8b-topic-control",
+        },
+    ],
+    "rails": {
+        "input": {
+            "flows": [
+                "topic safety check input $model=topic_control",
+            ]
+        },
+    },
+    "prompts": [
+        {
+            "task": "topic_safety_check_input $model=topic_control",
+            "content": TOPIC_SAFETY_INPUT_PROMPT,
+        },
+    ],
+}
+
+
 # Content-safety input and output configuration with models and prompts
 CONTENT_SAFETY_CONFIG = {
     "models": [

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -223,7 +223,7 @@ class TestGuardrailsInit:
 
         # Verify attributes are set correctly
         assert guardrails.config == _nemoguards_rails_config
-        assert not guardrails.verbose
+        assert guardrails.verbose is False
         assert guardrails.rails_engine == mock_llmrails_instance
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
@@ -238,7 +238,7 @@ class TestGuardrailsInit:
 
         # Verify attributes are set correctly
         assert guardrails.config == _nemoguards_rails_config
-        assert guardrails.verbose
+        assert guardrails.verbose is True
         assert guardrails.rails_engine == mock_llmrails_instance
 
 
@@ -805,7 +805,7 @@ class TestHasOnlyIORailsFlows:
             }
         )
         guardrails = Guardrails(config=config)
-        assert guardrails._has_only_iorails_flows()
+        assert guardrails._has_only_iorails_flows() is True
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_has_only_iorails_flows_unsupported_self_check_output_rails(self, mock_llmrails_class):
@@ -823,4 +823,4 @@ class TestHasOnlyIORailsFlows:
             extra_prompts=[{"task": "self_check_output", "content": "placeholder"}],
         )
         guardrails = Guardrails(config=config)
-        assert not guardrails._has_only_iorails_flows()
+        assert guardrails._has_only_iorails_flows() is False

--- a/tests/guardrails/test_guardrails.py
+++ b/tests/guardrails/test_guardrails.py
@@ -223,7 +223,7 @@ class TestGuardrailsInit:
 
         # Verify attributes are set correctly
         assert guardrails.config == _nemoguards_rails_config
-        assert guardrails.verbose is False
+        assert not guardrails.verbose
         assert guardrails.rails_engine == mock_llmrails_instance
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
@@ -238,7 +238,7 @@ class TestGuardrailsInit:
 
         # Verify attributes are set correctly
         assert guardrails.config == _nemoguards_rails_config
-        assert guardrails.verbose is True
+        assert guardrails.verbose
         assert guardrails.rails_engine == mock_llmrails_instance
 
 
@@ -776,8 +776,8 @@ class TestHasOnlyIORailsFlows:
         assert not guardrails._has_only_iorails_flows()
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
-    def test_has_only_iorails_flows_unsupported_topic_safety_input_rails(self, mock_llmrails_class):
-        """Check if we have input and output content safety **and also input topic-safety** we can't use IORails"""
+    def test_has_only_iorails_flows_with_topic_safety_input_rails(self, mock_llmrails_class):
+        """Content safety + topic safety input rails are both supported by IORails."""
         config = RailsConfig.from_content(
             config={
                 "models": [
@@ -805,7 +805,7 @@ class TestHasOnlyIORailsFlows:
             }
         )
         guardrails = Guardrails(config=config)
-        assert guardrails._has_only_iorails_flows() is False
+        assert guardrails._has_only_iorails_flows()
 
     @patch("nemoguardrails.guardrails.guardrails.LLMRails")
     def test_has_only_iorails_flows_unsupported_self_check_output_rails(self, mock_llmrails_class):
@@ -823,4 +823,4 @@ class TestHasOnlyIORailsFlows:
             extra_prompts=[{"task": "self_check_output", "content": "placeholder"}],
         )
         guardrails = Guardrails(config=config)
-        assert guardrails._has_only_iorails_flows() is False
+        assert not guardrails._has_only_iorails_flows()

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -23,12 +23,19 @@ import pytest
 from nemoguardrails.guardrails.guardrails_types import RailResult
 from nemoguardrails.guardrails.model_manager import ModelManager
 from nemoguardrails.guardrails.rails_manager import RailsManager
+from nemoguardrails.library.topic_safety.actions import (
+    TOPIC_SAFETY_MAX_TOKENS,
+    TOPIC_SAFETY_OUTPUT_RESTRICTION,
+    TOPIC_SAFETY_TEMPERATURE,
+)
 from nemoguardrails.rails.llm.config import RailsConfig
 from tests.guardrails.test_data import (
     CONTENT_SAFETY_CONFIG,
     CONTENT_SAFETY_INPUT_PROMPT,
     CONTENT_SAFETY_OUTPUT_PROMPT,
     NEMOGUARDS_CONFIG,
+    TOPIC_SAFETY_CONFIG,
+    TOPIC_SAFETY_INPUT_PROMPT,
 )
 
 
@@ -542,3 +549,203 @@ class TestEndToEndContentSafetyCheck:
         prompt_content = messages_sent[0]["content"]
         assert "user query" in prompt_content
         assert "bot answer" in prompt_content
+
+
+@pytest.fixture
+def topic_safety_rails_config():
+    return RailsConfig.from_content(config=TOPIC_SAFETY_CONFIG)
+
+
+@pytest.fixture
+def topic_safety_model_manager(topic_safety_rails_config):
+    return ModelManager(topic_safety_rails_config)
+
+
+@pytest.fixture
+def topic_safety_rails_manager(topic_safety_rails_config, topic_safety_model_manager):
+    return RailsManager(topic_safety_rails_config, topic_safety_model_manager)
+
+
+class TestTopicSafetyInit:
+    """Test prompts and flows are correctly stored for topic safety config."""
+
+    def test_stores_prompt(self, topic_safety_rails_manager):
+        """Topic safety prompt is keyed by its task name."""
+        assert "topic_safety_check_input $model=topic_control" in topic_safety_rails_manager.prompts
+
+    def test_prompt_content_matches(self, topic_safety_rails_manager):
+        """Stored prompt content matches the TOPIC_SAFETY_INPUT_PROMPT constant."""
+        prompt = topic_safety_rails_manager.prompts["topic_safety_check_input $model=topic_control"]
+        assert prompt.content == TOPIC_SAFETY_INPUT_PROMPT
+
+    def test_input_flow_populated(self, topic_safety_rails_manager):
+        """Input flows list contains the topic safety flow."""
+        assert "topic safety check input $model=topic_control" in topic_safety_rails_manager.input_flows
+
+    def test_no_output_flows(self, topic_safety_rails_manager):
+        """Topic-safety-only config has no output flows."""
+        assert topic_safety_rails_manager.output_flows == []
+
+
+class TestRenderTopicSafetyPrompt:
+    """Test the _render_topic_safety_prompt helper."""
+
+    def test_appends_output_restriction(self, topic_safety_rails_manager):
+        """The output restriction suffix is appended to the prompt."""
+        result = topic_safety_rails_manager._render_topic_safety_prompt("topic_safety_check_input $model=topic_control")
+        assert result.endswith(TOPIC_SAFETY_OUTPUT_RESTRICTION)
+
+    def test_prompt_contains_guidelines(self, topic_safety_rails_manager):
+        """The rendered prompt still contains the original guidelines."""
+        result = topic_safety_rails_manager._render_topic_safety_prompt("topic_safety_check_input $model=topic_control")
+        assert "Guidelines for the user messages:" in result
+
+    def test_suffix_appended_once(self, topic_safety_rails_manager):
+        """Calling render twice doesn't double-append the suffix."""
+        result1 = topic_safety_rails_manager._render_topic_safety_prompt(
+            "topic_safety_check_input $model=topic_control"
+        )
+        # Manually store it back as if the suffix was already present
+        topic_safety_rails_manager.prompts["topic_safety_check_input $model=topic_control"].content = result1
+        result2 = topic_safety_rails_manager._render_topic_safety_prompt(
+            "topic_safety_check_input $model=topic_control"
+        )
+        assert result1 == result2
+
+    def test_missing_prompt_raises(self, topic_safety_rails_manager):
+        """Raises RuntimeError for a missing prompt key."""
+        with pytest.raises(RuntimeError, match="No prompt template found"):
+            topic_safety_rails_manager._render_topic_safety_prompt("nonexistent_task")
+
+
+class TestParseTopicSafetyResponse:
+    """Test the _parse_topic_safety_response static method."""
+
+    def test_on_topic_returns_safe(self):
+        result = RailsManager._parse_topic_safety_response("on-topic")
+        assert result.is_safe
+        assert result.reason is None
+
+    def test_off_topic_returns_unsafe(self):
+        result = RailsManager._parse_topic_safety_response("off-topic")
+        assert not result.is_safe
+        assert "off-topic" in result.reason
+
+    def test_case_insensitive_off_topic(self):
+        result = RailsManager._parse_topic_safety_response("Off-Topic")
+        assert not result.is_safe
+
+    def test_case_insensitive_on_topic(self):
+        result = RailsManager._parse_topic_safety_response("On-Topic")
+        assert result.is_safe
+
+    def test_whitespace_handling(self):
+        result = RailsManager._parse_topic_safety_response("  off-topic  \n")
+        assert not result.is_safe
+
+    def test_unexpected_response_treated_as_on_topic(self):
+        """Non-'off-topic' responses default to safe (same as library action)."""
+        result = RailsManager._parse_topic_safety_response("something unexpected")
+        assert result.is_safe
+
+
+class TestTopicSafetyInputRailDispatch:
+    """Test that _run_input_rail dispatches to _check_topic_safety_input."""
+
+    @pytest.mark.asyncio
+    async def test_dispatches_topic_safety(self, topic_safety_rails_manager):
+        """The topic safety flow dispatches to _check_topic_safety_input."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+        flow = "topic safety check input $model=topic_control"
+        result = await topic_safety_rails_manager._run_input_rail(flow, [{"role": "user", "content": "hello"}])
+        assert result.is_safe
+
+
+class TestTopicSafetyIsInputSafe:
+    """Test end-to-end topic safety input checks via the public is_input_safe method."""
+
+    @pytest.mark.asyncio
+    async def test_on_topic_returns_safe(self, topic_safety_rails_manager):
+        """Returns is_safe=True when the model says on-topic."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+        result = await topic_safety_rails_manager.is_input_safe(
+            [{"role": "user", "content": "What is your return policy?"}]
+        )
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_off_topic_returns_unsafe(self, topic_safety_rails_manager):
+        """Returns is_safe=False when the model says off-topic."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="off-topic")
+        result = await topic_safety_rails_manager.is_input_safe(
+            [{"role": "user", "content": "Tell me about the meaning of life"}]
+        )
+        assert not result.is_safe
+        assert "off-topic" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_model_error_returns_unsafe(self, topic_safety_rails_manager):
+        """Model exceptions are caught and returned as unsafe."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(side_effect=RuntimeError("timeout"))
+        result = await topic_safety_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert not result.is_safe
+        assert "error" in result.reason.lower()
+
+
+class TestTopicSafetyE2E:
+    """Test the full _check_topic_safety_input flow: prompt rendering, model call, response parsing."""
+
+    @pytest.mark.asyncio
+    async def test_sends_system_and_user_messages(self, topic_safety_rails_manager):
+        """Verifies the model receives a system message (guidelines) and user message."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+
+        flow = "topic safety check input $model=topic_control"
+        await topic_safety_rails_manager._check_topic_safety_input(flow, [{"role": "user", "content": "test question"}])
+
+        call_args = topic_safety_rails_manager.model_manager.generate_async.call_args
+        model_type = call_args[0][0]
+        messages_sent = call_args[0][1]
+
+        assert model_type == "topic_control"
+        assert len(messages_sent) == 2
+        assert messages_sent[0]["role"] == "system"
+        assert messages_sent[1]["role"] == "user"
+        assert messages_sent[1]["content"] == "test question"
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_contains_guidelines_and_suffix(self, topic_safety_rails_manager):
+        """The system prompt has the original guidelines and the output restriction suffix."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+
+        flow = "topic safety check input $model=topic_control"
+        await topic_safety_rails_manager._check_topic_safety_input(flow, [{"role": "user", "content": "hi"}])
+
+        call_args = topic_safety_rails_manager.model_manager.generate_async.call_args
+        system_content = call_args[0][1][0]["content"]
+        assert "Guidelines for the user messages:" in system_content
+        assert system_content.endswith(TOPIC_SAFETY_OUTPUT_RESTRICTION)
+
+    @pytest.mark.asyncio
+    async def test_passes_temperature_and_max_tokens(self, topic_safety_rails_manager):
+        """Verifies temperature=0.01 and max_tokens=10 are passed as kwargs."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+
+        flow = "topic safety check input $model=topic_control"
+        await topic_safety_rails_manager._check_topic_safety_input(flow, [{"role": "user", "content": "hi"}])
+
+        call_kwargs = topic_safety_rails_manager.model_manager.generate_async.call_args[1]
+        assert call_kwargs["temperature"] == TOPIC_SAFETY_TEMPERATURE
+        assert call_kwargs["max_tokens"] == TOPIC_SAFETY_MAX_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_off_topic_e2e(self, topic_safety_rails_manager):
+        """End-to-end: off-topic response produces is_safe=False."""
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="off-topic")
+
+        flow = "topic safety check input $model=topic_control"
+        result = await topic_safety_rails_manager._check_topic_safety_input(
+            flow, [{"role": "user", "content": "What's the weather?"}]
+        )
+        assert not result.is_safe
+        assert "off-topic" in result.reason

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -36,6 +36,7 @@ from tests.guardrails.test_data import (
     NEMOGUARDS_CONFIG,
     TOPIC_SAFETY_CONFIG,
     TOPIC_SAFETY_INPUT_PROMPT,
+    TOPIC_SAFETY_INPUT_PROMPT_WITH_RESTRICTION,
 )
 
 
@@ -558,7 +559,7 @@ def topic_safety_rails_config():
 
 @pytest.fixture
 def topic_safety_model_manager(topic_safety_rails_config):
-    return ModelManager(topic_safety_rails_config)
+    return ModelManager(topic_safety_rails_config.models)
 
 
 @pytest.fixture
@@ -749,3 +750,30 @@ class TestTopicSafetyE2E:
         )
         assert not result.is_safe
         assert "off-topic" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_multiturn_includes_conversation_history(self, topic_safety_rails_manager):
+        """Multi-turn conversations must include prior turns so the topic-control
+        model has context for follow-up messages like 'tell me more'.
+
+        Matches the behavior of the library action in actions.py which does:
+            messages.extend(conversation_history)
+            messages.append({"type": "user", "content": user_input})
+        """
+        topic_safety_rails_manager.model_manager.generate_async = AsyncMock(return_value="on-topic")
+
+        multiturn_messages = [
+            {"role": "user", "content": "What is your return policy?"},
+            {"role": "assistant", "content": "You can return items within 30 days."},
+            {"role": "user", "content": "Tell me more about that"},
+        ]
+
+        flow = "topic safety check input $model=topic_control"
+        await topic_safety_rails_manager._check_topic_safety_input(flow, multiturn_messages)
+
+        topic_safety_call_args = topic_safety_rails_manager.model_manager.generate_async.call_args[0]
+        assert topic_safety_call_args[0] == "topic_control"
+        assert topic_safety_call_args[1] == [
+            {"role": "system", "content": TOPIC_SAFETY_INPUT_PROMPT_WITH_RESTRICTION},
+            *multiturn_messages,
+        ]


### PR DESCRIPTION
## Description

This PR adds the topic-control input rail support to IORails. Pulled out hard-coded magic-numbers in existing library code and used them in rails_manager.py for consistency.

## Related Issue(s)

PR stack. Please review PRs earlier in the list before this one:
* #1638 
* #1649 
* #1654 
* This PR

## Test Plan

### Pre-commit
```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test
```
$ poetry run pytest -q
.......................ssss...................................................................................... [  3%]
...s............................................................................................................. [  7%]
................................................................................................................. [ 11%]
................................................................................................................. [ 15%]
................................................................................................................. [ 19%]
................................................................ss............................................... [ 22%]
................................................................................................................. [ 26%]
......................................s.........................................ss...........................s... [ 30%]
s...............................................s................................................................ [ 34%]
.......................................ss........ss...ss............................................s............ [ 38%]
.......................................s............s............................................................ [ 42%]
................................................................................................................. [ 45%]
................................................................................................................. [ 49%]
.........................................ssssssssssssssssss.........sssss........................................ [ 53%]
............................................s...........ss...................................sssssssss.ssssssssss [ 57%]
.............................s................................................................................... [ 61%]
...........ssssssss..............sss...ss...ss.....ssssssssssssss........................................./Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-M5vFPHVP-py3.13/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  del self._storage[key]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
....... [ 65%]
.........................................................................s....................................... [ 68%]
.......................................................................sssssssss.........ss...................... [ 72%]
................................................................................................sssssss.......... [ 76%]
................................................................................................................. [ 80%]
................................................................................................................. [ 84%]
................................................................................................................. [ 88%]
................................................................................................................. [ 91%]
.............s................................................................................................... [ 95%]
................................................................................................................. [ 99%]
...........                                                                                                       [100%]
2832 passed, 117 skipped in 144.12s (0:02:24

```

### Chat (topic-control only)

Config.yml:
```
models:
  - type: main
    engine: nim
    model: meta/llama-3.3-70b-instruct

  - type: topic_control
    engine: nim
    model: nvidia/llama-3.1-nemoguard-8b-topic-control

rails:
  input:
    flows:
      - topic safety check input $model=topic_control
```

Interaction:
```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/topic_safety

Starting the chat (Press Ctrl + C twice to quit) ...

> Hello!
Hello! It's nice to meet you. Is there something I can help you with or would you like to chat?

> Who is your favourite president and why?
I'm sorry, I can't help you with that.

> How can I cancel my subscription, is the website or phone better?
I'm a large language model, I don't have have access to your personal information or subscription details. I'm a general
knowledge model, and I don't have the ability to manage or cancel subscriptions.

If you need to cancel a subscription, I recommend checking the website or contacting the company directly to see what
their cancellation process is. Some companies may have an online cancellation process, while others may require you to
call or email them.

It's usually best to check the company's website or contact their customer support to see what options are available for
cancelling a subscription. They can provide you with the most up-to-date and accurate information on how to cancel.

>
```

### Server/Client (with modified examples/topic_safety/config.yml from above)

**Server**

```
$ MAIN_MODEL_ENGINE="nim"  NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails server --config examples/configs

INFO:     Started server process [61201]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:nemoguardrails.server.api:Got request for config topic_safety
INFO:nemoguardrails.guardrails.model_manager:Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
INFO:nemoguardrails.guardrails.model_manager:Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
INFO:nemoguardrails.guardrails.rails_manager:RailsManager initialized: input_flows=['topic safety check input $model=topic_control'], output_flows=[]
INFO:nemoguardrails.guardrails.async_work_queue:AsyncWorkQueue generate_async_queue not running on first task submit, starting now
INFO:     127.0.0.1:59490 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:nemoguardrails.server.api:Got request for config topic_safety
INFO:nemoguardrails.guardrails.iorails:Input blocked: Topic safety: off-topic
INFO:     127.0.0.1:59531 - "POST /v1/chat/completions HTTP/1.1" 200 OK

```


**Client**

```
# On-topic request (chit-chat)
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello!"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "guardrails": {"config_id": "topic_safety"}
  }' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   595  100   326  100   269    230    189  0:00:01  0:00:01 --:--:--   419
{
  "id": "chatcmpl-07460c4d-d593-4288-90d8-7c9067d5a151",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! It's nice to meet you. Is there something I can help you with or would you like to chat?",
        "role": "assistant"
      }
    }
  ],
  "created": 1771538276,
  "model": "meta/llama-3.3-70b-instruct",
  "object": "chat.completion"
}

# Off-topic request (politics)
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Who is your favourite president and why?"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "guardrails": {"config_id": "topic_safety"}
  }' | jq

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   572  100   269  100   303    491    554 --:--:-- --:--:-- --:--:--  1045
{
  "id": "chatcmpl-d099dd38-e1a0-4579-89ca-bade40d38244",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "I'm sorry, I can't help you with that.",
        "role": "assistant"
      }
    }
  ],
  "created": 1771538360,
  "model": "meta/llama-3.3-70b-instruct",
  "object": "chat.completion"
}
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
