### PR TITLE
docs: Update service docs with OpenAI details

### DIFF
--- a/docs/reference/api-server-endpoints/index.md
+++ b/docs/reference/api-server-endpoints/index.md
@@ -45,7 +45,7 @@ with guardrails-specific fields nested under a `guardrails` object.
   "temperature": 0.7,
   "max_tokens": 256,
   "guardrails": {
-    "config_id": "my-config",
+    "config_id": "my-config"
   }
 }
 ```
@@ -69,7 +69,7 @@ with guardrails-specific fields nested under a `guardrails` object.
 * - `messages`
   - array of objects
   - No
-  - The list of messages in the current conversation. Each message has `role` and `content` fields.
+  - The list of messages in the current conversation. Each message has `role` and `content` fields. Although the OpenAI API requires this field, the Guardrails server treats it as optional to support stateful continuation via `guardrails.state`. When omitted, defaults to an empty list.
 
 * - `stream`
   - boolean
@@ -555,10 +555,14 @@ curl http://localhost:8000/v1/models
   - Description
 
 * - 502
-  - The upstream provider is unreachable, `MAIN_MODEL_ENGINE` is unsupported, or `MAIN_MODEL_BASE_URL` is not set.
+  - The upstream provider is unreachable or returned an error.
 
 * - 4xx
   - Proxied from the upstream provider (e.g., 401 for an invalid API key).
+```
+
+```{note}
+If the engine is not in the built-in provider table and `MAIN_MODEL_BASE_URL` is not set, the endpoint returns an empty model list instead of an error.
 ```
 
 ### Example with OpenAI Python SDK

--- a/docs/reference/api-server-endpoints/index.md
+++ b/docs/reference/api-server-endpoints/index.md
@@ -20,6 +20,7 @@ For more information about server options, see [](../../run-rails/using-fastapi-
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/v1/chat/completions` | Generate a guarded chat completion |
+| `GET` | `/v1/models` | List available models from the configured provider |
 | `GET` | `/v1/rails/configs` | List available guardrails configurations |
 | `GET` | `/v1/challenges` | Get red teaming challenges |
 | `GET` | `/` | Chat UI (if enabled) or health status |
@@ -148,7 +149,7 @@ Guardrails-specific fields are nested under the `guardrails` object in the reque
 * - `guardrails.state`
   - object
   - No
-  - A state object to continue a previous interaction.
+  - A state object to continue a previous interaction. Must contain an `events` or `state` key, or be an empty dict `{}` to start a new conversation.
 ```
 
 ### Generation Options
@@ -478,6 +479,101 @@ print(response.choices[0].message.content)
 
 ---
 
+## GET /v1/models
+
+List the available LLM models from the configured upstream provider.
+This endpoint proxies the request to the provider specified by `MAIN_MODEL_ENGINE` and returns the results in the standard OpenAI models list format.
+
+For a guide on configuring providers, see [](../../run-rails/using-fastapi-server/list-models.md).
+
+### Request
+
+No request body or query parameters. The `Authorization` header, if present, is forwarded to the upstream provider.
+
+```bash
+curl http://localhost:8000/v1/models
+```
+
+### Response Body
+
+```json
+{
+  "data": [
+    {
+      "id": "meta/llama-3.1-8b-instruct",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "system"
+    },
+    {
+      "id": "meta/llama-3.1-70b-instruct",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "system"
+    }
+  ]
+}
+```
+
+#### Response Fields
+
+```{list-table}
+:header-rows: 1
+:widths: 20 15 65
+
+* - Field
+  - Type
+  - Description
+
+* - `data`
+  - array
+  - List of model objects.
+
+* - `data[].id`
+  - string
+  - The model identifier (e.g., `"gpt-4o"`, `"meta/llama-3.1-8b-instruct"`).
+
+* - `data[].object`
+  - string
+  - Always `"model"`.
+
+* - `data[].created`
+  - integer
+  - Unix timestamp of the model's creation.
+
+* - `data[].owned_by`
+  - string
+  - The organization that owns the model.
+```
+
+#### Error Responses
+
+```{list-table}
+:header-rows: 1
+:widths: 15 85
+
+* - Status
+  - Description
+
+* - 502
+  - The upstream provider is unreachable, `MAIN_MODEL_ENGINE` is unsupported, or `MAIN_MODEL_BASE_URL` is not set.
+
+* - 4xx
+  - Proxied from the upstream provider (e.g., 401 for an invalid API key).
+```
+
+### Example with OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-used")
+for model in client.models.list().data:
+    print(model.id)
+```
+
+---
+
 ## GET /v1/rails/configs
 
 List all available guardrails configurations.
@@ -601,6 +697,16 @@ When `thread_id` is less than 16 characters:
 }
 ```
 
+### Invalid State Format
+
+When the `guardrails.state` object does not contain an `events` or `state` key, the server returns an HTTP 422 error:
+
+```json
+{
+  "detail": "Invalid state format: state must contain 'events' or 'state' key. Use an empty dict {} to start a new conversation."
+}
+```
+
 ### Internal Server Error
 
 ```json
@@ -650,7 +756,7 @@ The server supports the following environment variables:
   - Default guardrails configuration ID when none is specified in the request.
 
 * - `MAIN_MODEL_ENGINE`
-  - The LLM engine to use when the `model` field is specified in the request (e.g., `"openai"`, `"nim"`, `"vllm"`, `"anthropic"`). Default: `"openai"`.
+  - The LLM engine to use when the `model` field is specified in the request (e.g., `"openai"`, `"nim"`, `"vllm"`, `"anthropic"`, `"azure"` or `"azure_openai"`, `"cohere"`). Default: `"openai"`.
 
 * - `MAIN_MODEL_BASE_URL`
   - Base URL for the LLM provider when the `model` field is specified in the request. Useful for self-hosted models (e.g., `"http://localhost:8080/v1"`).
@@ -660,6 +766,24 @@ The server supports the following environment variables:
 
 * - `NVIDIA_API_KEY`
   - API key for NVIDIA-hosted models on build.nvidia.com.
+
+* - `ANTHROPIC_API_KEY`
+  - API key for Anthropic models. Used when `MAIN_MODEL_ENGINE` is `"anthropic"`.
+
+* - `AZURE_OPENAI_API_KEY`
+  - API key for Azure OpenAI. Used when `MAIN_MODEL_ENGINE` is `"azure"` or `"azure_openai"`.
+
+* - `AZURE_OPENAI_ENDPOINT`
+  - Azure OpenAI resource endpoint URL (e.g., `"https://your-resource.openai.azure.com"`). Required when `MAIN_MODEL_ENGINE` is `"azure"`.
+
+* - `AZURE_OPENAI_API_VERSION`
+  - Azure OpenAI API version. Default: `"2024-06-01"`.
+
+* - `COHERE_API_KEY`
+  - API key for Cohere models. Used when `MAIN_MODEL_ENGINE` is `"cohere"`.
+
+* - `COHERE_BASE_URL`
+  - Override the Cohere API base URL. Default: `"https://api.cohere.com"`.
 
 * - `NEMO_GUARDRAILS_SERVER_ENABLE_CORS`
   - Set to `"true"` to enable CORS. Default: `"false"`.

--- a/docs/reference/api-server-endpoints/index.md
+++ b/docs/reference/api-server-endpoints/index.md
@@ -46,7 +46,6 @@ with guardrails-specific fields nested under a `guardrails` object.
   "max_tokens": 256,
   "guardrails": {
     "config_id": "my-config",
-    "options": {}
   }
 }
 ```
@@ -274,7 +273,7 @@ The response follows the standard OpenAI `ChatCompletion` format with an additio
 {
   "id": "chatcmpl-abc123",
   "object": "chat.completion",
-  "created": 1700000000,
+  "created": 1709424000,
   "model": "meta/llama-3.1-8b-instruct",
   "choices": [
     {

--- a/docs/reference/api-server-endpoints/index.md
+++ b/docs/reference/api-server-endpoints/index.md
@@ -1,6 +1,7 @@
 # NeMo Guardrails Library API Server Endpoints Reference
 
 This reference documents the REST API endpoints provided by the NeMo Guardrails library API server.
+The server exposes an OpenAI-compatible Chat Completions API with additional guardrails-specific extensions.
 
 ## Starting the Server
 
@@ -28,21 +29,28 @@ For more information about server options, see [](../../run-rails/using-fastapi-
 ## POST /v1/chat/completions
 
 Generate a chat completion with guardrails applied.
+The request and response formats are compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create),
+with guardrails-specific fields nested under a `guardrails` object.
 
 ### Request Body
 
 ```json
 {
-  "config_id": "my-config",
+  "model": "meta/llama-3.1-8b-instruct",
   "messages": [
     {"role": "user", "content": "Hello, how are you?"}
   ],
   "stream": false,
-  "options": {}
+  "temperature": 0.7,
+  "max_tokens": 256,
+  "guardrails": {
+    "config_id": "my-config",
+    "options": {}
+  }
 }
 ```
 
-#### Request Fields
+#### OpenAI Fields
 
 ```{list-table}
 :header-rows: 1
@@ -53,42 +61,91 @@ Generate a chat completion with guardrails applied.
   - Required
   - Description
 
-* - `config_id`
+* - `model`
   - string
-  - No
-  - The ID of the configuration to use. If not set, uses the server's default configuration.
-
-* - `config_ids`
-  - array of strings
-  - No
-  - List of configuration IDs to combine. Mutually exclusive with `config_id`.
+  - **Yes**
+  - The LLM model to use for chat completion (e.g., `"meta/llama-3.1-8b-instruct"`, `"gpt-4o"`).
 
 * - `messages`
   - array of objects
   - No
   - The list of messages in the current conversation. Each message has `role` and `content` fields.
 
-* - `thread_id`
-  - string
-  - No
-  - ID of an existing thread for conversation persistence. Must be 16-255 characters.
-
-* - `context`
-  - object
-  - No
-  - Additional context data to add to the conversation.
-
 * - `stream`
   - boolean
   - No
   - If `true`, returns partial message deltas as server-sent events. Default: `false`.
 
-* - `options`
+* - `max_tokens`
+  - integer
+  - No
+  - The maximum number of tokens to generate.
+
+* - `temperature`
+  - float
+  - No
+  - Sampling temperature (0-2). Higher values make output more random.
+
+* - `top_p`
+  - float
+  - No
+  - Top-p (nucleus) sampling parameter.
+
+* - `stop`
+  - string or array
+  - No
+  - Stop sequence(s) where the model stops generating.
+
+* - `presence_penalty`
+  - float
+  - No
+  - Presence penalty parameter (-2.0 to 2.0).
+
+* - `frequency_penalty`
+  - float
+  - No
+  - Frequency penalty parameter (-2.0 to 2.0).
+```
+
+#### Guardrails Fields
+
+Guardrails-specific fields are nested under the `guardrails` object in the request body.
+
+```{list-table}
+:header-rows: 1
+:widths: 20 15 10 55
+
+* - Field
+  - Type
+  - Required
+  - Description
+
+* - `guardrails.config_id`
+  - string
+  - No
+  - The ID of the guardrails configuration to use. If not set, uses the server's default configuration. Mutually exclusive with `config_ids`.
+
+* - `guardrails.config_ids`
+  - array of strings
+  - No
+  - List of configuration IDs to combine. Mutually exclusive with `config_id`.
+
+* - `guardrails.thread_id`
+  - string
+  - No
+  - ID of an existing thread for conversation persistence. Must be 16-255 characters.
+
+* - `guardrails.context`
+  - object
+  - No
+  - Additional context data to add to the conversation.
+
+* - `guardrails.options`
   - object
   - No
   - Additional options for controlling the generation. See [Generation Options](#generation-options).
 
-* - `state`
+* - `guardrails.state`
   - object
   - No
   - A state object to continue a previous interaction.
@@ -96,25 +153,28 @@ Generate a chat completion with guardrails applied.
 
 ### Generation Options
 
-The `options` field controls which rails are applied and what information is returned.
+The `guardrails.options` field controls which rails are applied and what information is returned.
 
 ```json
 {
-  "options": {
-    "rails": {
-      "input": true,
-      "output": true,
-      "dialog": true,
-      "retrieval": true
-    },
-    "llm_params": {
-      "temperature": 0.7
-    },
-    "llm_output": false,
-    "output_vars": ["relevant_chunks"],
-    "log": {
-      "activated_rails": true,
-      "llm_calls": false
+  "guardrails": {
+    "config_id": "my-config",
+    "options": {
+      "rails": {
+        "input": true,
+        "output": true,
+        "dialog": true,
+        "retrieval": true
+      },
+      "llm_params": {
+        "temperature": 0.7
+      },
+      "llm_output": false,
+      "output_vars": ["relevant_chunks"],
+      "log": {
+        "activated_rails": true,
+        "llm_calls": false
+      }
     }
   }
 }
@@ -207,15 +267,31 @@ The `options` field controls which rails are applied and what information is ret
 
 ### Response Body
 
+The response follows the standard OpenAI `ChatCompletion` format with an additional `guardrails` object.
+
 ```json
 {
-  "messages": [
-    {"role": "assistant", "content": "I'm doing well, thank you!"}
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "meta/llama-3.1-8b-instruct",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I'm doing well, thank you!"
+      },
+      "finish_reason": "stop"
+    }
   ],
-  "llm_output": null,
-  "output_data": null,
-  "log": null,
-  "state": null
+  "guardrails": {
+    "config_id": "content_safety",
+    "llm_output": null,
+    "output_data": null,
+    "log": null,
+    "state": null
+  }
 }
 ```
 
@@ -229,25 +305,60 @@ The `options` field controls which rails are applied and what information is ret
   - Type
   - Description
 
-* - `messages`
-  - array of objects
-  - The new messages in the conversation (typically the assistant's response).
+* - `id`
+  - string
+  - A unique identifier for the chat completion (e.g., `"chatcmpl-abc123"`).
 
-* - `llm_output`
-  - object
-  - Additional output from the LLM. Only included if `options.llm_output` is `true`.
+* - `object`
+  - string
+  - Always `"chat.completion"`.
 
-* - `output_data`
-  - object
-  - Values for requested output variables. Only included if `options.output_vars` is set.
+* - `created`
+  - integer
+  - Unix timestamp of when the completion was created.
 
-* - `log`
-  - object
-  - Logging information based on `options.log` settings.
+* - `model`
+  - string
+  - The model used for the completion.
 
-* - `state`
+* - `choices`
+  - array
+  - Array of completion choices. Each choice contains `index`, `message` (with `role` and `content`), and `finish_reason`.
+
+* - `guardrails`
   - object
-  - State object for continuing the interaction in future requests.
+  - Guardrails-specific output data. See below.
+```
+
+#### Guardrails Response Fields
+
+```{list-table}
+:header-rows: 1
+:widths: 20 15 65
+
+* - Field
+  - Type
+  - Description
+
+* - `guardrails.config_id`
+  - string
+  - The guardrails configuration ID associated with this response.
+
+* - `guardrails.state`
+  - object
+  - State object for continuing the conversation in future requests.
+
+* - `guardrails.llm_output`
+  - object
+  - Additional LLM output data. Only included if `guardrails.options.llm_output` was `true`.
+
+* - `guardrails.output_data`
+  - object
+  - Values for requested output variables. Only included if `guardrails.options.output_vars` was set.
+
+* - `guardrails.log`
+  - object
+  - Logging information based on `guardrails.options.log` settings.
 ```
 
 ### Examples
@@ -258,10 +369,13 @@ The `options` field controls which rails are applied and what information is ret
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
       {"role": "user", "content": "What is the capital of France?"}
-    ]
+    ],
+    "guardrails": {
+      "config_id": "content_safety"
+    }
   }'
 ```
 
@@ -271,12 +385,25 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
       {"role": "user", "content": "Tell me a story"}
     ],
-    "stream": true
+    "stream": true,
+    "guardrails": {
+      "config_id": "content_safety"
+    }
   }'
+```
+
+Streaming responses use Server-Sent Events (SSE). Each chunk is a `chat.completion.chunk` object:
+
+```text
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"meta/llama-3.1-8b-instruct","choices":[{"delta":{"content":"Once"},"index":0,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"meta/llama-3.1-8b-instruct","choices":[{"delta":{"content":" upon"},"index":0,"finish_reason":null}]}
+
+data: [DONE]
 ```
 
 #### Request with Specific Rails
@@ -285,15 +412,18 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
       {"role": "user", "content": "Hello"}
     ],
-    "options": {
-      "rails": {
-        "input": ["check jailbreak"],
-        "output": false,
-        "dialog": false
+    "guardrails": {
+      "config_id": "content_safety",
+      "options": {
+        "rails": {
+          "input": ["check jailbreak"],
+          "output": false,
+          "dialog": false
+        }
       }
     }
   }'
@@ -305,17 +435,45 @@ curl -X POST http://localhost:8000/v1/chat/completions \
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
       {"role": "user", "content": "Hello"}
     ],
-    "options": {
-      "log": {
-        "activated_rails": true,
-        "llm_calls": true
+    "guardrails": {
+      "config_id": "content_safety",
+      "options": {
+        "log": {
+          "activated_rails": true,
+          "llm_calls": true
+        }
       }
     }
   }'
+```
+
+#### Request with OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="not-used"
+)
+
+response = client.chat.completions.create(
+    model="meta/llama-3.1-8b-instruct",
+    messages=[
+        {"role": "user", "content": "What is the capital of France?"}
+    ],
+    extra_body={
+        "guardrails": {
+            "config_id": "content_safety"
+        }
+    }
+)
+
+print(response.choices[0].message.content)
 ```
 
 ---
@@ -382,18 +540,38 @@ Root endpoint that serves the Chat UI or returns a health status.
 
 ## Error Responses
 
+Errors from the chat completions endpoint are returned as `ChatCompletion` objects with the error message in the assistant's content, or as HTTP exceptions.
+
 ### Configuration Error
 
-When no configuration is provided and no default is set:
+When the guardrails configuration cannot be loaded:
 
 ```json
 {
-  "messages": [
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "meta/llama-3.1-8b-instruct",
+  "choices": [
     {
-      "role": "assistant",
-      "content": "Could not load the [config_id] guardrails configuration. An internal error has occurred."
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Could not load the ['my-config'] guardrails configuration. An internal error has occurred."
+      },
+      "finish_reason": "stop"
     }
   ]
+}
+```
+
+### Missing Configuration
+
+When no `config_id` is provided and no default is set, the server returns an HTTP 422 error:
+
+```json
+{
+  "detail": "No guardrails config_id provided and server has no default configuration"
 }
 ```
 
@@ -403,12 +581,23 @@ When `thread_id` is less than 16 characters:
 
 ```json
 {
-  "messages": [
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "meta/llama-3.1-8b-instruct",
+  "choices": [
     {
-      "role": "assistant",
-      "content": "The `thread_id` must have a minimum length of 16 characters."
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The `thread_id` must have a minimum length of 16 characters."
+      },
+      "finish_reason": "stop"
     }
-  ]
+  ],
+  "guardrails": {
+    "config_id": "my-config"
+  }
 }
 ```
 
@@ -416,13 +605,32 @@ When `thread_id` is less than 16 characters:
 
 ```json
 {
-  "messages": [
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "meta/llama-3.1-8b-instruct",
+  "choices": [
     {
-      "role": "assistant",
-      "content": "Internal server error."
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Internal server error"
+      },
+      "finish_reason": "stop"
     }
-  ]
+  ],
+  "guardrails": {
+    "config_id": "my-config"
+  }
 }
+```
+
+### Streaming Errors
+
+During streaming, errors are sent as SSE events with an `error` object:
+
+```text
+data: {"error": {"message": "...", "type": "...", "param": "...", "code": "..."}}
 ```
 
 ---
@@ -439,7 +647,19 @@ The server supports the following environment variables:
   - Description
 
 * - `DEFAULT_CONFIG_ID`
-  - Default configuration ID when none is specified in the request.
+  - Default guardrails configuration ID when none is specified in the request.
+
+* - `MAIN_MODEL_ENGINE`
+  - The LLM engine to use when the `model` field is specified in the request (e.g., `"openai"`, `"nim"`, `"vllm"`, `"anthropic"`). Default: `"openai"`.
+
+* - `MAIN_MODEL_BASE_URL`
+  - Base URL for the LLM provider when the `model` field is specified in the request. Useful for self-hosted models (e.g., `"http://localhost:8080/v1"`).
+
+* - `OPENAI_API_KEY`
+  - API key for OpenAI models.
+
+* - `NVIDIA_API_KEY`
+  - API key for NVIDIA-hosted models on build.nvidia.com.
 
 * - `NEMO_GUARDRAILS_SERVER_ENABLE_CORS`
   - Set to `"true"` to enable CORS. Default: `"false"`.

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
@@ -71,7 +71,7 @@ The response follows the standard OpenAI `ChatCompletion` format, with an additi
 The `guardrails` response object may include additional fields depending on your request options:
 
 - **`state`** — State object for continuing the conversation. Return this in subsequent requests to resume.
-- **`llm_output`** — Additional LLM output data (when `options.llm_output` is `true`).
+- **`llm_output`** — Additional LLM output data (when `guardrails.options.llm_output` is `true`).
 - **`output_data`** — Values for requested context variables (when `guardrails.options.output_vars` is set).
 - **`log`** — Logging information (when `guardrails.options.log` is configured).
 

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
@@ -72,8 +72,8 @@ The `guardrails` response object may include additional fields depending on your
 
 - **`state`** — State object for continuing the conversation. Return this in subsequent requests to resume.
 - **`llm_output`** — Additional LLM output data (when `options.llm_output` is `true`).
-- **`output_data`** — Values for requested context variables (when `options.output_vars` is set).
-- **`log`** — Logging information (when `options.log` is configured).
+- **`output_data`** — Values for requested context variables (when `guardrails.options.output_vars` is set).
+- **`log`** — Logging information (when `guardrails.options.log` is configured).
 
 ## Using the OpenAI Python SDK
 

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
@@ -59,10 +59,21 @@ The response follows the standard OpenAI `ChatCompletion` format, with an additi
     }
   ],
   "guardrails": {
-    "config_id": "content_safety"
+    "config_id": "content_safety",
+    "state": null,
+    "llm_output": null,
+    "output_data": null,
+    "log": null
   }
 }
 ```
+
+The `guardrails` response object may include additional fields depending on your request options:
+
+- **`state`** — State object for continuing the conversation. Return this in subsequent requests to resume.
+- **`llm_output`** — Additional LLM output data (when `options.llm_output` is `true`).
+- **`output_data`** — Values for requested context variables (when `options.output_vars` is set).
+- **`log`** — Logging information (when `options.log` is configured).
 
 ## Using the OpenAI Python SDK
 
@@ -114,7 +125,8 @@ print(response.json())
 
 ## Combine Multiple Configurations
 
-You can combine multiple guardrails configurations in a single request using `config_ids` inside the `guardrails` object:
+You can combine multiple guardrails configurations in a single request using `config_ids` inside the `guardrails` object.
+Use either `config_id` or `config_ids`, but not both — they are mutually exclusive.
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
@@ -271,7 +283,7 @@ Use `thread_id` inside the `guardrails` object to maintain conversation history 
 This is useful when you can only send the latest message rather than the full history.
 
 ```{tip}
-The `thread_id` must be at least 16 characters long for security reasons.
+The `thread_id` must be between 16 and 255 characters long.
 ```
 
 ```python
@@ -369,7 +381,36 @@ response = requests.post(f"{base_url}/v1/chat/completions", json={
 })
 ```
 
-You can also pass standard OpenAI parameters such as `temperature`, `max_tokens`, and `top_p` at the top level:
+### Continue with State
+
+To continue a conversation using the `state` object returned in a previous response, pass it back in the `guardrails.state` field.
+The state object must contain an `events` or `state` key. Use an empty dict `{}` to start a new conversation.
+
+```python
+# First request
+response = requests.post(f"{base_url}/v1/chat/completions", json={
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "guardrails": {
+        "config_id": "content_safety"
+    }
+})
+state = response.json().get("guardrails", {}).get("state")
+
+# Continue with state
+response = requests.post(f"{base_url}/v1/chat/completions", json={
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "Tell me more"}],
+    "guardrails": {
+        "config_id": "content_safety",
+        "state": state
+    }
+})
+```
+
+### Standard OpenAI Parameters
+
+You can also pass standard OpenAI parameters such as `temperature`, `max_tokens`, `top_p`, `stop`, `presence_penalty`, and `frequency_penalty` at the top level:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
@@ -85,7 +85,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:8000/v1",
-    api_key="not-used"  # Required by the SDK but not used by the guardrails server
+    api_key="not-used"  # Required by OpenAI SDK but not used by the guardrails server
 )
 
 response = client.chat.completions.create(
@@ -377,33 +377,6 @@ response = requests.post(f"{base_url}/v1/chat/completions", json={
                 "activated_rails": True
             }
         }
-    }
-})
-```
-
-### Continue with State
-
-To continue a conversation using the `state` object returned in a previous response, pass it back in the `guardrails.state` field.
-The state object must contain an `events` or `state` key. Use an empty dict `{}` to start a new conversation.
-
-```python
-# First request
-response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "model": "meta/llama-3.1-8b-instruct",
-    "messages": [{"role": "user", "content": "Hello"}],
-    "guardrails": {
-        "config_id": "content_safety"
-    }
-})
-state = response.json().get("guardrails", {}).get("state")
-
-# Continue with state
-response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "model": "meta/llama-3.1-8b-instruct",
-    "messages": [{"role": "user", "content": "Tell me more"}],
-    "guardrails": {
-        "config_id": "content_safety",
-        "state": state
     }
 })
 ```

--- a/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
+++ b/docs/run-rails/using-fastapi-server/chat-with-guardrailed-model.md
@@ -3,7 +3,7 @@ title:
   page: "Chat with Guardrailed Model"
   nav: "Chat Completions"
 description: "Send chat requests, use streaming, and manage conversation threads."
-keywords: ["chat completions", "guardrails API", "streaming responses", "conversation threads", "config_id"]
+keywords: ["chat completions", "guardrails API", "streaming responses", "conversation threads", "config_id", "OpenAI compatible"]
 topics: ["generative_ai", "developer_tools"]
 tags: ["llms", "ai_inference", "ai_platforms"]
 content:
@@ -15,40 +15,84 @@ content:
 # Chat with Guardrailed Model
 
 Use the `/v1/chat/completions` endpoint to send messages and receive guarded responses from the server.
-
-:::{note}
-While the endpoint is in the same format as the OpenAI's chat completions API endpoint, it is currently not compatible with the OpenAI API.
-:::
+The endpoint is compatible with the [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat/create),
+with additional guardrails-specific fields nested under a `guardrails` object.
 
 ## Basic Request
 
-Send a POST request to the chat completions endpoint:
+Send a POST request to the chat completions endpoint.
+The `model` field is required and specifies which LLM to use.
+Guardrails-specific fields such as `config_id` are nested under the `guardrails` object.
 
 ```bash
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
       {"role": "user", "content": "Hello! What can you do for me?"}
-    ]
+    ],
+    "guardrails": {
+      "config_id": "content_safety"
+    }
   }'
 ```
 
 ### Response
 
+The response follows the standard OpenAI `ChatCompletion` format, with an additional `guardrails` object containing guardrails-specific output data.
+
 ```json
 {
-  "messages": [
+  "id": "chatcmpl-abc123",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "meta/llama-3.1-8b-instruct",
+  "choices": [
     {
-      "role": "assistant",
-      "content": "I can help you with your questions. What would you like to know?"
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I can help you with your questions. What would you like to know?"
+      },
+      "finish_reason": "stop"
     }
-  ]
+  ],
+  "guardrails": {
+    "config_id": "content_safety"
+  }
 }
 ```
 
-## Using Python
+## Using the OpenAI Python SDK
+
+Since the server is OpenAI-compatible, you can use the [OpenAI Python SDK](https://github.com/openai/openai-python) to interact with it.
+Pass guardrails-specific fields using the `extra_body` parameter.
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="not-used"  # Required by the SDK but not used by the guardrails server
+)
+
+response = client.chat.completions.create(
+    model="meta/llama-3.1-8b-instruct",
+    messages=[
+        {"role": "user", "content": "Hello! What can you do for me?"}
+    ],
+    extra_body={
+        "guardrails": {
+            "config_id": "content_safety"
+        }
+    }
+)
+
+print(response.choices[0].message.content)
+```
+
+## Using Python Requests
 
 ```python
 import requests
@@ -56,10 +100,13 @@ import requests
 base_url = "http://localhost:8000"
 
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
         {"role": "user", "content": "Hello! What can you do for me?"}
-    ]
+    ],
+    "guardrails": {
+        "config_id": "content_safety"
+    }
 })
 
 print(response.json())
@@ -67,14 +114,17 @@ print(response.json())
 
 ## Combine Multiple Configurations
 
-You can combine multiple guardrails configurations in a single request using `config_ids`:
+You can combine multiple guardrails configurations in a single request using `config_ids` inside the `guardrails` object:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_ids": ["main", "input_checking", "output_checking"],
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
         {"role": "user", "content": "Hello!"}
-    ]
+    ],
+    "guardrails": {
+        "config_ids": ["main", "input_checking", "output_checking"]
+    }
 })
 ```
 
@@ -97,10 +147,13 @@ Create reusable *atomic configurations* that you can combine as needed:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "main",
-    "messages": [{"role": "user", "content": "You are stupid."}]
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "You are stupid."}],
+    "guardrails": {
+        "config_id": "main"
+    }
 })
-print(response.json())
+print(response.json()["choices"][0]["message"]["content"])
 # LLM responds to the message
 ```
 
@@ -108,21 +161,25 @@ print(response.json())
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_ids": ["main", "input_checking"],
-    "messages": [{"role": "user", "content": "You are stupid."}]
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "You are stupid."}],
+    "guardrails": {
+        "config_ids": ["main", "input_checking"]
+    }
 })
-print(response.json())
-# {"messages": [{"role": "assistant", "content": "I'm sorry, I can't respond to that."}]}
+print(response.json()["choices"][0]["message"]["content"])
+# "I'm sorry, I can't respond to that."
 ```
 
 The input rail blocks the inappropriate message before it reaches the LLM.
 
 ## Use the Default Configuration
 
-If the server was started with `--default-config-id`, you can omit the configuration:
+If the server was started with `--default-config-id`, you can omit the `guardrails` object:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [
         {"role": "user", "content": "Hello!"}
     ]
@@ -131,7 +188,61 @@ response = requests.post(f"{base_url}/v1/chat/completions", json={
 
 ## Streaming Responses
 
-Enable streaming to receive partial responses as they are generated:
+Enable streaming to receive partial responses as server-sent events (SSE).
+Each chunk follows the OpenAI streaming format.
+
+### Using curl
+
+```bash
+curl -X POST http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "Tell me a story"}],
+    "stream": true,
+    "guardrails": {
+      "config_id": "content_safety"
+    }
+  }'
+```
+
+The server sends chunks in SSE format:
+
+```text
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"meta/llama-3.1-8b-instruct","choices":[{"delta":{"content":"Once"},"index":0,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1700000000,"model":"meta/llama-3.1-8b-instruct","choices":[{"delta":{"content":" upon"},"index":0,"finish_reason":null}]}
+
+data: [DONE]
+```
+
+### Using the OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="not-used"
+)
+
+stream = client.chat.completions.create(
+    model="meta/llama-3.1-8b-instruct",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+    extra_body={
+        "guardrails": {
+            "config_id": "content_safety"
+        }
+    }
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content is not None:
+        print(chunk.choices[0].delta.content, end="")
+```
+
+### Using Python Requests
 
 ```python
 import requests
@@ -139,9 +250,12 @@ import requests
 response = requests.post(
     f"{base_url}/v1/chat/completions",
     json={
-        "config_id": "content_safety",
+        "model": "meta/llama-3.1-8b-instruct",
         "messages": [{"role": "user", "content": "Tell me a story"}],
-        "stream": True
+        "stream": True,
+        "guardrails": {
+            "config_id": "content_safety"
+        }
     },
     stream=True
 )
@@ -153,7 +267,7 @@ for line in response.iter_lines():
 
 ## Conversation Threads
 
-Use `thread_id` to maintain conversation history on the server.
+Use `thread_id` inside the `guardrails` object to maintain conversation history on the server.
 This is useful when you can only send the latest message rather than the full history.
 
 ```{tip}
@@ -163,16 +277,22 @@ The `thread_id` must be at least 16 characters long for security reasons.
 ```python
 # First message
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "content_safety",
-    "thread_id": "user-session-12345678",
-    "messages": [{"role": "user", "content": "My name is Alice."}]
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "My name is Alice."}],
+    "guardrails": {
+        "config_id": "content_safety",
+        "thread_id": "user-session-12345678"
+    }
 })
 
 # Follow-up message (server remembers the conversation)
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "content_safety",
-    "thread_id": "user-session-12345678",
-    "messages": [{"role": "user", "content": "What is my name?"}]
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "What is my name?"}],
+    "guardrails": {
+        "config_id": "content_safety",
+        "thread_id": "user-session-12345678"
+    }
 })
 # The assistant remembers "Alice"
 ```
@@ -209,36 +329,56 @@ To use `RedisStore`, install `aioredis >= 2.0.1`.
 
 ## Add Context
 
-Include additional context data in your request:
+Include additional context data in your request using the `context` field inside the `guardrails` object:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [{"role": "user", "content": "What is my account balance?"}],
-    "context": {
-        "user_id": "12345",
-        "account_type": "premium"
+    "guardrails": {
+        "config_id": "content_safety",
+        "context": {
+            "user_id": "12345",
+            "account_type": "premium"
+        }
     }
 })
 ```
 
 ## Control Generation Options
 
-Use the `options` field to control which rails are applied and what information is returned:
+Use the `options` field inside the `guardrails` object to control which rails are applied and what information is returned:
 
 ```python
 response = requests.post(f"{base_url}/v1/chat/completions", json={
-    "config_id": "content_safety",
+    "model": "meta/llama-3.1-8b-instruct",
     "messages": [{"role": "user", "content": "Hello"}],
-    "options": {
-        "rails": {
-            "input": True,
-            "output": True,
-            "dialog": False
-        },
-        "log": {
-            "activated_rails": True
+    "guardrails": {
+        "config_id": "content_safety",
+        "options": {
+            "rails": {
+                "input": True,
+                "output": True,
+                "dialog": False
+            },
+            "log": {
+                "activated_rails": True
+            }
         }
+    }
+})
+```
+
+You can also pass standard OpenAI parameters such as `temperature`, `max_tokens`, and `top_p` at the top level:
+
+```python
+response = requests.post(f"{base_url}/v1/chat/completions", json={
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "temperature": 0.7,
+    "max_tokens": 256,
+    "guardrails": {
+        "config_id": "content_safety"
     }
 })
 ```

--- a/docs/run-rails/using-fastapi-server/index.md
+++ b/docs/run-rails/using-fastapi-server/index.md
@@ -56,6 +56,15 @@ Retrieve available guardrails configurations from the server.
 {bdg-secondary}`Reference`
 :::
 
+:::{grid-item-card} List Models
+:link: list-models
+:link-type: doc
+
+Query the available LLM models from the configured provider.
++++
+{bdg-secondary}`Reference`
+:::
+
 :::{grid-item-card} Actions Server
 :link: actions-server
 :link-type: doc
@@ -74,5 +83,6 @@ Overview <overview>
 Run the Server <run-guardrails-server>
 Chat Completions <chat-with-guardrailed-model>
 List Configurations <list-guardrail-configs>
+List Models <list-models>
 Actions Server <actions-server>
 ```

--- a/docs/run-rails/using-fastapi-server/list-guardrail-configs.md
+++ b/docs/run-rails/using-fastapi-server/list-guardrail-configs.md
@@ -72,8 +72,11 @@ if configs:
     config_id = configs[0]["id"]
 
     response = requests.post(f"{base_url}/v1/chat/completions", json={
-        "config_id": config_id,
-        "messages": [{"role": "user", "content": "Hello!"}]
+        "model": "meta/llama-3.1-8b-instruct",
+        "messages": [{"role": "user", "content": "Hello!"}],
+        "guardrails": {
+            "config_id": config_id
+        }
     })
     print(response.json())
 ```

--- a/docs/run-rails/using-fastapi-server/list-models.md
+++ b/docs/run-rails/using-fastapi-server/list-models.md
@@ -1,0 +1,167 @@
+---
+title:
+  page: "List Available Models"
+  nav: "List Models"
+description: "Query the available LLM models from the configured provider."
+keywords: ["list models", "guardrails API", "OpenAI compatible", "model discovery", "v1/models"]
+topics: ["generative_ai", "developer_tools"]
+tags: ["llms", "ai_inference", "ai_platforms"]
+content:
+  type: reference
+  difficulty: technical_intermediate
+  audience: ["data_scientist", "engineer"]
+---
+
+# List Available Models
+
+Use the `GET /v1/models` endpoint to retrieve the list of LLM models available from the configured provider.
+This endpoint is compatible with the [OpenAI Models API](https://platform.openai.com/docs/api-reference/models/list)
+and proxies the request to the upstream model provider configured via environment variables.
+
+## Request
+
+```bash
+curl http://localhost:8000/v1/models
+```
+
+No request body or query parameters are required.
+
+## Response
+
+The endpoint returns a standard OpenAI models list:
+
+```json
+{
+  "data": [
+    {
+      "id": "meta/llama-3.1-8b-instruct",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "system"
+    },
+    {
+      "id": "meta/llama-3.1-70b-instruct",
+      "object": "model",
+      "created": 1700000000,
+      "owned_by": "system"
+    }
+  ]
+}
+```
+
+## Using Python
+
+```python
+import requests
+
+base_url = "http://localhost:8000"
+
+response = requests.get(f"{base_url}/v1/models")
+models = response.json()
+
+print("Available models:")
+for model in models["data"]:
+    print(f"  - {model['id']}")
+```
+
+## Using the OpenAI Python SDK
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="not-used"
+)
+
+models = client.models.list()
+
+for model in models.data:
+    print(model.id)
+```
+
+## Provider Configuration
+
+The server determines which upstream provider to query based on the `MAIN_MODEL_ENGINE` and related environment variables.
+The following providers are supported.
+
+### OpenAI
+
+```bash
+export MAIN_MODEL_ENGINE="openai"
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+### NVIDIA NIM
+
+```bash
+export MAIN_MODEL_ENGINE="nim"
+export MAIN_MODEL_BASE_URL="http://localhost:8080/v1"
+```
+
+### vLLM / TRT-LLM
+
+```bash
+export MAIN_MODEL_ENGINE="vllm"  # or "trt_llm"
+export MAIN_MODEL_BASE_URL="http://localhost:8080/v1"
+```
+
+### Anthropic
+
+```bash
+export MAIN_MODEL_ENGINE="anthropic"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+```
+
+### Azure OpenAI
+
+The engine name `azure_openai` is also accepted as an alias for `azure`.
+
+```bash
+export MAIN_MODEL_ENGINE="azure"
+export AZURE_OPENAI_API_KEY="your-azure-api-key"
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+export AZURE_OPENAI_API_VERSION="2024-06-01"  # optional, defaults to 2024-06-01
+```
+
+### Cohere
+
+```bash
+export MAIN_MODEL_ENGINE="cohere"
+export COHERE_API_KEY="your-cohere-api-key"
+# Optional: override the Cohere API base URL (defaults to https://api.cohere.com)
+# export COHERE_BASE_URL="https://custom-cohere-endpoint.example.com"
+```
+
+### Custom OpenAI-Compatible Endpoint
+
+For any provider that exposes an OpenAI-compatible `/v1/models` endpoint, set `MAIN_MODEL_BASE_URL`:
+
+```bash
+export MAIN_MODEL_ENGINE="my-custom-engine"
+export MAIN_MODEL_BASE_URL="http://my-provider:8080/v1"
+```
+
+The server falls back to querying `MAIN_MODEL_BASE_URL` when the engine is not in the built-in provider table.
+
+## Authentication
+
+The endpoint forwards the `Authorization` header from the incoming request to the upstream provider.
+If no `Authorization` header is present, the server uses the API key from the appropriate environment variable for the configured engine.
+
+## Error Responses
+
+| Status Code | Description |
+|-------------|-------------|
+| 502 | The upstream provider is unreachable or returned an error. |
+| 4xx | Proxied from the upstream provider (e.g., 401 for invalid API key). |
+
+```{note}
+If the engine is not in the built-in provider table and `MAIN_MODEL_BASE_URL` is not set, the endpoint returns an empty model list instead of an error.
+```
+
+## Related Topics
+
+- [](run-guardrails-server.md)
+- [](chat-with-guardrailed-model.md)
+- [](../../reference/api-server-endpoints/index.md)

--- a/docs/run-rails/using-fastapi-server/list-models.md
+++ b/docs/run-rails/using-fastapi-server/list-models.md
@@ -89,6 +89,7 @@ The following providers are supported.
 
 ```bash
 export MAIN_MODEL_ENGINE="openai"
+export MAIN_MODEL_BASE_URL="https://api.openai.com/v1"
 export OPENAI_API_KEY="your-openai-api-key"
 ```
 

--- a/docs/run-rails/using-fastapi-server/overview.md
+++ b/docs/run-rails/using-fastapi-server/overview.md
@@ -81,20 +81,6 @@ curl -X POST http://localhost:8000/v1/chat/completions \
   }'
 ```
 
-Or use the OpenAI Python SDK:
-
-```python
-from openai import OpenAI
-
-client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-used")
-response = client.chat.completions.create(
-    model="meta/llama-3.1-8b-instruct",
-    messages=[{"role": "user", "content": "Hello!"}],
-    extra_body={"guardrails": {"config_id": "content_safety"}}
-)
-print(response.choices[0].message.content)
-```
-
 ### View the Chat UI
 
 Open `http://localhost:8000` in your browser to access the built-in Chat UI for testing.

--- a/docs/run-rails/using-fastapi-server/overview.md
+++ b/docs/run-rails/using-fastapi-server/overview.md
@@ -17,7 +17,8 @@ content:
 The NeMo Guardrails API server:
 
 - Loads guardrails configurations at startup.
-- Exposes a REST API compatible with OpenAI's chat completions format.
+- Exposes an [OpenAI-compatible REST API](https://platform.openai.com/docs/api-reference/chat/create) for chat completions.
+- Works with the [OpenAI Python SDK](https://github.com/openai/openai-python) — use `OpenAI(base_url="http://localhost:8000/v1")`.
 - Includes a built-in Chat UI for testing.
 - Supports multiple configurations and combining them per-request.
 
@@ -72,9 +73,26 @@ Send a chat completion request to the server:
 curl -X POST http://localhost:8000/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "config_id": "content_safety",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "model": "meta/llama-3.1-8b-instruct",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "guardrails": {
+      "config_id": "content_safety"
+    }
   }'
+```
+
+Or use the OpenAI Python SDK:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="not-used")
+response = client.chat.completions.create(
+    model="meta/llama-3.1-8b-instruct",
+    messages=[{"role": "user", "content": "Hello!"}],
+    extra_body={"guardrails": {"config_id": "content_safety"}}
+)
+print(response.choices[0].message.content)
 ```
 
 ### View the Chat UI

--- a/docs/run-rails/using-fastapi-server/overview.md
+++ b/docs/run-rails/using-fastapi-server/overview.md
@@ -17,7 +17,7 @@ content:
 The NeMo Guardrails API server:
 
 - Loads guardrails configurations at startup.
-- Exposes an [OpenAI-compatible REST API](https://platform.openai.com/docs/api-reference/chat/create) for chat completions.
+- Exposes an [OpenAI-compatible REST API](https://platform.openai.com/docs/api-reference/chat/create) for chat completions and model listing.
 - Works with the [OpenAI Python SDK](https://github.com/openai/openai-python) — use `OpenAI(base_url="http://localhost:8000/v1")`.
 - Includes a built-in Chat UI for testing.
 - Supports multiple configurations and combining them per-request.

--- a/docs/run-rails/using-fastapi-server/run-guardrails-server.md
+++ b/docs/run-rails/using-fastapi-server/run-guardrails-server.md
@@ -161,13 +161,18 @@ Set the appropriate API key for your provider:
 
 ```bash
 # For NVIDIA-hosted models
+export MAIN_MODEL_ENGINE="nim"
+export MAIN_MODEL_BASE_URL="https://integrate.api.nvidia.com"
 export NVIDIA_API_KEY="your-nvidia-api-key"
 
 # For OpenAI models
+export MAIN_MODEL_ENGINE="openai"
+export MAIN_MODEL_BASE_URL="https://api.openai.com/v1"
 export OPENAI_API_KEY="your-openai-api-key"
 
 # For Anthropic models
 export MAIN_MODEL_ENGINE="anthropic"
+export MAIN_MODEL_BASE_URL="https://api.anthropic.com"
 export ANTHROPIC_API_KEY="your-anthropic-api-key"
 
 # For Azure OpenAI (also accepts "azure_openai" as engine name)

--- a/docs/run-rails/using-fastapi-server/run-guardrails-server.md
+++ b/docs/run-rails/using-fastapi-server/run-guardrails-server.md
@@ -166,6 +166,21 @@ export NVIDIA_API_KEY="your-nvidia-api-key"
 # For OpenAI models
 export OPENAI_API_KEY="your-openai-api-key"
 
+# For Anthropic models
+export MAIN_MODEL_ENGINE="anthropic"
+export ANTHROPIC_API_KEY="your-anthropic-api-key"
+
+# For Azure OpenAI (also accepts "azure_openai" as engine name)
+export MAIN_MODEL_ENGINE="azure"
+export AZURE_OPENAI_API_KEY="your-azure-api-key"
+export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+export AZURE_OPENAI_API_VERSION="2024-06-01"  # optional, defaults to 2024-06-01
+
+# For Cohere models
+export MAIN_MODEL_ENGINE="cohere"
+export COHERE_API_KEY="your-cohere-api-key"
+# export COHERE_BASE_URL="https://custom-endpoint.example.com"  # optional
+
 # For self-hosted models (e.g., vLLM, NIM, TRT-LLM)
 export MAIN_MODEL_ENGINE="vllm"
 export MAIN_MODEL_BASE_URL="http://localhost:8080/v1"

--- a/docs/run-rails/using-fastapi-server/run-guardrails-server.md
+++ b/docs/run-rails/using-fastapi-server/run-guardrails-server.md
@@ -139,6 +139,38 @@ nemoguardrails server --config ./configs --auto-reload
 Use `--auto-reload` only in development environments. It is not recommended for production.
 ```
 
+## Model Provider Configuration
+
+When the `model` field is specified in a chat completion request, the server uses environment variables to determine which LLM provider and endpoint to use.
+
+```{list-table}
+:header-rows: 1
+:widths: 35 65
+
+* - Environment Variable
+  - Description
+
+* - `MAIN_MODEL_ENGINE`
+  - The LLM engine to use (e.g., `"openai"`, `"nim"`, `"vllm"`, `"anthropic"`). Default: `"openai"`.
+
+* - `MAIN_MODEL_BASE_URL`
+  - Base URL for the LLM provider. Use this for self-hosted models (e.g., `"http://localhost:8080/v1"`).
+```
+
+Set the appropriate API key for your provider:
+
+```bash
+# For NVIDIA-hosted models
+export NVIDIA_API_KEY="your-nvidia-api-key"
+
+# For OpenAI models
+export OPENAI_API_KEY="your-openai-api-key"
+
+# For self-hosted models (e.g., vLLM, NIM, TRT-LLM)
+export MAIN_MODEL_ENGINE="vllm"
+export MAIN_MODEL_BASE_URL="http://localhost:8080/v1"
+```
+
 ## CORS Configuration
 
 To enable your guardrails server to receive requests from browser-based applications, configure CORS using environment variables:


### PR DESCRIPTION
## Description

The Guardrails server was recently updated to be OpenAI-compatible, with `/models` and `/chat/completions` endpoints. The work was merged in #1340 and #1637 PRs. The documents are now updated with the OpenAI-compatible request and response formats, and how environment variables are used to set the main-model engine and base URL.

## Related Issue(s)

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
