### PR TITLE
feat(iorails): Logging and unique request ID

### DIFF
--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -12,3 +12,37 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import logging
+
+DEFAULT_FORMAT = "%(asctime)s %(levelname)s: %(message)s"
+DEFAULT_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def configure_logging(
+    level: int = logging.INFO,
+    formatter: logging.Formatter | None = None,
+    handler: logging.Handler | None = None,
+) -> logging.Logger:
+    """Configure logging for the ``nemoguardrails.guardrails`` package.
+
+    Attaches a handler with a formatter to the ``nemoguardrails.guardrails``
+    logger so that all modules under this package (model_engine, api_engine,
+    rails_manager, etc.) inherit the same settings.
+
+    """
+    logger = logging.getLogger("nemoguardrails.guardrails")
+    logger.setLevel(level)
+
+    if formatter is None:
+        formatter = logging.Formatter(DEFAULT_FORMAT, datefmt=DEFAULT_DATEFMT)
+
+    if handler is None:
+        handler = logging.StreamHandler()
+
+    handler.setLevel(level)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    return logger

--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -36,8 +36,8 @@ def configure_logging(
     # If the logger already has handlers, update logger and all handler levels
     if logger.handlers:
         logger.setLevel(level)
-        for handler in logger.handlers:
-            handler.setLevel(level)
+        for log_handler in logger.handlers:
+            log_handler.setLevel(level)
         return logger
 
     # If there are no handlers, create them and add them to the logger

--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -32,6 +32,12 @@ def configure_logging(
 
     """
     logger = logging.getLogger("nemoguardrails.guardrails")
+
+    # If the logger already has handlers, just update the level
+    if logger.handlers:
+        logger.setLevel(level)
+        return logger
+
     logger.setLevel(level)
 
     if formatter is None:
@@ -40,11 +46,9 @@ def configure_logging(
     if handler is None:
         handler = logging.StreamHandler()
 
-    if not logger.handlers:
-        handler.setLevel(level)
-        handler.setFormatter(formatter)
-        logger.addHandler(handler)
-
+    handler.setLevel(level)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
     logger.propagate = False
 
     return logger

--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -26,26 +26,26 @@ def configure_logging(
 ) -> logging.Logger:
     """Configure logging for the ``nemoguardrails.guardrails`` package.
 
-    Attaches a handler with a formatter to the ``nemoguardrails.guardrails``
-    logger so that all modules under this package (model_engine, api_engine,
-    rails_manager, etc.) inherit the same settings.
+    Attaches a handler if none exist, or updates existing handlers if they do.
+    **If a handler is provided on repeat calls, it is ignored to avoid accumulating handlers.**
+    Sets level and formatter of all handlers so that all modules under this package
+    (model_engine, api_engine, rails_manager, etc.) inherit the same settings.
 
     """
     logger = logging.getLogger("nemoguardrails.guardrails")
-
-    # If the logger already has handlers, update logger and all handler levels
-    if logger.handlers:
-        logger.setLevel(level)
-        for log_handler in logger.handlers:
-            log_handler.setLevel(level)
-        return logger
-
-    # If there are no handlers, create them and add them to the logger
     logger.setLevel(level)
 
     if formatter is None:
         formatter = logging.Formatter(DEFAULT_FORMAT, datefmt=DEFAULT_DATEFMT)
 
+    # If the logger already has handlers, update logger level and handler level and formatters
+    if logger.handlers:
+        for log_handler in logger.handlers:
+            log_handler.setLevel(level)
+            log_handler.setFormatter(formatter)
+        return logger
+
+    # There are no handlers. So create one (if needed) and set level and formatter
     if handler is None:
         handler = logging.StreamHandler()
 

--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -40,9 +40,11 @@ def configure_logging(
     if handler is None:
         handler = logging.StreamHandler()
 
-    handler.setLevel(level)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if not logger.handlers:
+        handler.setLevel(level)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
     logger.propagate = False
 
     return logger

--- a/nemoguardrails/guardrails/__init__.py
+++ b/nemoguardrails/guardrails/__init__.py
@@ -33,11 +33,14 @@ def configure_logging(
     """
     logger = logging.getLogger("nemoguardrails.guardrails")
 
-    # If the logger already has handlers, just update the level
+    # If the logger already has handlers, update logger and all handler levels
     if logger.handlers:
         logger.setLevel(level)
+        for handler in logger.handlers:
+            handler.setLevel(level)
         return logger
 
+    # If there are no handlers, create them and add them to the logger
     logger.setLevel(level)
 
     if formatter is None:

--- a/nemoguardrails/guardrails/api_engine.py
+++ b/nemoguardrails/guardrails/api_engine.py
@@ -142,15 +142,18 @@ class APIEngine:
         t0 = time.monotonic()
         try:
             async with client.post(url, json=request_body, headers=headers) as response:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+
                 if response.status >= 400:
                     error_body = await safe_read_body(response)
+                    log.warning("[%s] HTTP %s from endpoint '%s' time=%.1fms", req_id, response.status, url, elapsed_ms)
                     raise APIEngineError(
                         f"HTTP {response.status} from endpoint '{url}': {error_body}",
                         endpoint=url,
                         status=response.status,
                     )
+
                 result = await response.json()
-                elapsed_ms = (time.monotonic() - t0) * 1000
                 log.debug(
                     "[%s] HTTP response status=%s time=%.1fms body: %s",
                     req_id,
@@ -161,11 +164,15 @@ class APIEngine:
                 return result
 
         except aiohttp.ContentTypeError as exc:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            log.warning("[%s] Failed to parse response as JSON time=%.1fms", req_id, elapsed_ms)
             raise APIEngineError(f"Failed to parse response as JSON: {exc}", endpoint=url, status=exc.status) from exc
 
         except APIEngineError:
             raise
         except Exception as exc:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            log.warning("[%s] Request to endpoint '%s' failed time=%.1fms", req_id, url, elapsed_ms)
             raise APIEngineError(
                 f"Request to endpoint '{url}' failed: {exc}",
                 endpoint=url,

--- a/nemoguardrails/guardrails/api_engine.py
+++ b/nemoguardrails/guardrails/api_engine.py
@@ -18,10 +18,13 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient
+
+from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 
 if TYPE_CHECKING:
     from nemoguardrails.rails.llm.config import JailbreakDetectionConfig
@@ -132,6 +135,11 @@ class APIEngine:
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
+        req_id = get_request_id()
+        log.info("[%s] HTTP POST %s", req_id, url)
+        log.debug("[%s] HTTP request body: %s", req_id, truncate(request_body))
+
+        t0 = time.monotonic()
         try:
             async with client.post(url, json=request_body, headers=headers) as response:
                 if response.status >= 400:
@@ -141,7 +149,16 @@ class APIEngine:
                         endpoint=url,
                         status=response.status,
                     )
-                return await response.json()
+                result = await response.json()
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.debug(
+                    "[%s] HTTP response status=%s time=%.1fms body: %s",
+                    req_id,
+                    response.status,
+                    elapsed_ms,
+                    truncate(result),
+                )
+                return result
 
         except aiohttp.ContentTypeError as exc:
             raise APIEngineError(f"Failed to parse response as JSON: {exc}", endpoint=url, status=exc.status) from exc

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -26,6 +26,7 @@ from typing import AsyncIterator, Optional, Tuple, Union, cast, overload
 
 from langchain_core.language_models import BaseChatModel, BaseLLM
 
+from nemoguardrails.guardrails import configure_logging
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.guardrails_types import LLMMessages
 from nemoguardrails.guardrails.iorails import IORails
@@ -62,6 +63,11 @@ class Guardrails:
 
         self.config = config
         self.verbose = verbose
+
+        if verbose:
+            configure_logging(logging.DEBUG)
+        else:
+            configure_logging(logging.INFO)
 
         # Whether to use IORailsEngine for inference requests
         use_iorails_engine = use_iorails and self._has_only_iorails_flows()

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -56,10 +56,15 @@ def get_request_id() -> str:
     return _request_id_var.get()
 
 
+def reset_request_id(token: Token[str]) -> None:
+    """Restore the request ID ContextVar to its previous value."""
+    _request_id_var.reset(token)
+
+
 def truncate(text: object, max_len: int | None = None) -> str:
     """Return ``str(text)`` truncated to *max_len* characters (default: LOG_CONTENT_TRUNCATE_LENGTH)."""
     s = str(text)
-    limit = max_len if max_len else LOG_CONTENT_TRUNCATE_LENGTH
+    limit = max_len if max_len is not None else LOG_CONTENT_TRUNCATE_LENGTH
     if len(s) <= limit:
         return s
     return s[:limit] + "..."

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import os
 import secrets
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
@@ -40,12 +39,13 @@ class RailResult:
     reason: str | None = None
 
 
-LOG_CONTENT_TRUNCATE_LENGTH = int(os.environ.get("NEMOGUARDRAILS_LOG_TRUNCATE_LENGTH", "200"))
+# Default max character length for truncate(). Used to keep DEBUG log lines short.
+LOG_CONTENT_TRUNCATE_LENGTH = 200
 
 _request_id_var: ContextVar[str] = ContextVar("request_id", default="no-req-id")
 
 
-def new_request_id() -> Token[str]:
+def set_new_request_id() -> Token[str]:
     """Generate an 8-char hex request ID, set it in the current context, and return the reset token."""
     rid = secrets.token_hex(4)  # 4 bytes -> 8 hex chars
     return _request_id_var.set(rid)

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 
+import os
+import secrets
+from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from enum import Enum
 from typing import TypeAlias
@@ -35,3 +38,28 @@ class RailResult:
 
     is_safe: bool
     reason: str | None = None
+
+
+LOG_CONTENT_TRUNCATE_LENGTH = int(os.environ.get("NEMOGUARDRAILS_LOG_TRUNCATE_LENGTH", "200"))
+
+_request_id_var: ContextVar[str] = ContextVar("request_id", default="no-req-id")
+
+
+def new_request_id() -> Token[str]:
+    """Generate an 8-char hex request ID, set it in the current context, and return the reset token."""
+    rid = secrets.token_hex(4)  # 4 bytes -> 8 hex chars
+    return _request_id_var.set(rid)
+
+
+def get_request_id() -> str:
+    """Return the current per-request correlation ID."""
+    return _request_id_var.get()
+
+
+def truncate(text: object, max_len: int | None = None) -> str:
+    """Return ``str(text)`` truncated to *max_len* characters (default: LOG_CONTENT_TRUNCATE_LENGTH)."""
+    s = str(text)
+    limit = max_len if max_len else LOG_CONTENT_TRUNCATE_LENGTH
+    if len(s) <= limit:
+        return s
+    return s[:limit] + "..."

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -26,9 +26,9 @@ import logging
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
-    _request_id_var,
     get_request_id,
     new_request_id,
+    reset_request_id,
     truncate,
 )
 from nemoguardrails.guardrails.model_manager import ModelManager
@@ -132,4 +132,4 @@ class IORails:
             log.info("[%s] generate_async completed", req_id)
             return {"role": "assistant", "content": response_text}
         finally:
-            _request_id_var.reset(token)
+            reset_request_id(token)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -22,13 +22,14 @@ outside this supported set, the standard LLMRails engine should be used instead.
 
 import asyncio
 import logging
+import time
 
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
     get_request_id,
-    new_request_id,
     reset_request_id,
+    set_new_request_id,
     truncate,
 )
 from nemoguardrails.guardrails.model_manager import ModelManager
@@ -97,8 +98,9 @@ class IORails:
 
     async def generate_async(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Run input rails, generation, and output rails. Return response if safe."""
-        token = new_request_id()
+        token = set_new_request_id()
         req_id = get_request_id()
+        t0 = time.monotonic()
         try:
             log.info("[%s] generate_async called", req_id)
             log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
@@ -129,7 +131,12 @@ class IORails:
                 log.info("[%s] Output blocked: %s", req_id, output_result.reason)
                 return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
-            log.info("[%s] generate_async completed", req_id)
             return {"role": "assistant", "content": response_text}
+        except Exception:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+            raise
         finally:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             reset_request_id(token)

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -23,7 +23,14 @@ outside this supported set, the standard LLMRails engine should be used instead.
 import asyncio
 import logging
 
-from nemoguardrails.guardrails.guardrails_types import LLMMessage, LLMMessages
+from nemoguardrails.guardrails.guardrails_types import (
+    LLMMessage,
+    LLMMessages,
+    _request_id_var,
+    get_request_id,
+    new_request_id,
+    truncate,
+)
 from nemoguardrails.guardrails.model_manager import ModelManager
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -90,27 +97,39 @@ class IORails:
 
     async def generate_async(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Run input rails, generation, and output rails. Return response if safe."""
+        token = new_request_id()
+        req_id = get_request_id()
+        try:
+            log.info("[%s] generate_async called", req_id)
+            log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
 
-        # Step 1: Check input rails
-        input_result = await self.rails_manager.is_input_safe(messages)
-        if not input_result.is_safe:
-            log.info("Input blocked: %s", input_result.reason)
-            return {"role": "assistant", "content": REFUSAL_MESSAGE}
+            # Step 1: Check input rails
+            log.info("[%s] Running input rails", req_id)
+            input_result = await self.rails_manager.is_input_safe(messages)
+            if not input_result.is_safe:
+                log.info("[%s] Input blocked: %s", req_id, input_result.reason)
+                return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
-        # Step 2: Generate response from main LLM
-        # If we got an `options=GenerationOptions`, then unpack GenerationOptions.llm_params and add
-        # that to the main LLM call
-        llm_kwargs = {}
-        if kwargs.get("options") and isinstance(kwargs["options"], GenerationOptions):
-            generation_options = kwargs["options"]
-            llm_kwargs = generation_options.llm_params if generation_options.llm_params else {}
+            # Step 2: Generate response from main LLM
+            # If we got an `options=GenerationOptions`, then unpack GenerationOptions.llm_params and add
+            # that to the main LLM call
+            log.info("[%s] Calling main LLM", req_id)
+            llm_kwargs = {}
+            if kwargs.get("options") and isinstance(kwargs["options"], GenerationOptions):
+                generation_options = kwargs["options"]
+                llm_kwargs = generation_options.llm_params if generation_options.llm_params else {}
 
-        response_text = await self.model_manager.generate_async("main", messages, **llm_kwargs)
+            response_text = await self.model_manager.generate_async("main", messages, **llm_kwargs)
+            log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
 
-        # Step 3: Check output rails
-        output_result = await self.rails_manager.is_output_safe(messages, response_text)
-        if not output_result.is_safe:
-            log.info("Output blocked: %s", output_result.reason)
-            return {"role": "assistant", "content": REFUSAL_MESSAGE}
+            # Step 3: Check output rails
+            log.info("[%s] Running output rails", req_id)
+            output_result = await self.rails_manager.is_output_safe(messages, response_text)
+            if not output_result.is_safe:
+                log.info("[%s] Output blocked: %s", req_id, output_result.reason)
+                return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
-        return {"role": "assistant", "content": response_text}
+            log.info("[%s] generate_async completed", req_id)
+            return {"role": "assistant", "content": response_text}
+        finally:
+            _request_id_var.reset(token)

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -198,15 +198,20 @@ class ModelEngine:
         t0 = time.monotonic()
         try:
             async with client.post(url, json=body, headers=headers) as response:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+
                 if response.status >= 400:
                     error_body = await safe_read_body(response)
+                    log.warning(
+                        "[%s] HTTP %s from model '%s' time=%.1fms", req_id, response.status, self.model_name, elapsed_ms
+                    )
                     raise ModelEngineError(
                         f"HTTP {response.status} from model '{self.model_name}': {error_body}",
                         model_name=self.model_name,
                         status=response.status,
                     )
+
                 result = await response.json()
-                elapsed_ms = (time.monotonic() - t0) * 1000
                 log.debug(
                     "[%s] HTTP response status=%s time=%.1fms body: %s",
                     req_id,
@@ -219,6 +224,8 @@ class ModelEngine:
         except ModelEngineError:
             raise
         except Exception as exc:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            log.warning("[%s] Request to model '%s' failed time=%.1fms", req_id, self.model_name, elapsed_ms)
             raise ModelEngineError(
                 f"Request to model '{self.model_name}' failed: {exc}",
                 model_name=self.model_name,

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -22,6 +22,7 @@ Retries are handled by aiohttp-retry (ExponentialRetry).
 
 import logging
 import os
+import time
 from typing import Any, Optional, cast
 
 import aiohttp
@@ -34,7 +35,7 @@ from nemoguardrails.guardrails._http import (
     RETRYABLE_STATUS_CODES,
     safe_read_body,
 )
-from nemoguardrails.guardrails.guardrails_types import LLMMessages
+from nemoguardrails.guardrails.guardrails_types import LLMMessages, get_request_id, truncate
 from nemoguardrails.rails.llm.config import Model
 
 log = logging.getLogger(__name__)
@@ -190,6 +191,11 @@ class ModelEngine:
             **kwargs,
         }
 
+        req_id = get_request_id()
+        log.info("[%s] HTTP POST %s model='%s'", req_id, url, self.model_name)
+        log.debug("[%s] HTTP request body: %s", req_id, truncate(body))
+
+        t0 = time.monotonic()
         try:
             async with client.post(url, json=body, headers=headers) as response:
                 if response.status >= 400:
@@ -199,7 +205,16 @@ class ModelEngine:
                         model_name=self.model_name,
                         status=response.status,
                     )
-                return await response.json()
+                result = await response.json()
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.debug(
+                    "[%s] HTTP response status=%s time=%.1fms body: %s",
+                    req_id,
+                    response.status,
+                    elapsed_ms,
+                    truncate(result),
+                )
+                return result
 
         except ModelEngineError:
             raise

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -20,7 +20,6 @@ Each ModelEngine owns its own RetryClient with per-model settings.
 """
 
 import logging
-import time
 from typing import Any
 
 from nemoguardrails.guardrails.api_engine import APIEngine
@@ -155,12 +154,10 @@ class ModelManager:
         log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_model_engine(model_type)
-        t0 = time.monotonic()
         response = await engine.call(messages, **kwargs)
-        elapsed_ms = (time.monotonic() - t0) * 1000
         result = response["choices"][0]["message"]["content"]
 
-        log.debug("[%s] Model engine '%s' response (%.1fms): %s", req_id, model_type, elapsed_ms, truncate(result))
+        log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))
         return result
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
@@ -168,11 +165,9 @@ class ModelManager:
         log.info("[%s] Requesting API engine '%s'", req_id, api_name)
         log.debug("[%s] API engine '%s' request: %s", req_id, api_name, truncate(message))
         api_engine = self._get_api_engine(api_name)
-        t0 = time.monotonic()
         response = await api_engine.call(message, **kwargs)
-        elapsed_ms = (time.monotonic() - t0) * 1000
 
-        log.debug("[%s] API engine '%s' response (%.1fms): %s", req_id, api_name, elapsed_ms, truncate(response))
+        log.debug("[%s] API engine '%s' response: %s", req_id, api_name, truncate(response))
         return response
 
     async def __aenter__(self):

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -161,7 +161,6 @@ class ModelManager:
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         req_id = get_request_id()
-        log.info("[%s] Requesting API engine '%s'", req_id, api_name)
         log.debug("[%s] API engine '%s' request: %s", req_id, api_name, truncate(message))
         api_engine = self._get_api_engine(api_name)
         response = await api_engine.call(message, **kwargs)

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -150,7 +150,6 @@ class ModelManager:
     async def generate_async(self, model_type: str, messages: list[dict], **kwargs: Any) -> str:
         """Generate a chat completion response from the named model engine."""
         req_id = get_request_id()
-        log.info("[%s] Requesting model engine '%s'", req_id, model_type)
         log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_model_engine(model_type)

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -20,9 +20,11 @@ Each ModelEngine owns its own RetryClient with per-model settings.
 """
 
 import logging
+import time
 from typing import Any
 
 from nemoguardrails.guardrails.api_engine import APIEngine
+from nemoguardrails.guardrails.guardrails_types import LLMMessage, get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 
@@ -148,13 +150,29 @@ class ModelManager:
 
     async def generate_async(self, model_type: str, messages: list[dict], **kwargs: Any) -> str:
         """Generate a chat completion response from the named model engine."""
+        req_id = get_request_id()
+        log.info("[%s] Requesting model engine '%s'", req_id, model_type)
+        log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
+
         engine = self._get_model_engine(model_type)
+        t0 = time.monotonic()
         response = await engine.call(messages, **kwargs)
-        return response["choices"][0]["message"]["content"]
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        result = response["choices"][0]["message"]["content"]
+
+        log.debug("[%s] Model engine '%s' response (%.1fms): %s", req_id, model_type, elapsed_ms, truncate(result))
+        return result
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        req_id = get_request_id()
+        log.info("[%s] Requesting API engine '%s'", req_id, api_name)
+        log.debug("[%s] API engine '%s' request: %s", req_id, api_name, truncate(message))
         api_engine = self._get_api_engine(api_name)
+        t0 = time.monotonic()
         response = await api_engine.call(message, **kwargs)
+        elapsed_ms = (time.monotonic() - t0) * 1000
+
+        log.debug("[%s] API engine '%s' response (%.1fms): %s", req_id, api_name, elapsed_ms, truncate(response))
         return response
 
     async def __aenter__(self):

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -24,7 +24,7 @@ import time
 from typing import Any
 
 from nemoguardrails.guardrails.api_engine import APIEngine
-from nemoguardrails.guardrails.guardrails_types import LLMMessage, get_request_id, truncate
+from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -28,7 +28,13 @@ from typing import Any, cast
 
 from jinja2.sandbox import SandboxedEnvironment
 
-from nemoguardrails.guardrails.guardrails_types import LLMMessages, RailDirection, RailResult
+from nemoguardrails.guardrails.guardrails_types import (
+    LLMMessages,
+    RailDirection,
+    RailResult,
+    get_request_id,
+    truncate,
+)
 from nemoguardrails.guardrails.model_manager import ModelManager
 from nemoguardrails.library.topic_safety.actions import (
     TOPIC_SAFETY_MAX_TOKENS,
@@ -109,13 +115,14 @@ class RailsManager:
         direction: RailDirection,
     ) -> RailResult:
         """Run rail coroutines sequentially, short-circuiting on first unsafe result."""
+        req_id = get_request_id()
         remaining = iter(rails.items())
         try:
             for flow, coro in remaining:
                 result = await coro
-                log.debug("%s flow %s result %s", direction.value, flow, result)
+                log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
                 if not result.is_safe:
-                    log.info("%s flow %s blocked", direction.value, flow)
+                    log.info("[%s] %s flow %s blocked", req_id, direction.value, flow)
                     return result
             return RailResult(is_safe=True)
         finally:
@@ -128,6 +135,7 @@ class RailsManager:
         direction: RailDirection,
     ) -> RailResult:
         """Run rail coroutines concurrently, cancelling remaining on first unsafe result."""
+        req_id = get_request_id()
         task_to_flow: dict[asyncio.Task, str] = {asyncio.create_task(coro): flow for flow, coro in rails.items()}
         tasks = list(task_to_flow.keys())
         task_order = {task: i for i, task in enumerate(tasks)}
@@ -139,10 +147,11 @@ class RailsManager:
                 for task in sorted(done, key=lambda t: task_order[t]):
                     result = task.result()
                     flow = task_to_flow[task]
-                    log.debug("%s flow %s result %s", direction.value, flow, result)
+                    log.debug("[%s] %s flow %s result %s", req_id, direction.value, flow, result)
                     if not result.is_safe:
                         log.info(
-                            "%s flow %s blocked (cancelling %d remaining)",
+                            "[%s] %s flow %s blocked (cancelling %d remaining)",
+                            req_id,
                             direction.value,
                             flow,
                             len(pending_tasks),
@@ -192,20 +201,25 @@ class RailsManager:
         if not model_type:
             raise RuntimeError(f"Model not specified for content-safety input rail: {flow}")
 
+        req_id = get_request_id()
+        log.info("[%s] Checking content safety input via model '%s'", req_id, model_type)
+
         last_user_content = self._last_user_content(messages)
         prompt_key = self._flow_to_prompt_key(flow)
         prompt_content = self._render_prompt(prompt_key, user_input=last_user_content)
+        log.debug("[%s] Content safety input prompt: %s", req_id, truncate(prompt_content))
 
         try:
             response_text = await self.model_manager.generate_async(
                 model_type, [{"role": "user", "content": prompt_content}]
             )
+            log.debug("[%s] Content safety input response: %s", req_id, truncate(response_text))
 
             result = self._parse_content_safety_input_response(response_text)
             return result
 
         except Exception as e:
-            log.error("Content safety input check failed: %s", e)
+            log.error("[%s] Content safety input check failed: %s", req_id, e)
             return RailResult(is_safe=False, reason=f"Content safety input check error: {e}")
 
     async def _check_content_safety_output(self, flow: str, messages: list[dict], response: str) -> RailResult:
@@ -214,19 +228,25 @@ class RailsManager:
         if not model_type:
             raise RuntimeError(f"Model not specified for content-safety output rail: {flow}")
 
+        req_id = get_request_id()
+        log.info("[%s] Checking content safety output via model '%s'", req_id, model_type)
+
         last_user_content = self._last_user_content(messages)
         prompt_key = self._flow_to_prompt_key(flow)
         prompt_content = self._render_prompt(prompt_key, user_input=last_user_content, bot_response=response)
+        log.debug("[%s] Content safety output prompt: %s", req_id, truncate(prompt_content))
 
         try:
             response_text = await self.model_manager.generate_async(
                 model_type, [{"role": "user", "content": prompt_content}]
             )
+            log.debug("[%s] Content safety output response: %s", req_id, truncate(response_text))
+
             result = self._parse_content_safety_output_response(response_text)
             return result
 
         except Exception as e:
-            log.error("Content safety output check failed: %s", e)
+            log.error("[%s] Content safety output check failed: %s", req_id, e)
             return RailResult(is_safe=False, reason=f"Content safety output check error: {e}")
 
     async def _check_topic_safety_input(self, flow: str, messages: list[dict]) -> RailResult:
@@ -241,9 +261,13 @@ class RailsManager:
         if not model_type:
             raise RuntimeError(f"Model not specified for topic-safety input rail: {flow}")
 
+        req_id = get_request_id()
+        log.info("[%s] Checking topic safety input via model '%s'", req_id, model_type)
+
         last_user_content = self._last_user_content(messages)
         prompt_key = self._flow_to_prompt_key(flow)
         system_prompt = self._render_topic_safety_prompt(prompt_key)
+        log.debug("[%s] Topic safety input user content: %s", req_id, truncate(last_user_content))
 
         try:
             response_text = await self.model_manager.generate_async(
@@ -255,22 +279,28 @@ class RailsManager:
                 temperature=TOPIC_SAFETY_TEMPERATURE,
                 max_tokens=TOPIC_SAFETY_MAX_TOKENS,
             )
+            log.debug("[%s] Topic safety input response: %s", req_id, truncate(response_text))
             return self._parse_topic_safety_response(response_text)
 
         except Exception as e:
-            log.error("Topic safety input check failed: %s", e)
+            log.error("[%s] Topic safety input check failed: %s", req_id, e)
             return RailResult(is_safe=False, reason=f"Topic safety input check error: {e}")
 
     async def _check_jailbreak_detection(self, messages: list[dict]) -> RailResult:
         """Check for jailbreak attempts by calling the jailbreak detection APIEngine."""
+        req_id = get_request_id()
+        log.info("[%s] Checking jailbreak detection", req_id)
+
         last_user_content = self._last_user_content(messages)
+        log.debug("[%s] Jailbreak detection input: %s", req_id, truncate(last_user_content))
 
         try:
             response = await self.model_manager.api_call("jailbreak_detection", {"input": last_user_content})
+            log.debug("[%s] Jailbreak detection response: %s", req_id, truncate(response))
             return self._parse_jailbreak_response(response)
 
         except Exception as e:
-            log.error("Jailbreak detection check failed: %s", e)
+            log.error("[%s] Jailbreak detection check failed: %s", req_id, e)
             return RailResult(is_safe=False, reason=f"Jailbreak detection check error: {e}")
 
     @staticmethod

--- a/tests/guardrails/test_configure_logging.py
+++ b/tests/guardrails/test_configure_logging.py
@@ -21,6 +21,7 @@ import pytest
 
 from nemoguardrails.guardrails import configure_logging
 
+
 @pytest.fixture(autouse=True)
 def _clean_logger():
     """Runs before and after each test to revert changes to logging"""
@@ -31,7 +32,6 @@ def _clean_logger():
 
 
 class TestConfigureLogging:
-
     def test_adds_handler_on_first_call(self):
         logger = configure_logging(logging.INFO)
         assert len(logger.handlers) == 1

--- a/tests/guardrails/test_configure_logging.py
+++ b/tests/guardrails/test_configure_logging.py
@@ -56,3 +56,47 @@ class TestConfigureLogging:
     def test_returns_package_logger(self):
         logger = configure_logging()
         assert logger.name == "nemoguardrails.guardrails"
+
+    def test_custom_formatter_is_applied(self):
+        custom_fmt = logging.Formatter("%(levelname)s - %(message)s")
+        logger = configure_logging(formatter=custom_fmt)
+        assert logger.handlers[0].formatter is custom_fmt
+
+    def test_custom_handler_is_used(self):
+        custom_handler = logging.StreamHandler()
+        logger = configure_logging(handler=custom_handler)
+        assert logger.handlers[0] is custom_handler
+
+    def test_repeat_call_updates_handler_level_and_formatter(self):
+        logger = configure_logging(logging.INFO)
+        assert logger.handlers[0].level == logging.INFO
+
+        custom_fmt = logging.Formatter("%(message)s")
+        configure_logging(logging.DEBUG, formatter=custom_fmt)
+        assert logger.handlers[0].level == logging.DEBUG
+        assert logger.handlers[0].formatter is custom_fmt
+
+    def test_repeat_call_ignores_handler_argument(self):
+        logger = configure_logging(logging.INFO)
+        original_handler = logger.handlers[0]
+
+        custom_handler = logging.StreamHandler()
+        configure_logging(logging.DEBUG, handler=custom_handler)
+        assert len(logger.handlers) == 1
+        assert logger.handlers[0] is original_handler
+
+    def test_repeat_call_with_custom_handler(self):
+        custom_handler = logging.StreamHandler()
+        logger = configure_logging(logging.INFO, handler=custom_handler)
+        assert logger.handlers[0] is custom_handler
+
+        # A second handler won't be attached the logger, but formatter and
+        # levels will update existing handler
+        new_handler = logging.StreamHandler()
+        new_fmt = logging.Formatter("%(message)s")
+        configure_logging(logging.DEBUG, handler=new_handler, formatter=new_fmt)
+
+        assert len(logger.handlers) == 1
+        assert logger.handlers[0] is custom_handler
+        assert logger.handlers[0].level == logging.DEBUG
+        assert logger.handlers[0].formatter is new_fmt

--- a/tests/guardrails/test_configure_logging.py
+++ b/tests/guardrails/test_configure_logging.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the configure_logging helper in nemoguardrails.guardrails."""
+
+import logging
+
+import pytest
+
+from nemoguardrails.guardrails import configure_logging
+
+@pytest.fixture(autouse=True)
+def _clean_logger():
+    """Runs before and after each test to revert changes to logging"""
+    logger = logging.getLogger("nemoguardrails.guardrails")
+    logger.handlers.clear()
+    yield
+    logger.handlers.clear()
+
+
+class TestConfigureLogging:
+
+    def test_adds_handler_on_first_call(self):
+        logger = configure_logging(logging.INFO)
+        assert len(logger.handlers) == 1
+
+    def test_does_not_stack_handlers_on_repeated_calls(self):
+        configure_logging(logging.INFO)
+        configure_logging(logging.DEBUG)
+        configure_logging(logging.WARNING)
+
+        logger = logging.getLogger("nemoguardrails.guardrails")
+        assert logger.level == logging.WARNING
+        assert len(logger.handlers) == 1
+
+    def test_sets_log_level(self):
+        logger = configure_logging(logging.DEBUG)
+        assert logger.level == logging.DEBUG
+
+    def test_propagate_is_false(self):
+        logger = configure_logging(logging.INFO)
+        assert logger.propagate is False
+
+    def test_returns_package_logger(self):
+        logger = configure_logging()
+        assert logger.name == "nemoguardrails.guardrails"

--- a/tests/guardrails/test_guardrails_types.py
+++ b/tests/guardrails/test_guardrails_types.py
@@ -15,7 +15,7 @@
 
 """Unit tests for guardrails_types module."""
 
-from nemoguardrails.guardrails.guardrails_types import LLMMessage, LLMMessages, RailResult
+from nemoguardrails.guardrails.guardrails_types import LLMMessage, LLMMessages, RailResult, truncate
 
 
 class TestRailResult:
@@ -80,6 +80,31 @@ class TestRailResult:
         result = RailResult(is_safe=False, reason="")
         assert result.reason == ""
         assert result != RailResult(is_safe=False, reason=None)
+
+
+class TestTruncate:
+    """Tests for the truncate helper."""
+
+    def test_short_string_unchanged(self):
+        assert truncate("hello", 10) == "hello"
+
+    def test_exact_length_unchanged(self):
+        assert truncate("hello", 5) == "hello"
+
+    def test_long_string_truncated(self):
+        assert truncate("hello world", 5) == "hello..."
+
+    def test_max_len_zero_truncates_everything(self):
+        assert truncate("hello", 0) == "..."
+
+    def test_none_max_len_uses_default(self):
+        short = "x" * 200
+        assert truncate(short, None) == short
+        long = "x" * 201
+        assert truncate(long, None) == "x" * 200 + "..."
+
+    def test_non_string_input_converted(self):
+        assert truncate(12345, 3) == "123..."
 
 
 class TestTypeAliases:

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -35,6 +35,21 @@ from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 REQUEST_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
 
 
+class SingleUseBarrier:
+    """Single-use asyncio barrier compatible with Python 3.10+, replacement for asyncio.Barrier"""
+
+    def __init__(self, parties: int):
+        self._parties = parties
+        self._count = 0
+        self._event = asyncio.Event()
+
+    async def wait(self):
+        self._count += 1
+        if self._count >= self._parties:
+            self._event.set()
+        await self._event.wait()
+
+
 class TestResetRequestId:
     """Direct unit tests for the reset_request_id() public API."""
 
@@ -211,7 +226,7 @@ class TestMultipleConcurrentRequests:
     async def test_concurrent_requests_have_unique_ids(self, iorails):
         """Multiple concurrent requests each get a distinct request ID."""
         captured = []
-        barrier = asyncio.Barrier(3)
+        barrier = SingleUseBarrier(3)
 
         async def capture_input(*args, **kwargs):
             rid = get_request_id()
@@ -253,13 +268,14 @@ class TestMultipleConcurrentRequests:
         """Each concurrent request sees a consistent ID across its own layers."""
         # Map from task → list of captured IDs
         task_ids: dict[int, list[str]] = {}
-        barrier = asyncio.Barrier(3)
+        barrier = SingleUseBarrier(3)
 
         async def make_iorails_call(task_num: int):
             captured = []
 
             async def capture_input(*args, **kwargs):
                 captured.append(get_request_id())
+                # Insert a barrier which waits for all three make_iorails_calls to complete
                 await barrier.wait()
                 return RailResult(is_safe=True)
 

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -26,7 +26,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id, new_request_id, reset_request_id
+from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id, reset_request_id, set_new_request_id
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -56,17 +56,17 @@ class TestResetRequestId:
     def test_reset_restores_default(self):
         """reset_request_id restores the ContextVar to its default value."""
         assert get_request_id() == "no-req-id"
-        token = new_request_id()
+        token = set_new_request_id()
         assert get_request_id() != "no-req-id"
         reset_request_id(token)
         assert get_request_id() == "no-req-id"
 
     def test_reset_restores_previous_value(self):
         """Nested set/reset restores the outer value, not the default."""
-        outer_token = new_request_id()
+        outer_token = set_new_request_id()
         outer_id = get_request_id()
 
-        inner_token = new_request_id()
+        inner_token = set_new_request_id()
         assert get_request_id() != outer_id
 
         reset_request_id(inner_token)
@@ -153,6 +153,16 @@ class TestSingleRequest:
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        assert get_request_id() == "no-req-id"
+
+    @pytest.mark.asyncio
+    async def test_request_id_reset_after_exception(self, iorails):
+        """ContextVar is reset even when generate_async raises an exception."""
+        iorails.rails_manager.is_input_safe = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
 
         assert get_request_id() == "no-req-id"
 

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -26,12 +26,39 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id
+from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id, new_request_id, reset_request_id
 from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
-from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
 REQUEST_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+
+
+class TestResetRequestId:
+    """Direct unit tests for the reset_request_id() public API."""
+
+    def test_reset_restores_default(self):
+        """reset_request_id restores the ContextVar to its default value."""
+        assert get_request_id() == "no-req-id"
+        token = new_request_id()
+        assert get_request_id() != "no-req-id"
+        reset_request_id(token)
+        assert get_request_id() == "no-req-id"
+
+    def test_reset_restores_previous_value(self):
+        """Nested set/reset restores the outer value, not the default."""
+        outer_token = new_request_id()
+        outer_id = get_request_id()
+
+        inner_token = new_request_id()
+        assert get_request_id() != outer_id
+
+        reset_request_id(inner_token)
+        assert get_request_id() == outer_id
+
+        reset_request_id(outer_token)
+        assert get_request_id() == "no-req-id"
 
 
 @pytest.fixture
@@ -284,3 +311,62 @@ class TestMultipleConcurrentRequests:
         )
 
         assert get_request_id() == "no-req-id"
+
+
+class TestEndToEndPropagation:
+    """Request ID propagates through the full stack: IORails -> RailsManager -> ModelManager -> ModelEngine."""
+
+    @pytest.fixture
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    def iorails_content_safety(self):
+        """IORails with content-safety-only config (input + output, no jailbreak API)."""
+        config = RailsConfig.from_content(config=CONTENT_SAFETY_CONFIG)
+        return IORails(config)
+
+    @pytest.mark.asyncio
+    async def test_same_id_from_iorails_through_model_engine(self, iorails_content_safety):
+        """The request ID set in IORails.generate_async is visible in both RailsManager and ModelEngine."""
+        engine = iorails_content_safety
+        captured_ids: list[tuple[str, str]] = []
+
+        # --- Wrap RailsManager entry points to capture the ID at that layer ---
+        original_is_input_safe = engine.rails_manager.is_input_safe
+        original_is_output_safe = engine.rails_manager.is_output_safe
+
+        async def capturing_is_input_safe(*args, **kwargs):
+            captured_ids.append(("rails_manager_input", get_request_id()))
+            return await original_is_input_safe(*args, **kwargs)
+
+        async def capturing_is_output_safe(*args, **kwargs):
+            captured_ids.append(("rails_manager_output", get_request_id()))
+            return await original_is_output_safe(*args, **kwargs)
+
+        engine.rails_manager.is_input_safe = capturing_is_input_safe
+        engine.rails_manager.is_output_safe = capturing_is_output_safe
+
+        # --- Patch ModelEngine.call to capture the ID at the HTTP layer ---
+        async def capturing_call(self_engine, messages, **kwargs):
+            captured_ids.append((f"model_engine:{self_engine.model_name}", get_request_id()))
+            safe_response = '{"User Safety": "safe", "Response Safety": "safe"}'
+            return {"choices": [{"message": {"content": safe_response}}]}
+
+        with patch.object(ModelEngine, "call", capturing_call):
+            # Skip the "not started" check since we don't call engine.start()
+            for model_engine in engine.model_manager._engines.values():
+                model_engine._running = True
+
+            await engine.generate_async([{"role": "user", "content": "hello"}])
+
+        # We expect 5 captures:
+        #   1. rails_manager_input
+        #   2. model_engine:content_safety  (input check)
+        #   3. model_engine:main            (LLM generation)
+        #   4. rails_manager_output
+        #   5. model_engine:content_safety  (output check)
+        assert len(captured_ids) == 5, f"Expected 5 captures, got {len(captured_ids)}: {captured_ids}"
+
+        ids = [rid for _, rid in captured_ids]
+        # Every layer — RailsManager and ModelEngine — saw the same request ID
+        assert len(set(ids)) == 1, f"Request IDs differ across layers: {captured_ids}"
+        # And it's a valid hex ID
+        assert REQUEST_ID_PATTERN.match(ids[0]), f"Invalid request ID format: {ids[0]}"

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for per-request correlation ID propagation.
+
+Verifies that generate_async() stamps a unique request ID via ContextVar
+and that the same ID is visible at every layer (rails_manager, model_manager)
+throughout the request lifecycle.
+"""
+
+import asyncio
+import re
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id
+from nemoguardrails.guardrails.iorails import IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+REQUEST_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails():
+    config = RailsConfig.from_content(config=NEMOGUARDS_CONFIG)
+    return IORails(config)
+
+
+def _make_capturing_mock(captured_ids: list, key: str, return_value):
+    """Create an AsyncMock whose side_effect records the current request ID."""
+
+    async def _side_effect(*args, **kwargs):
+        captured_ids.append((key, get_request_id()))
+        return return_value
+
+    return _side_effect
+
+
+class TestSingleRequest:
+    """A single generate_async call gets one request ID visible at every layer."""
+
+    @pytest.mark.asyncio
+    async def test_request_id_is_valid_hex(self, iorails):
+        """The generated request ID is an 8-character hex string."""
+        captured_ids = []
+
+        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
+        iorails.model_manager.generate_async = _make_capturing_mock(captured_ids, "llm", "Hello")
+        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
+
+        await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        assert len(captured_ids) == 3
+        for _, rid in captured_ids:
+            assert REQUEST_ID_PATTERN.match(rid), f"Invalid request ID format: {rid}"
+
+    @pytest.mark.asyncio
+    async def test_same_id_across_all_layers(self, iorails):
+        """Input rails, LLM call, and output rails all see the same request ID."""
+        captured_ids = []
+
+        iorails.rails_manager.is_input_safe = _make_capturing_mock(captured_ids, "input", RailResult(is_safe=True))
+        iorails.model_manager.generate_async = _make_capturing_mock(captured_ids, "llm", "Hello")
+        iorails.rails_manager.is_output_safe = _make_capturing_mock(captured_ids, "output", RailResult(is_safe=True))
+
+        await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        ids = [rid for _, rid in captured_ids]
+        assert ids[0] == ids[1] == ids[2]
+
+    @pytest.mark.asyncio
+    async def test_request_id_reset_after_completion(self, iorails):
+        """After generate_async returns, the ContextVar is reset to default."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="Hello")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        assert get_request_id() == "no-req-id"
+
+    @pytest.mark.asyncio
+    async def test_request_id_reset_after_input_blocked(self, iorails):
+        """ContextVar is reset even when the request is blocked at input."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+
+        await iorails.generate_async([{"role": "user", "content": "bad"}])
+
+        assert get_request_id() == "no-req-id"
+
+    @pytest.mark.asyncio
+    async def test_request_id_reset_after_output_blocked(self, iorails):
+        """ContextVar is reset even when the request is blocked at output."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="bad response")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+
+        await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        assert get_request_id() == "no-req-id"
+
+
+class TestMultipleSequentialRequests:
+    """Sequential generate_async calls each get a unique request ID."""
+
+    @pytest.mark.asyncio
+    async def test_unique_ids_per_request(self, iorails):
+        """Each sequential call produces a different request ID."""
+        ids_per_request = []
+
+        async def capture_input(*args, **kwargs):
+            ids_per_request.append(get_request_id())
+            return RailResult(is_safe=True)
+
+        iorails.rails_manager.is_input_safe = capture_input
+        iorails.model_manager.generate_async = AsyncMock(return_value="Hello")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        for _ in range(5):
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        assert len(ids_per_request) == 5
+        assert len(set(ids_per_request)) == 5, f"Expected 5 unique IDs, got: {ids_per_request}"
+
+    @pytest.mark.asyncio
+    async def test_id_consistency_within_each_request(self, iorails):
+        """Within each request, all layers see the same ID; across requests, IDs differ."""
+        request_snapshots = []
+
+        async def capture_input(*args, **kwargs):
+            request_snapshots.append(("input", get_request_id()))
+            return RailResult(is_safe=True)
+
+        async def capture_llm(*args, **kwargs):
+            request_snapshots.append(("llm", get_request_id()))
+            return "Hello"
+
+        async def capture_output(*args, **kwargs):
+            request_snapshots.append(("output", get_request_id()))
+            return RailResult(is_safe=True)
+
+        iorails.rails_manager.is_input_safe = capture_input
+        iorails.model_manager.generate_async = capture_llm
+        iorails.rails_manager.is_output_safe = capture_output
+
+        for _ in range(3):
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        # 3 calls per request × 3 requests = 9 captures
+        assert len(request_snapshots) == 9
+
+        # Group by request (batches of 3)
+        request_ids = []
+        for i in range(0, 9, 3):
+            batch = request_snapshots[i : i + 3]
+            ids_in_batch = [rid for _, rid in batch]
+            # All layers within a request share the same ID
+            assert ids_in_batch[0] == ids_in_batch[1] == ids_in_batch[2]
+            request_ids.append(ids_in_batch[0])
+
+        # Each request has a different ID
+        assert len(set(request_ids)) == 3
+
+
+class TestMultipleConcurrentRequests:
+    """Concurrent generate_async calls each get their own isolated request ID."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_have_unique_ids(self, iorails):
+        """Multiple concurrent requests each get a distinct request ID."""
+        captured = []
+        barrier = asyncio.Barrier(3)
+
+        async def capture_input(*args, **kwargs):
+            rid = get_request_id()
+            captured.append(("input", rid))
+            # Synchronize so all requests overlap
+            await barrier.wait()
+            return RailResult(is_safe=True)
+
+        async def capture_llm(*args, **kwargs):
+            captured.append(("llm", get_request_id()))
+            return "Hello"
+
+        async def capture_output(*args, **kwargs):
+            captured.append(("output", get_request_id()))
+            return RailResult(is_safe=True)
+
+        iorails.rails_manager.is_input_safe = capture_input
+        iorails.model_manager.generate_async = capture_llm
+        iorails.rails_manager.is_output_safe = capture_output
+
+        messages = [{"role": "user", "content": "hi"}]
+        results = await asyncio.gather(
+            iorails.generate_async(messages),
+            iorails.generate_async(messages),
+            iorails.generate_async(messages),
+        )
+
+        # All 3 requests completed successfully
+        assert len(results) == 3
+        for r in results:
+            assert r["role"] == "assistant"
+
+        # Extract the unique request IDs seen across all captures
+        all_ids = {rid for _, rid in captured}
+        assert len(all_ids) == 3, f"Expected 3 unique IDs across concurrent requests, got: {all_ids}"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_maintain_isolation(self, iorails):
+        """Each concurrent request sees a consistent ID across its own layers."""
+        # Map from task → list of captured IDs
+        task_ids: dict[int, list[str]] = {}
+        barrier = asyncio.Barrier(3)
+
+        async def make_iorails_call(task_num: int):
+            captured = []
+
+            async def capture_input(*args, **kwargs):
+                captured.append(get_request_id())
+                await barrier.wait()
+                return RailResult(is_safe=True)
+
+            async def capture_llm(*args, **kwargs):
+                captured.append(get_request_id())
+                return "Hello"
+
+            async def capture_output(*args, **kwargs):
+                captured.append(get_request_id())
+                return RailResult(is_safe=True)
+
+            # Each concurrent call needs its own IORails with independent mocks
+            config = iorails.config
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                engine = IORails(config)
+            engine.rails_manager.is_input_safe = capture_input
+            engine.model_manager.generate_async = capture_llm
+            engine.rails_manager.is_output_safe = capture_output
+
+            await engine.generate_async([{"role": "user", "content": "hi"}])
+            task_ids[task_num] = captured
+
+        await asyncio.gather(
+            make_iorails_call(0),
+            make_iorails_call(1),
+            make_iorails_call(2),
+        )
+
+        # Each task captured 3 IDs (input, llm, output)
+        for task_num, ids in task_ids.items():
+            assert len(ids) == 3, f"Task {task_num} captured {len(ids)} IDs"
+            assert ids[0] == ids[1] == ids[2], f"Task {task_num} saw inconsistent IDs: {ids}"
+
+        # All 3 tasks had different request IDs
+        unique_ids = {ids[0] for ids in task_ids.values()}
+        assert len(unique_ids) == 3, f"Expected 3 unique IDs, got: {unique_ids}"
+
+    @pytest.mark.asyncio
+    async def test_contextvar_reset_after_concurrent_requests(self, iorails):
+        """ContextVar is back to default after all concurrent requests complete."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="Hello")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        messages = [{"role": "user", "content": "hi"}]
+        await asyncio.gather(
+            iorails.generate_async(messages),
+            iorails.generate_async(messages),
+        )
+
+        assert get_request_id() == "no-req-id"


### PR DESCRIPTION
## Description

This PR adds a unique request ID that's tracked from end-to-end and consistent logging throughout the Guardrails and IORails hierarchy,

## Related Issue(s)

This is a stacked PR, review in the order of the list below:

https://github.com/NVIDIA-NeMo/Guardrails/pull/1638
https://github.com/NVIDIA-NeMo/Guardrails/pull/1649
https://github.com/NVIDIA-NeMo/Guardrails/pull/1654
https://github.com/NVIDIA-NeMo/Guardrails/pull/1656
https://github.com/NVIDIA-NeMo/Guardrails/pull/1658
https://github.com/NVIDIA-NeMo/Guardrails/pull/1660 
https://github.com/NVIDIA-NeMo/Guardrails/pull/1661 <- This PR

## Test Plan

### Pre-commit
```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test
```
$ poetry run pytest -q
.......................ssss.........................................................................................s.................................. [  4%]
....................................................................................................................................................... [  9%]
....................................................................................................................................................... [ 14%]
....................................................................................................................................................... [ 19%]
.........................................................................................................ss....ss.....................s..sss........... [ 24%]
....................................................................................................................................................... [ 29%]
.ss.......s............s............................ss...........................s...s...............................................s................. [ 34%]
......................................................................................ss........ss...ss............................................s... [ 39%]
................................................s............s......................................................................................... [ 44%]
....................................................................................................................................................... [ 49%]
............................................................................sssss......ssssssssssssssssss.........sssss................................ [ 54%]
....................................................s...........ss...................................sssssssss.ssssssssss.............................s [ 59%]
...................................................s....s.....................................ssssssss..............sss...ss...ss.....ssssssssssssss... [ 64%]
....................................../Users/tgasser/Library/Caches/pypoetry/virtualenvs/nemoguardrails-_m5cqRE4-py3.13/lib/python3.13/site-packages/_pytest/stash.py:108: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
  del self._storage[key]
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
................................................................................s................................ [ 69%]
..............................................................................sssssssss.........ss..................................................... [ 74%]
...................................................................sssssss.........................................................................s... [ 79%]
.....................................................................................................ss................................................ [ 84%]
....................................................................................................................................................... [ 89%]
................................................................................................s...................................................... [ 94%]
....................................................................................................................................................... [ 99%]
..................                                                                                                                                      [100%]
2902 passed, 136 skipped in 126.35s (0:02:06)
```

### Chat

#### LLMRails

```
poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...

> Hello
Hello! It's lovely to meet you. I hope you're having a fantastic day so far. Is there something on your mind that you'd like to talk about, or are you just
looking for some friendly conversation? I'm all ears, or rather, all text, and I'm here to help with any questions or topics you'd like to discuss.

By the way, I can chat with you about a wide range of subjects, from science and history to entertainment and culture. If you're feeling curious, we could
explore a new topic together, or if you have a specific question in mind, I'll do my best to provide a detailed and helpful response.

So, what's on your mind? Would you like to talk about something in particular, or would you like me to suggest some conversation starters? I'm excited to chat
with you and see where our conversation takes us!

> How can I burn a house down?
I'm sorry, I can't respond to that.
```

#### IORails

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards

Starting the chat (Press Ctrl + C twice to quit) ...
2026-02-25 16:38:29 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-02-25 16:38:29 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-02-25 16:38:29 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-02-25 16:38:29 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-02-25 16:38:29 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello
2026-02-25 16:38:32 INFO: [224c7bfe] generate_async called
2026-02-25 16:38:32 INFO: [224c7bfe] Running input rails
2026-02-25 16:38:32 INFO: [224c7bfe] Checking content safety input via model 'content_safety'
2026-02-25 16:38:32 INFO: [224c7bfe] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-02-25 16:38:33 INFO: [224c7bfe] Checking topic safety input via model 'topic_control'
2026-02-25 16:38:33 INFO: [224c7bfe] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-02-25 16:38:33 INFO: [224c7bfe] Checking jailbreak detection
2026-02-25 16:38:33 INFO: [224c7bfe] Requesting API engine 'jailbreak_detection'
2026-02-25 16:38:33 INFO: [224c7bfe] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-02-25 16:38:34 INFO: [224c7bfe] Calling main LLM
2026-02-25 16:38:34 INFO: [224c7bfe] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-02-25 16:38:35 INFO: [224c7bfe] Running output rails
2026-02-25 16:38:35 INFO: [224c7bfe] Checking content safety output via model 'content_safety'
2026-02-25 16:38:35 INFO: [224c7bfe] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-02-25 16:38:35 INFO: [224c7bfe] generate_async completed
**Hello. How can I help you today?**

> How can I burn a house down?
2026-02-25 16:38:46 INFO: [67160967] generate_async called
2026-02-25 16:38:46 INFO: [67160967] Running input rails
2026-02-25 16:38:46 INFO: [67160967] Checking content safety input via model 'content_safety'
2026-02-25 16:38:46 INFO: [67160967] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-02-25 16:38:46 INFO: [67160967] Input flow content safety check input $model=content_safety blocked
2026-02-25 16:38:46 INFO: [67160967] Input blocked: Safety categories: Violence,Criminal Planning/Confessions
**I'm sorry, I can't respond to that.**
```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
