### PR TITLE
fix(logging): show cache hits in Stats log and fix duplicate metadata restore

### DIFF
--- a/nemoguardrails/llm/cache/utils.py
+++ b/nemoguardrails/llm/cache/utils.py
@@ -107,6 +107,7 @@ def restore_llm_stats_from_cache(cached_stats: LLMStatsDict, cache_read_duration
         llm_stats_var.set(llm_stats)
 
     llm_stats.inc("total_calls")
+    llm_stats.inc("cache_hits")
     llm_stats.inc("total_time", cache_read_duration_s)
     llm_stats.inc("total_tokens", cached_stats.get("total_tokens", 0))
     llm_stats.inc("total_prompt_tokens", cached_stats.get("prompt_tokens", 0))
@@ -164,12 +165,6 @@ def get_from_cache_and_restore_stats(cache: "CacheInterface", cache_key: str) ->
 
     if cached_stats:
         restore_llm_stats_from_cache(cached_stats, cache_read_duration_s)
-
-    if cached_metadata:
-        restore_llm_metadata_from_cache(cached_metadata)
-
-    if cached_metadata:
-        restore_llm_metadata_from_cache(cached_metadata)
 
     if cached_metadata:
         restore_llm_metadata_from_cache(cached_metadata)

--- a/nemoguardrails/logging/stats.py
+++ b/nemoguardrails/logging/stats.py
@@ -30,6 +30,7 @@ class LLMStats:
             "total_tokens": 0,
             "total_prompt_tokens": 0,
             "total_completion_tokens": 0,
+            "cache_hits": 0,
             "latencies": [],
         }
 
@@ -53,8 +54,14 @@ class LLMStats:
         self._stats = self._get_empty_stats()
 
     def __str__(self):
+        cache_hits = self._stats["cache_hits"]
+        total_calls = self._stats["total_calls"]
+        if cache_hits > 0:
+            calls_str = f"{total_calls} total calls ({cache_hits} from cache)"
+        else:
+            calls_str = f"{total_calls} total calls"
         return (
-            f"{self._stats['total_calls']} total calls, "
+            f"{calls_str}, "
             f"{round(self._stats['total_time'], 2)} total time, "
             f"{self._stats['total_tokens']} total tokens, "
             f"{self._stats['total_prompt_tokens']} total prompt tokens, "

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -970,7 +970,7 @@ class LLMRails:
             log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
 
         total_time = time.time() - t0
-        log.info("--- :: Total processing took %.2f seconds. LLM Stats: %s" % (total_time, llm_stats))
+        log.info("--- :: Total processing took %.2f seconds. Stats: %s" % (total_time, llm_stats))
 
         # If there is a streaming handler, we make sure we close it now
         streaming_handler = streaming_handler_var.get()

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -202,6 +202,7 @@ class TestCacheUtils:
         llm_stats = llm_stats_var.get()
         assert llm_stats is not None
         assert llm_stats.get_stat("total_calls") == 1
+        assert llm_stats.get_stat("cache_hits") == 1
         assert llm_stats.get_stat("total_time") == 0.01
         assert llm_stats.get_stat("total_tokens") == 100
         assert llm_stats.get_stat("total_prompt_tokens") == 50
@@ -227,6 +228,7 @@ class TestCacheUtils:
         llm_stats = llm_stats_var.get()
         assert llm_stats is not None
         assert llm_stats.get_stat("total_calls") == 6
+        assert llm_stats.get_stat("cache_hits") == 1
         assert llm_stats.get_stat("total_time") == 1.5
         assert llm_stats.get_stat("total_tokens") == 300
 
@@ -295,6 +297,7 @@ class TestCacheUtils:
         llm_stats = llm_stats_var.get()
         assert llm_stats is not None
         assert llm_stats.get_stat("total_calls") == 1
+        assert llm_stats.get_stat("cache_hits") == 1
         assert llm_stats.get_stat("total_tokens") == 100
 
         updated_info = llm_call_info_var.get()


### PR DESCRIPTION
## Description

- add `cache_hits` counter to `LLMStats` so the processing summary shows how many calls were served from cache, e.g. `Stats: 5 total calls (3 from cache), ...`
- rename `LLM Stats:` label to `Stats:` in `generate_async` to align with `generate_events_async` and `process_events_async` which already use `Stats:`
- fix copy-paste bug in `get_from_cache_and_restore_stats` where `restore_llm_metadata_from_cache` was called 3 times instead of once

## Test plan

**Unit tests:**

Save the following script (cache_stats_display.py) and run it against the `nemoguards_cache` config:

```python
import asyncio
import logging

from nemoguardrails import LLMRails, RailsConfig

logging.basicConfig(level=logging.INFO)

config = RailsConfig.from_path("./examples/configs/nemoguards_cache")
rails = LLMRails(config=config, verbose=True)

caches = rails.runtime.registered_action_params.get("model_caches", {})
messages = [{"role": "user", "content": "What is the company policy on paid time off?"}]


async def main():
    print("\n========== REQUEST 1 (cold cache) ==========\n")
    await rails.generate_async(messages=messages)
    for name, cache in caches.items():
        print(f"  {name}: {cache.get_stats()}")

    print("\n========== REQUEST 2 (warm cache) ==========\n")
    await rails.generate_async(messages=messages)
    for name, cache in caches.items():
        print(f"  {name}: {cache.get_stats()}")


asyncio.run(main())
```

Then filter for the Stats line:
```
poetry run python cache_stats_display.py 2>&1 | grep "Stats:"
```
**Expected output:**
```
14:13:42.597 | Total processing took 6.35 seconds. Stats: 4 total calls, 6.08 total time, 2734 total tokens, 2333 total prompt tokens, 401 total completion tokens, [0.51, 0.29, 4.85, 0.43] as latencies
14:13:48.738 | Total processing took 6.14 seconds. Stats: 4 total calls (2 from cache), 6.07 total time, 2898 total tokens, 2415 total prompt tokens, 483 total completion tokens, [0.0, 0.0, 5.49, 0.59] as latencies
```

