### PR TITLE
fix(cache): make cache stats log visible in verbose mode

### DIFF
--- a/nemoguardrails/llm/cache/lfu.py
+++ b/nemoguardrails/llm/cache/lfu.py
@@ -315,7 +315,6 @@ class LFUCache(CacheInterface):
 
         # Format the log message
         log_msg = (
-            f"LFU Cache Statistics - "
             f"Size: {stats['current_size']}/{stats['maxsize']} | "
             f"Hits: {stats['hits']} | "
             f"Misses: {stats['misses']} | "
@@ -325,7 +324,7 @@ class LFUCache(CacheInterface):
             f"Updates: {stats['updates']}"
         )
 
-        log.info(log_msg)
+        log.info("Cache Stats :: %s", log_msg)
 
     def log_stats_now(self) -> None:
         """Force immediate logging of cache statistics."""

--- a/tests/test_cache_lfu.py
+++ b/tests/test_cache_lfu.py
@@ -396,10 +396,9 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
 
             # Verify log was called
             self.assertEqual(mock_log.call_count, 1)
-            log_message = mock_log.call_args[0][0]
+            self.assertEqual(mock_log.call_args[0][0], "Cache Stats :: %s")
+            log_message = mock_log.call_args[0][1]
 
-            # Check log format
-            self.assertIn("LFU Cache Statistics", log_message)
             self.assertIn("Size: 2/5", log_message)
             self.assertIn("Hits: 1", log_message)
             self.assertIn("Misses: 1", log_message)
@@ -456,7 +455,7 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
             cache.get("another_nonexistent")  # Trigger check
 
             self.assertEqual(mock_log.call_count, 1)
-            log_message = mock_log.call_args[0][0]
+            log_message = mock_log.call_args[0][1]
 
             self.assertIn("Size: 0/5", log_message)
             self.assertIn("Hits: 0", log_message)
@@ -481,7 +480,7 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
             time.sleep(0.2)
             cache.get("key4")  # Trigger check
 
-            log_message = mock_log.call_args[0][0]
+            log_message = mock_log.call_args[0][1]
             self.assertIn("Size: 3/3", log_message)
             self.assertIn("Evictions: 1", log_message)
             self.assertIn("Puts: 4", log_message)
@@ -504,7 +503,7 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
         with patch.object(logging.getLogger("nemoguardrails.llm.cache.lfu"), "info") as mock_log:
             cache.log_stats_now()
 
-            log_message = mock_log.call_args[0][0]
+            log_message = mock_log.call_args[0][1]
             self.assertIn("Hit Rate: 99.00%", log_message)
             self.assertIn("Hits: 99", log_message)
             self.assertIn("Misses: 1", log_message)
@@ -566,7 +565,7 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
         with patch.object(logging.getLogger("nemoguardrails.llm.cache.lfu"), "info") as mock_log:
             cache.log_stats_now()
 
-            log_message = mock_log.call_args[0][0]
+            log_message = mock_log.call_args[0][1]
             self.assertIn("Updates: 2", log_message)
             self.assertIn("Puts: 1", log_message)
 
@@ -603,7 +602,7 @@ class TestLFUCacheStatsLogging(unittest.TestCase):
                 cache.log_stats_now()
 
                 if hits > 0 or misses > 0:
-                    log_message = mock_log.call_args[0][0]
+                    log_message = mock_log.call_args[0][1]
                     self.assertIn(f"Hit Rate: {expected_rate}", log_message)
 
 


### PR DESCRIPTION
## Description
Fix cache stats periodic logging being silently dropped in verbose mode

## When cache stats logs will now appear

Cache stats logging is event driven, not timer driven. Logs appear when:
1. `stats.enabled: true` and `stats.log_interval` is set in config
2. cache operation (`get`/`put`) occurs AFTER `log_interval` seconds have elapsed since the last log

Logs will not appear during idle periods. This is by design
## Test plan

Save the following script as `test_cache_log_interval.py`:

```python
import asyncio
import logging
import time

from nemoguardrails import LLMRails, RailsConfig

logging.basicConfig(level=logging.INFO, format="%(message)s")
log = logging.getLogger(__name__)

config = RailsConfig.from_path("examples/configs/nemoguards_cache")
rails = LLMRails(config=config, verbose=True)

caches = rails.runtime.registered_action_params.get("model_caches", {})

for name, cache in caches.items():
    log.info("--- :: %s: log_interval=%s, track_stats=%s", name, cache.stats_logging_interval, cache.track_stats)
    cache.stats_logging_interval = 2

log.info("--- :: ")
messages = [{"role": "user", "content": "What is the company policy on paid time off?"}]


async def main():
    log.info("--- :: === REQUEST 1 (cold cache — initializes timer, no Cache Stats log) ===")
    await rails.generate_async(messages=messages)

    log.info("--- :: ")
    log.info("--- :: === REQUEST 2 immediately after (interval not elapsed, no Cache Stats log) ===")
    await rails.generate_async(messages=messages)

    log.info("--- :: ")
    log.info("--- :: === Sleep 3s then REQUEST 3 (interval elapsed — Cache Stats logs appear) ===")
    time.sleep(3)
    await rails.generate_async(messages=messages)

    log.info("--- :: ")
    log.info("--- :: === Sleep 5s, no request (no Cache Stats log — nobody calls get/put) ===")
    time.sleep(5)
    log.info("--- :: (silence — this is the bug)")


asyncio.run(main())
```

Then filter for key lines:

```bash
poetry run python test_cache_log_interval.py 2>&1 | grep -E "REQUEST|Cache Stats|silence|bug|Stats:"
```

**Expected output:**
```
14:38:14.342 | === REQUEST 1 (cold cache — initializes timer, no Cache Stats log) ===
14:38:19.517 | Cache Stats Size: 1/10000 | Hits: 0 | Misses: 1 | Hit Rate: 0.00% | Evictions: 0 | Puts: 1 | Updates: 0
14:38:19.996 | Total processing took 5.65 seconds. Stats: 4 total calls, 5.32 total time, 2726 total tokens, 2329 total prompt tokens, 397 total completion tokens, [0.3, 0.3, 4.26, 0.46] as latencies
14:38:19.996 | === REQUEST 2 immediately after (interval not elapsed, no Cache Stats log) ===
14:38:19.999 | Cache Stats Size: 1/10000 | Hits: 0 | Misses: 1 | Hit Rate: 0.00% | Evictions: 0 | Puts: 1 | Updates: 0
14:38:20.009 | Cache Stats Size: 1/10000 | Hits: 0 | Misses: 1 | Hit Rate: 0.00% | Evictions: 0 | Puts: 1 | Updates: 0
14:38:24.392 | Cache Stats Size: 2/10000 | Hits: 1 | Misses: 2 | Hit Rate: 33.33% | Evictions: 0 | Puts: 2 | Updates: 0
14:38:24.915 | Total processing took 4.92 seconds. Stats: 4 total calls (2 from cache), 4.84 total time, 2708 total tokens, 2320 total prompt tokens, 388 total completion tokens, [0.0, 0.0, 4.35, 0.49] as latencies
14:38:24.916 | === Sleep 3s then REQUEST 3 (interval elapsed — Cache Stats logs appear) ===
14:38:27.923 | Cache Stats Size: 1/10000 | Hits: 1 | Misses: 1 | Hit Rate: 50.00% | Evictions: 0 | Puts: 1 | Updates: 0
14:38:27.929 | Cache Stats Size: 3/10000 | Hits: 1 | Misses: 3 | Hit Rate: 25.00% | Evictions: 0 | Puts: 3 | Updates: 0
14:38:27.936 | Cache Stats Size: 1/10000 | Hits: 1 | Misses: 1 | Hit Rate: 50.00% | Evictions: 0 | Puts: 1 | Updates: 0
14:38:32.362 | Cache Stats Size: 3/10000 | Hits: 2 | Misses: 3 | Hit Rate: 40.00% | Evictions: 0 | Puts: 3 | Updates: 0
14:38:32.887 | Total processing took 4.97 seconds. Stats: 4 total calls (2 from cache), 4.92 total time, 2768 total tokens, 2350 total prompt tokens, 418 total completion tokens, [0.0, 0.0, 4.41, 0.51] as latencies
14:38:32.887 | === Sleep 5s, no request (no Cache Stats log — nobody calls get/put) ===
14:38:37.891 | (silence — this is the bug)
```
