### PR TITLE
chore(iorails): Increase work queue concurrency and depth

### DIFF
--- a/benchmark/Procfile
+++ b/benchmark/Procfile
@@ -1,7 +1,7 @@
 # Procfile
 
 # NeMo Guardrails server
-gr: poetry run nemoguardrails server --config ../examples/configs/content_safety_local --default-config-id content_safety_local --port 9000
+gr: MAIN_MODEL_ENGINE=nim MAIN_MODEL_BASE_URL=http://localhost:8000 poetry run nemoguardrails server --config ../examples/configs/content_safety_local --default-config-id content_safety_local --port 9000
 
 # Guardrails NIMs for inference. PYTHONPATH is set to the project root so absolute imports work
 app_llm: PYTHONPATH=.. python mock_llm_server/run_server.py --workers 4 --port 8000 --config-file mock_llm_server/configs/meta-llama-3.3-70b-instruct.env

--- a/benchmark/aiperf/configs/sweep_concurrency_benchmark.yaml
+++ b/benchmark/aiperf/configs/sweep_concurrency_benchmark.yaml
@@ -1,0 +1,38 @@
+# Concurrency sweep. One-minute tests at log-spaced concurrencies
+
+# Name for this batch of benchmarks (will be part of output directory name)
+batch_name: sweep_concurrency
+
+# Base directory where all benchmark results will be stored.
+# Actual name is <output_base_dir>/<batch_name>/<sweep value> for sweeps
+output_base_dir: aiperf_results
+
+# Base configuration applied to all benchmark runs
+# These parameters can be overridden by sweep parameters
+base_config:
+  # Model details
+  model: meta/llama-3.3-70b-instruct
+  tokenizer: meta-llama/Llama-3.3-70B-Instruct
+  url: "https://integrate.api.nvidia.com"
+  endpoint: "/v1/chat/completions"
+  endpoint_type: chat
+  api_key_env_var: NVIDIA_API_KEY
+
+  # Load generation settings.
+  warmup_request_count: 10
+  benchmark_duration: 60
+  concurrency: 0  # Overridden by the concurrency sweep below
+  request_rate_mode: "constant"
+
+  # Synthetic data generation
+  random_seed: 12345
+  prompt_input_tokens_mean: 100
+  prompt_input_tokens_stddev: 10
+  prompt_output_tokens_mean: 50
+  prompt_output_tokens_stddev: 5
+
+# Parameter sweeps. Each parameter can have multiple values
+# The script will run all combinations (Cartesian product)
+sweeps:
+  # Sweep over the following concurrency values
+  concurrency: [1, 2, 4]

--- a/benchmark/aiperf/configs/sweep_concurrency_benchmark.yaml
+++ b/benchmark/aiperf/configs/sweep_concurrency_benchmark.yaml
@@ -1,7 +1,7 @@
-# Concurrency sweep. One-minute tests at log-spaced concurrencies
+# Benchmarking AIPerf configuration to test locally-running Guardrails
 
 # Name for this batch of benchmarks (will be part of output directory name)
-batch_name: sweep_concurrency
+batch_name: sweep_concurrency_benchmark
 
 # Base directory where all benchmark results will be stored.
 # Actual name is <output_base_dir>/<batch_name>/<sweep value> for sweeps
@@ -13,10 +13,9 @@ base_config:
   # Model details
   model: meta/llama-3.3-70b-instruct
   tokenizer: meta-llama/Llama-3.3-70B-Instruct
-  url: "https://integrate.api.nvidia.com"
+  url: "http://localhost:9000"
   endpoint: "/v1/chat/completions"
   endpoint_type: chat
-  api_key_env_var: NVIDIA_API_KEY
 
   # Load generation settings.
   warmup_request_count: 10
@@ -35,4 +34,4 @@ base_config:
 # The script will run all combinations (Cartesian product)
 sweeps:
   # Sweep over the following concurrency values
-  concurrency: [1, 2, 4]
+  concurrency: [1, 2, 4, 8, 16, 32, 64, 128, 256]

--- a/benchmark/mock_llm_server/configs/nvidia-llama-3.1-nemoguard-8b-content-safety.env
+++ b/benchmark/mock_llm_server/configs/nvidia-llama-3.1-nemoguard-8b-content-safety.env
@@ -1,5 +1,5 @@
 MODEL="nvidia/llama-3.1-nemoguard-8b-content-safety"
-UNSAFE_PROBABILITY=0.03
+UNSAFE_PROBABILITY=0.0
 UNSAFE_TEXT="{\"User Safety\": \"unsafe\", \"Response Safety\": \"unsafe\", \"Safety Categories\": \"Violence, Criminal Planning/Confessions\"}"
 SAFE_TEXT="{\"User Safety\": \"safe\", \"Response Safety\": \"safe\"}"
 # End-to-end latency

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -36,8 +36,8 @@ from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
 
 # Queue configuration constants
-MAX_QUEUE_SIZE = 100
-MAX_CONCURRENCY = 10
+MAX_QUEUE_SIZE = 256
+MAX_CONCURRENCY = 256
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

This PR tunes the AsyncWorkQueue depth and max concurrency to give good out-of-the-box improvements on internal Guardrails latency. The results were generated using the tooling under benchmark and steps-to-reproduce and results are copied below. The `UNSAFE_PROBABILITY` of the content-safety Mock LLM was changed to 0% (i.e. 100% safe) so every request passes through two content safety checks (input and output) and a generation LLM  latency. 

The benchmarking isolates only the **internal Guardrails** latency by using Mock LLMs for both content-safety and application LLM. The content-safety has a fixed latency of 500ms, and application LLM is fixed at 4s. As every request is classified as safe, this means the lower-bound on end-to-end latency is 500ms (input content-safety rail) + 4000ms (app LLM end-to-end latency) + 500ms (output content-safety rail) = 5s.

### Mock-LLM only benchmarking

The table below shows end-to-end latency percentiles in milliseconds for only the Application Mock LLM itself (which has a configured latency of 4000ms). The latency values already have 4000ms subtracted, so this is the **incremental** latency on top of the configured latency. At a concurrency of 32, p50 and p99 latency are 12.33 and 27.03 respectively. 

<img width="576" height="292" alt="image" src="https://github.com/user-attachments/assets/2b850524-2574-4ded-8201-b97c1fea0cd9" />


### Baseline LLMRails benchmarking

The table below has the end-to-end latency results relative to the lower-bound of 5000ms (2 content-safety rails at 500ms each, with application LLM of 4000ms). The incremental latency at concurrency 32 is 1063ms and 1,257ms at p50 and p99 respectively. This shows the LLMRails internally adds a second or more to half of the requests at concurrency 32.

<img width="576" height="291" alt="image" src="https://github.com/user-attachments/assets/15b8d134-616c-4e05-9047-2600756e9e19" />


### IORails benchmarking

The table below shows end-to-end results for the new IORails engine introduced in v0.21. IORails doesn't support streaming in this release, so Time-To-First-Token and Inter-Token-Latency aren't measured. IORails is optimized purely for input and output rails, without support for dialog, retrieval, or execution rails. The benchmarking setup is identical to the LLMRails benchmark, except calls are routed to IORails using the `NEMO_GUARDRAILS_IORAILS_ENGINE=1` environment variable.

This table shows at a concurrency of 32, IORails reduces internal Guardrails p50 latency from 1063ms to 38ms (a 1.025s or 28x reduction) and p99 from 1257ms to 78ms (a 1.179s or 16x reduction). 

<img width="570" height="298" alt="image" src="https://github.com/user-attachments/assets/14c01cab-9937-472c-9305-e8051c0c7554" />


## Steps to reproduce

### Guardrails and Mock LLM terminal

To run with IORails, add `NEMO_GUARDRAILS_IORAILS_ENGINE=1` to the Guardrails invocation in line 4. This changes the [Procfile line](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/benchmark/Procfile#L4) from:

`gr: MAIN_MODEL_ENGINE=nim MAIN_MODEL_BASE_URL=http://localhost:8000 poetry run nemoguardrails server --config ../examples/configs/content_safety_local --default-config-id content_safety_local --port 9000`

to:

`gr: NEMO_GUARDRAILS_IORAILS_ENGINE=1 MAIN_MODEL_ENGINE=nim MAIN_MODEL_BASE_URL=http://localhost:8000 poetry run nemoguardrails server --config ../examples/configs/content_safety_local --default-config-id content_safety_local --port 9000`

Commands:

```shell
$ poetry install --with dev -E "server nvidia openai"
$ poetry run pip install honcho
$ cd benchmark
$ poetry run honcho start
...
14:44:21 app_llm.1 | INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
14:44:21 cs_llm.1  | INFO:     Uvicorn running on http://0.0.0.0:8001 (Press CTRL+C to quit)
14:44:31 gr.1      | INFO:     Uvicorn running on http://0.0.0.0:9000 (Press CTRL+C to quit)
```

### AIPerf terminal

Commands:

```shell
# Create the virtual environment if it doesn't exist
$ python -m venv benchmark_env
$ source benchmark_env/bin/activate
(benchmark_env) $ pip install -r benchmark/requirements.txt
(benchmark_env) $ python -m benchmark.aiperf --config-file benchmark/aiperf/configs/sweep_concurrency_benchmark.yaml
```



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
