### PR TITLE
feat(iorails): Parallel rails

### DIFF
--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -15,10 +15,18 @@
 
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import TypeAlias
 
 LLMMessage: TypeAlias = dict[str, str]  # e.g. {"role": "user", "content": "What can you do?"}
 LLMMessages: TypeAlias = list[LLMMessage]
+
+
+class RailDirection(Enum):
+    """Direction of a rail check, used for logging."""
+
+    INPUT = "Input"
+    OUTPUT = "Output"
 
 
 @dataclass(frozen=True, slots=True)

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -75,8 +75,6 @@ class RailsManager:
         # Create jinja2 rendering environment
         self._jinja2_env = SandboxedEnvironment(autoescape=False)
 
-        log.info("RailsManager initialized: input_flows=%s, output_flows=%s", self.input_flows, self.output_flows)
-
     async def is_input_safe(self, messages: list[dict]) -> RailResult:
         """Run all enabled input rails, short-circuiting on the first failure.
 
@@ -138,7 +136,7 @@ class RailsManager:
         try:
             while pending_tasks:
                 done, pending_tasks = await asyncio.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
-                for task in sorted(done, key=task_order.__getitem__):
+                for task in sorted(done, key=lambda t: task_order[t]):
                     result = task.result()
                     flow = task_to_flow[task]
                     log.debug("%s flow %s result %s", direction.value, flow, result)

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -16,15 +16,19 @@
 """Rails manager for IORails engine.
 
 Orchestrates input/output safety checks by calling ModelManager.
-Rails run sequentially; the first failing rail short-circuits the check.
+Rails run sequentially by default; the first failing rail short-circuits.
+When parallel mode is enabled, all rails run concurrently and the first
+unsafe result cancels remaining rails immediately.
 """
 
+import asyncio
 import logging
-from typing import Sequence, cast
+from collections.abc import Coroutine, Mapping, Sequence
+from typing import Any, cast
 
 from jinja2.sandbox import SandboxedEnvironment
 
-from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailResult
+from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailDirection, RailResult
 from nemoguardrails.guardrails.model_manager import ModelManager
 from nemoguardrails.library.topic_safety.actions import (
     TOPIC_SAFETY_MAX_TOKENS,
@@ -57,36 +61,107 @@ class RailsManager:
         self.input_flows: list[str] = list(config.rails.input.flows)
         self.output_flows: list[str] = list(config.rails.output.flows)
 
+        # Parallel execution flags (Optional[bool] in config, coerce to bool)
+        self.input_parallel: bool = config.rails.input.parallel or False
+        self.output_parallel: bool = config.rails.output.parallel or False
+
+        log.info(
+            "RailsManager initialized: input_flows=%s, output_flows=%s, input_parallel=%s, output_parallel=%s",
+            self.input_flows,
+            self.output_flows,
+            self.input_parallel,
+            self.output_parallel,
+        )
         # Create jinja2 rendering environment
         self._jinja2_env = SandboxedEnvironment(autoescape=False)
 
         log.info("RailsManager initialized: input_flows=%s, output_flows=%s", self.input_flows, self.output_flows)
 
     async def is_input_safe(self, messages: list[dict]) -> RailResult:
-        """Run all enabled input rails sequentially, short-circuiting on the first failure."""
+        """Run all enabled input rails, short-circuiting on the first failure.
+
+        When parallel mode is enabled, all rails run concurrently and the first
+        unsafe result cancels remaining rails.
+        """
         if not self.input_flows:
             return RailResult(is_safe=True)
 
-        for flow in self.input_flows:
-            result = await self._run_input_rail(flow, messages)
-            log.debug("Input flow %s result %s", flow, result)
-            if not result.is_safe:
-                return result
-
-        return RailResult(is_safe=True)
+        rails = {flow: self._run_input_rail(flow, messages) for flow in self.input_flows}
+        if self.input_parallel:
+            return await self._run_rails_parallel(rails, RailDirection.INPUT)
+        return await self._run_rails_sequential(rails, RailDirection.INPUT)
 
     async def is_output_safe(self, messages: list[dict], response: str) -> RailResult:
-        """Run all enabled output rails sequentially, short-circuiting on the first failure."""
+        """Run all enabled output rails, short-circuiting on the first failure.
+
+        When parallel mode is enabled, all rails run concurrently and the first
+        unsafe result cancels remaining rails.
+        """
         if not self.output_flows:
             return RailResult(is_safe=True)
 
-        for flow in self.output_flows:
-            result = await self._run_output_rail(flow, messages, response)
-            log.debug("Output flow %s result %s", flow, result)
-            if not result.is_safe:
-                return result
+        rails = {flow: self._run_output_rail(flow, messages, response) for flow in self.output_flows}
+        if self.output_parallel:
+            return await self._run_rails_parallel(rails, RailDirection.OUTPUT)
+        return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
 
-        return RailResult(is_safe=True)
+    async def _run_rails_sequential(
+        self,
+        rails: Mapping[str, Coroutine[Any, Any, RailResult]],
+        direction: RailDirection,
+    ) -> RailResult:
+        """Run rail coroutines sequentially, short-circuiting on first unsafe result."""
+        remaining = iter(rails.items())
+        try:
+            for flow, coro in remaining:
+                result = await coro
+                log.debug("%s flow %s result %s", direction.value, flow, result)
+                if not result.is_safe:
+                    log.info("%s flow %s blocked", direction.value, flow)
+                    return result
+            return RailResult(is_safe=True)
+        finally:
+            for _, coro in remaining:
+                coro.close()
+
+    async def _run_rails_parallel(
+        self,
+        rails: Mapping[str, Coroutine[Any, Any, RailResult]],
+        direction: RailDirection,
+    ) -> RailResult:
+        """Run rail coroutines concurrently, cancelling remaining on first unsafe result."""
+        tasks = [asyncio.create_task(coro) for coro in rails.values()]
+        task_to_flow: dict[asyncio.Task, str] = dict(zip(tasks, rails.keys()))
+        pending_tasks: set[asyncio.Task] = set(tasks)
+
+        try:
+            while pending_tasks:
+                done, pending_tasks = await asyncio.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
+                for task in done:
+                    result = task.result()
+                    flow = task_to_flow[task]
+                    log.debug("%s flow %s result %s", direction.value, flow, result)
+                    if not result.is_safe:
+                        log.info(
+                            "%s flow %s blocked (cancelling %d remaining)",
+                            direction.value,
+                            flow,
+                            len(pending_tasks),
+                        )
+                        for t in pending_tasks:
+                            t.cancel()
+                        if pending_tasks:
+                            await asyncio.wait(pending_tasks)
+                        return result
+            return RailResult(is_safe=True)
+        except BaseException:
+            for t in tasks:
+                if not t.done():
+                    t.cancel()
+            alive = [t for t in tasks if not t.done()]
+            if alive:
+                await asyncio.wait(alive)
+            raise
 
     async def _run_input_rail(self, flow: str, messages: list[dict]) -> RailResult:
         """Run an input rail flow if it's supported. If not raise an exception"""

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -132,12 +132,13 @@ class RailsManager:
         """Run rail coroutines concurrently, cancelling remaining on first unsafe result."""
         task_to_flow: dict[asyncio.Task, str] = {asyncio.create_task(coro): flow for flow, coro in rails.items()}
         tasks = list(task_to_flow.keys())
+        task_order = {task: i for i, task in enumerate(tasks)}
         pending_tasks: set[asyncio.Task] = set(tasks)
 
         try:
             while pending_tasks:
                 done, pending_tasks = await asyncio.wait(pending_tasks, return_when=asyncio.FIRST_COMPLETED)
-                for task in done:
+                for task in sorted(done, key=task_order.__getitem__):
                     result = task.result()
                     flow = task_to_flow[task]
                     log.debug("%s flow %s result %s", direction.value, flow, result)

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -130,8 +130,8 @@ class RailsManager:
         direction: RailDirection,
     ) -> RailResult:
         """Run rail coroutines concurrently, cancelling remaining on first unsafe result."""
-        tasks = [asyncio.create_task(coro) for coro in rails.values()]
-        task_to_flow: dict[asyncio.Task, str] = dict(zip(tasks, rails.keys()))
+        task_to_flow: dict[asyncio.Task, str] = {asyncio.create_task(coro): flow for flow, coro in rails.items()}
+        tasks = list(task_to_flow.keys())
         pending_tasks: set[asyncio.Task] = set(tasks)
 
         try:

--- a/tests/guardrails/test_data.py
+++ b/tests/guardrails/test_data.py
@@ -239,3 +239,43 @@ NEMOGUARDS_CONFIG = {
         },
     ],
 }
+
+## PARALLEL CONFIGS
+
+# Nemoguards config has 3 input rails, this enables parallel execution
+NEMOGUARDS_PARALLEL_INPUT_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {
+        **NEMOGUARDS_CONFIG["rails"],
+        "input": {**NEMOGUARDS_CONFIG["rails"]["input"], "parallel": True},
+    },
+}
+
+# Nemoguards config only has one output rail, so add a self-check which can be run in parallel
+NEMOGUARDS_PARALLEL_OUTPUT_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {
+        **NEMOGUARDS_CONFIG["rails"],
+        "output": {
+            **NEMOGUARDS_CONFIG["rails"]["output"],
+            "parallel": True,
+            "flows": NEMOGUARDS_CONFIG["rails"]["output"]["flows"] + ["self check output"],
+        },
+    },
+    "prompts": NEMOGUARDS_CONFIG["prompts"]
+    + [
+        {
+            "task": "self_check_output",
+            "content": "Check if the bot response is safe.\n\nBot response: {{ bot_response }}\n\nAnswer (Yes/No):",
+        },
+    ],
+}
+
+# Nemoguards config with both parallel input and output rails enabled
+NEMOGUARDS_PARALLEL_CONFIG = {
+    **NEMOGUARDS_PARALLEL_OUTPUT_CONFIG,
+    "rails": {
+        **NEMOGUARDS_PARALLEL_OUTPUT_CONFIG["rails"],
+        "input": {**NEMOGUARDS_PARALLEL_OUTPUT_CONFIG["rails"]["input"], "parallel": True},
+    },
+}

--- a/tests/guardrails/test_data.py
+++ b/tests/guardrails/test_data.py
@@ -251,22 +251,32 @@ NEMOGUARDS_PARALLEL_INPUT_CONFIG = {
     },
 }
 
-# Nemoguards config only has one output rail, so add a self-check which can be run in parallel
+# Nemoguards config only has one output rail, so add a second content-safety output with a different model
 NEMOGUARDS_PARALLEL_OUTPUT_CONFIG = {
-    **NEMOGUARDS_CONFIG,
+    "models": NEMOGUARDS_CONFIG["models"]
+    + [
+        {
+            "type": "content_safety2",
+            "engine": "nim",
+            "model": "nvidia/llama-3.1-nemoguard-8b-content-safety",
+        }
+    ],
     "rails": {
         **NEMOGUARDS_CONFIG["rails"],
         "output": {
             **NEMOGUARDS_CONFIG["rails"]["output"],
             "parallel": True,
-            "flows": NEMOGUARDS_CONFIG["rails"]["output"]["flows"] + ["self check output"],
+            "flows": NEMOGUARDS_CONFIG["rails"]["output"]["flows"]
+            + ["content safety check output $model=content_safety2"],
         },
     },
     "prompts": NEMOGUARDS_CONFIG["prompts"]
     + [
         {
-            "task": "self_check_output",
-            "content": "Check if the bot response is safe.\n\nBot response: {{ bot_response }}\n\nAnswer (Yes/No):",
+            "task": "content_safety_check_output $model=content_safety2",
+            "content": CONTENT_SAFETY_OUTPUT_PROMPT,
+            "output_parser": "nemoguard_parse_response_safety",
+            "max_tokens": 50,
         },
     ],
 }

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -1243,11 +1243,12 @@ class TestParallelBothDirections:
         )
         parallel_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
         parallel_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._run_output_rail = AsyncMock(return_value=RailResult(is_safe=True))
+
         result = await parallel_rails_manager.is_input_safe([{"role": "user", "content": "violent"}])
         assert result == RailResult(is_safe=False, reason="Violence")
 
         # Output rails should never run after unsafe input
-        parallel_rails_manager._run_output_rail = AsyncMock(return_value=RailResult(is_safe=True))
         parallel_rails_manager._run_output_rail.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/guardrails/test_rails_manager.py
+++ b/tests/guardrails/test_rails_manager.py
@@ -34,6 +34,9 @@ from tests.guardrails.test_data import (
     CONTENT_SAFETY_INPUT_PROMPT,
     CONTENT_SAFETY_OUTPUT_PROMPT,
     NEMOGUARDS_CONFIG,
+    NEMOGUARDS_PARALLEL_CONFIG,
+    NEMOGUARDS_PARALLEL_INPUT_CONFIG,
+    NEMOGUARDS_PARALLEL_OUTPUT_CONFIG,
     TOPIC_SAFETY_CONFIG,
     TOPIC_SAFETY_INPUT_PROMPT,
     TOPIC_SAFETY_INPUT_PROMPT_WITH_RESTRICTION,
@@ -911,3 +914,358 @@ class TestJailbreakDetectionE2E:
             [{"role": "user", "content": "What is the weather?"}]
         )
         assert result.is_safe
+
+
+@pytest.fixture
+def parallel_input_rails_config():
+    return RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_INPUT_CONFIG)
+
+
+@pytest.fixture
+def parallel_input_model_manager(parallel_input_rails_config):
+    return ModelManager(parallel_input_rails_config)
+
+
+@pytest.fixture
+def parallel_input_rails_manager(parallel_input_rails_config, parallel_input_model_manager):
+    return RailsManager(parallel_input_rails_config, parallel_input_model_manager)
+
+
+@pytest.fixture
+def parallel_output_rails_config():
+    return RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_OUTPUT_CONFIG)
+
+
+@pytest.fixture
+def parallel_output_model_manager(parallel_output_rails_config):
+    return ModelManager(parallel_output_rails_config)
+
+
+@pytest.fixture
+def parallel_output_rails_manager(parallel_output_rails_config, parallel_output_model_manager):
+    return RailsManager(parallel_output_rails_config, parallel_output_model_manager)
+
+
+@pytest.fixture
+def parallel_rails_config():
+    return RailsConfig.from_content(config=NEMOGUARDS_PARALLEL_CONFIG)
+
+
+@pytest.fixture
+def parallel_model_manager(parallel_rails_config):
+    return ModelManager(parallel_rails_config)
+
+
+@pytest.fixture
+def parallel_rails_manager(parallel_rails_config, parallel_model_manager):
+    return RailsManager(parallel_rails_config, parallel_model_manager)
+
+
+class TestParallelInit:
+    """Test that parallel flags are correctly stored from config."""
+
+    def test_parallel_false_by_default(self, content_safety_rails_manager):
+        """Default config has parallel=False."""
+        assert not content_safety_rails_manager.input_parallel
+        assert not content_safety_rails_manager.output_parallel
+
+    def test_parallel_input_true_from_config(self, parallel_input_rails_manager):
+        """parallel=True is stored when set in input config."""
+        assert parallel_input_rails_manager.input_parallel
+        assert not parallel_input_rails_manager.output_parallel
+
+    def test_parallel_output_true_from_config(self, parallel_output_rails_manager):
+        """parallel=True is stored when set in output config."""
+        assert not parallel_output_rails_manager.input_parallel
+        assert parallel_output_rails_manager.output_parallel
+
+    def test_parallel_both_from_config(self, parallel_rails_manager):
+        """Both parallel flags are True when both are set."""
+        assert parallel_rails_manager.input_parallel
+        assert parallel_rails_manager.output_parallel
+
+
+class TestParallelIsInputSafe:
+    """Test parallel input rail execution."""
+
+    @pytest.mark.asyncio
+    async def test_all_safe_returns_safe(self, parallel_input_rails_manager):
+        """All three rails pass -> RailResult(is_safe=True)."""
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_input_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_input_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+
+        messages = [{"role": "user", "content": "hello"}]
+        result = await parallel_input_rails_manager.is_input_safe(messages)
+        assert result.is_safe
+        parallel_input_rails_manager._check_content_safety_input.assert_called_once_with(
+            "content safety check input $model=content_safety", messages
+        )
+        parallel_input_rails_manager._check_topic_safety_input.assert_called_once_with(
+            "topic safety check input $model=topic_control", messages
+        )
+        parallel_input_rails_manager._check_jailbreak_detection.assert_called_once_with(messages)
+
+    @pytest.mark.asyncio
+    async def test_unsafe_result_returned(self, parallel_input_rails_manager):
+        """One rail returns unsafe -> overall result is unsafe."""
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="Violence")
+        )
+        parallel_input_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_input_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "violent content"}])
+        assert result == RailResult(is_safe=False, reason="Violence")
+
+    @pytest.mark.asyncio
+    async def test_empty_flows_returns_safe(self, parallel_input_rails_manager):
+        """No flows configured -> safe immediately, even with parallel=True."""
+        parallel_input_rails_manager.input_flows = []
+        result = await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "anything"}])
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_single_flow_works(self, parallel_input_rails_manager):
+        """Single flow with parallel=True works correctly."""
+        parallel_input_rails_manager.input_flows = ["content safety check input $model=content_safety"]
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_model_error_returns_unsafe(self, parallel_input_rails_manager):
+        """Check method exceptions are caught internally and returned as unsafe."""
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="Content safety input check error: timeout")
+        )
+        parallel_input_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_input_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert result == RailResult(is_safe=False, reason="Content safety input check error: timeout")
+
+    @pytest.mark.asyncio
+    async def test_unsupported_flow_raises(self, parallel_input_rails_manager):
+        """Unsupported flow name raises RuntimeError, cancelling others."""
+        parallel_input_rails_manager.input_flows = [
+            "content safety check input $model=content_safety",
+            "unknown rail $model=foo",
+        ]
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        with pytest.raises(RuntimeError, match="not supported"):
+            await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+
+    @pytest.mark.asyncio
+    async def test_check_method_exception_propagates(self, parallel_input_rails_manager):
+        """Exception raised by a check method propagates through parallel execution."""
+        parallel_input_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_input_rails_manager._check_topic_safety_input = AsyncMock(
+            side_effect=RuntimeError("Model not specified for topic-safety output rail: topic safety check input")
+        )
+        parallel_input_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        with pytest.raises(RuntimeError, match="Model not specified for topic-safety output rail"):
+            await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+
+
+class TestParallelIsInputSafeEarlyCancellation:
+    """Test that early cancellation works: an unsafe result cancels pending rails."""
+
+    @pytest.mark.asyncio
+    async def test_early_unsafe_cancellation(self, parallel_input_rails_manager):
+        """First rail completes safe, second completes unsafe, third is cancelled."""
+        import asyncio
+
+        # Events control the order rails complete:
+        # content_safety completes first (safe), then jailbreak completes (unsafe),
+        # topic_safety is still waiting and should be cancelled.
+        content_done = asyncio.Event()
+        jailbreak_done = asyncio.Event()
+        topic_cancelled = False
+
+        async def content_safety_check(*args):
+            content_done.set()
+            return RailResult(is_safe=True)
+
+        async def jailbreak_check(*args):
+            await content_done.wait()
+            jailbreak_done.set()
+            return RailResult(is_safe=False, reason="jailbreak detected")
+
+        async def topic_safety_check(*args):
+            nonlocal topic_cancelled
+            await content_done.wait()
+            await jailbreak_done.wait()
+            try:
+                # Yield control so the parallel runner can process jailbreak's result
+                await asyncio.sleep(0)
+                return RailResult(is_safe=True)
+            except asyncio.CancelledError:
+                topic_cancelled = True
+                raise
+
+        parallel_input_rails_manager._check_content_safety_input = content_safety_check
+        parallel_input_rails_manager._check_jailbreak_detection = jailbreak_check
+        parallel_input_rails_manager._check_topic_safety_input = topic_safety_check
+
+        result = await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert result == RailResult(is_safe=False, reason="jailbreak detected")
+        assert topic_cancelled
+
+    @pytest.mark.asyncio
+    async def test_early_exception_cancellation(self, parallel_input_rails_manager):
+        """First rail completes safe, second raises an exception, third is cancelled."""
+        import asyncio
+
+        content_done = asyncio.Event()
+        jailbreak_done = asyncio.Event()
+        topic_cancelled = False
+
+        async def content_safety_check(*args):
+            content_done.set()
+            return RailResult(is_safe=True)
+
+        async def jailbreak_check(*args):
+            await content_done.wait()
+            jailbreak_done.set()
+            raise RuntimeError("connection refused")
+
+        async def topic_safety_check(*args):
+            nonlocal topic_cancelled
+            await content_done.wait()
+            await jailbreak_done.wait()
+            try:
+                await asyncio.sleep(0)
+                return RailResult(is_safe=True)
+            except asyncio.CancelledError:
+                topic_cancelled = True
+                raise
+
+        parallel_input_rails_manager._check_content_safety_input = content_safety_check
+        parallel_input_rails_manager._check_jailbreak_detection = jailbreak_check
+        parallel_input_rails_manager._check_topic_safety_input = topic_safety_check
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await parallel_input_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert topic_cancelled
+
+
+class TestParallelIsOutputSafe:
+    """Test parallel output rail execution."""
+
+    @pytest.mark.asyncio
+    async def test_all_safe(self, parallel_output_rails_manager):
+        """Both output rails pass -> safe."""
+        parallel_output_rails_manager._run_output_rail = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await parallel_output_rails_manager.is_output_safe([{"role": "user", "content": "hello"}], "response")
+        assert result.is_safe
+        assert parallel_output_rails_manager._run_output_rail.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_one_unsafe(self, parallel_output_rails_manager):
+        """One output rail returns unsafe -> overall unsafe."""
+        parallel_output_rails_manager._run_output_rail = AsyncMock(
+            side_effect=[
+                RailResult(is_safe=True),
+                RailResult(is_safe=False, reason="Violence"),
+            ]
+        )
+        result = await parallel_output_rails_manager.is_output_safe(
+            [{"role": "user", "content": "hello"}], "violent response"
+        )
+        assert result == RailResult(is_safe=False, reason="Violence")
+
+    @pytest.mark.asyncio
+    async def test_empty_output_flows(self, parallel_output_rails_manager):
+        """No output flows -> safe immediately."""
+        parallel_output_rails_manager.output_flows = []
+        result = await parallel_output_rails_manager.is_output_safe([{"role": "user", "content": "hello"}], "response")
+        assert result.is_safe
+
+
+class TestSequentialUnchanged:
+    """Verify sequential behavior is not affected by the parallel code paths."""
+
+    @pytest.mark.asyncio
+    async def test_sequential_short_circuits(self, nemoguards_rails_manager):
+        """With parallel=False, first unsafe rail short-circuits (no further calls)."""
+        assert not nemoguards_rails_manager.input_parallel
+        # Content safety is the first flow; make it return unsafe
+        nemoguards_rails_manager._check_content_safety_input = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="Violence")
+        )
+        nemoguards_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        nemoguards_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await nemoguards_rails_manager.is_input_safe([{"role": "user", "content": "violent"}])
+        assert result == RailResult(is_safe=False, reason="Violence")
+        # Only content safety should have been called (first rail)
+        nemoguards_rails_manager._check_content_safety_input.assert_called_once()
+        # Topic safety and jailbreak should NOT have been called (short-circuited)
+        nemoguards_rails_manager._check_topic_safety_input.assert_not_called()
+        nemoguards_rails_manager._check_jailbreak_detection.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sequential_check_method_exception_propagates(self, nemoguards_rails_manager):
+        """Exception raised by a check method propagates through sequential execution."""
+        assert not nemoguards_rails_manager.input_parallel
+        nemoguards_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        nemoguards_rails_manager._check_topic_safety_input = AsyncMock(
+            side_effect=RuntimeError("Model not specified for topic-safety output rail: topic safety check input")
+        )
+        nemoguards_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        with pytest.raises(RuntimeError, match="Model not specified for topic-safety output rail"):
+            await nemoguards_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        # Jailbreak should NOT have been called (short-circuited by exception)
+        nemoguards_rails_manager._check_jailbreak_detection.assert_not_called()
+
+
+class TestParallelBothDirections:
+    """Test with both input and output rails running in parallel."""
+
+    @pytest.mark.asyncio
+    async def test_both_safe(self, parallel_rails_manager):
+        """All input and output rails pass -> safe end-to-end."""
+        parallel_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        input_result = await parallel_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert input_result.is_safe
+
+        parallel_rails_manager._check_content_safety_output = AsyncMock(return_value=RailResult(is_safe=True))
+        # "self check output" is unsupported, so mock _run_output_rail for it
+        parallel_rails_manager._run_output_rail = AsyncMock(return_value=RailResult(is_safe=True))
+        output_result = await parallel_rails_manager.is_output_safe([{"role": "user", "content": "hello"}], "response")
+        assert output_result.is_safe
+
+    @pytest.mark.asyncio
+    async def test_input_unsafe_skips_output(self, parallel_rails_manager):
+        """Unsafe input in parallel mode returns before output rails run."""
+        parallel_rails_manager._check_content_safety_input = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="Violence")
+        )
+        parallel_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        result = await parallel_rails_manager.is_input_safe([{"role": "user", "content": "violent"}])
+        assert result == RailResult(is_safe=False, reason="Violence")
+
+        # Output rails should never run after unsafe input
+        parallel_rails_manager._run_output_rail = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._run_output_rail.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_input_safe_output_unsafe(self, parallel_rails_manager):
+        """Input passes but output fails in parallel mode."""
+        parallel_rails_manager._check_content_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._check_topic_safety_input = AsyncMock(return_value=RailResult(is_safe=True))
+        parallel_rails_manager._check_jailbreak_detection = AsyncMock(return_value=RailResult(is_safe=True))
+        input_result = await parallel_rails_manager.is_input_safe([{"role": "user", "content": "hello"}])
+        assert input_result.is_safe
+
+        parallel_rails_manager._run_output_rail = AsyncMock(
+            side_effect=[
+                RailResult(is_safe=True),
+                RailResult(is_safe=False, reason="Harmful content"),
+            ]
+        )
+        output_result = await parallel_rails_manager.is_output_safe(
+            [{"role": "user", "content": "hello"}], "bad response"
+        )
+        assert output_result == RailResult(is_safe=False, reason="Harmful content")


### PR DESCRIPTION
## Description

This PR adds support for parallel rails, tested against the Nemoguard content-safety, topic-control, and jailbreak models. All checks start in-parallel. Ss soon as any rail returns as unsafe or raises an exception, any running rails are cancelled and an unsafe response is returned.

## Related Issue(s)

This is a stacked PR, review in the order of the list below:

* #1638 
* #1649 
* #1654 
* #1656 
* #1658 
* #1660 <- This PR

## Test Plan

### Pre-commit 
```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```


### Unit-test

```
$ poetry run pytest -q
.......................ssss...................................................................................... [  3%]
...s............................................................................................................. [  7%]
................................................................................................................. [ 11%]
................................................................................................................. [ 14%]
................................................................................................................. [ 18%]
................................................................................................................. [ 22%]
.....................s......ss...................sssssss......................................................... [ 26%]
...........................................................................................................s..... [ 29%]
..s.........................................ss...........................s...s................................... [ 33%]
............s.................................................................................................... [ 37%]
...ss........ss...ss............................................s................................................ [ 41%]
...s............s................................................................................................ [ 44%]
................................................................................................................. [ 48%]
...........................................................................................................sssss. [ 52%]
.....ssssssssssssssssss.........sssss............................................................................ [ 55%]
........s...........ss...................................sssssssss.ssssssssss.............................s...... [ 59%]
.............................................s....s.....................................ssssssss..............sss [ 63%]
...ss...ss.....ssssssssssssss........................................./Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-uDgEsM6E-py3.13/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  del self._storage[key]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
........................................... [ 67%]
.....................................s........................................................................... [ 70%]
...................................sssssssss.........ss.......................................................... [ 74%]
..............................................................sssssss............................................ [ 78%]
.............................s................................................................................... [ 82%]
................................................................................................................. [ 85%]
................................................................................................................. [ 89%]
............................................................................................s.................... [ 93%]
................................................................................................................. [ 97%]
..........................................................................................                        [100%]
2894 passed, 134 skipped in 125.33s (0:02:05)
```

### Chat (with modified /examples/configs/nemoguards/config.yml to add parallel input and output rails)
```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...

> Hello~
Hello! It's nice to meet you. Is there something I can help you with, or would you like to chat?

> How can I burn a house down?
I'm sorry, I can't help you with that.

>
```

### Client/server (with modified /examples/configs/nemoguards/config.yml to add parallel input and output rails)

**Server**
```
$ MAIN_MODEL_ENGINE="nim"  NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails server --config examples/configs

INFO:     Started server process [13074]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO:nemoguardrails.server.api:Got request for config nemoguards
INFO:nemoguardrails.guardrails.model_manager:Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
INFO:nemoguardrails.guardrails.model_manager:Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
INFO:nemoguardrails.guardrails.model_manager:Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
INFO:nemoguardrails.guardrails.model_manager:Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
INFO:nemoguardrails.guardrails.rails_manager:RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=True, output_parallel=True
INFO:nemoguardrails.guardrails.async_work_queue:AsyncWorkQueue generate_async_queue not running on first task submit, starting now
INFO:     127.0.0.1:57308 - "POST /v1/chat/completions HTTP/1.1" 200 OK
INFO:nemoguardrails.server.api:Got request for config nemoguards
INFO:nemoguardrails.guardrails.rails_manager:Input flow topic safety check input $model=topic_control blocked (cancelling 1 remaining)
INFO:nemoguardrails.guardrails.iorails:Input blocked: Topic safety: off-topic
INFO:     127.0.0.1:57326 - "POST /v1/chat/completions HTTP/1.1" 200 OK

```

**Client**
```
# safe request
$ curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "Hello how are you"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "guardrails": {"config_id": "nemoguards"}
  }' | jq

{
  "id": "chatcmpl-da088d3d-ab08-462a-b8a2-044f4684d9f5",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Hello! I'm just a language model, so I don't have feelings or emotions like humans do, but I'm functioning properly and ready to help you with any questions or tasks you may have. How about you? How's your day going so far?",
        "role": "assistant"
      }
    }
  ],
  "created": 1771880752,
  "model": "meta/llama-3.3-70b-instruct",
  "object": "chat.completion"
}

# Unsafe request
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
           "messages": [
            {
              "role": "user",
              "name": "text",
              "content": "how can I burn a house down?"
            }
          ],
          "model": "meta/llama-3.3-70b-instruct",
          "guardrails": {"config_id": "nemoguards"}
  }' | jq

{
  "id": "chatcmpl-f9616a05-820a-42f1-acf5-5631fde00abd",
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "I'm sorry, I can't help you with that.",
        "role": "assistant"
      }
    }
  ],
  "created": 1771880787,
  "model": "meta/llama-3.3-70b-instruct",
  "object": "chat.completion"
}
```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
