### PR TITLE
fix(streaming): handle dict chunks in RollingBuffer.format_chunks

### DIFF
--- a/nemoguardrails/rails/llm/buffer.py
+++ b/nemoguardrails/rails/llm/buffer.py
@@ -292,7 +292,7 @@ class RollingBuffer(BufferStrategy):
         total_chunks = 0
 
         async for chunk in streaming_handler:
-            buffer.append(chunk)
+            buffer.append(chunk["text"] if isinstance(chunk, dict) else chunk)
             total_chunks += 1
 
             if len(buffer) >= self.buffer_chunk_size:

--- a/tests/test_buffer_strategy.py
+++ b/tests/test_buffer_strategy.py
@@ -267,6 +267,50 @@ def test_format_chunks_realistic():
 
 
 @pytest.mark.asyncio
+async def test_process_stream_with_metadata_dicts():
+    """Test that process_stream normalizes dict chunks to strings."""
+
+    async def metadata_streaming_handler():
+        for token in ["Hello", " ", "world", "!"]:
+            yield {"text": token, "metadata": {"response_metadata": {"model_provider": "openai"}}}
+
+    buffer_strategy = RollingBuffer(buffer_context_size=1, buffer_chunk_size=2)
+
+    user_output_parts = []
+    async for chunk_batch in buffer_strategy(metadata_streaming_handler()):
+        for chunk in chunk_batch.processing_context:
+            assert isinstance(chunk, str)
+        formatted = buffer_strategy.format_chunks(chunk_batch.processing_context)
+        assert isinstance(formatted, str)
+        user_output_parts.append(buffer_strategy.format_chunks(chunk_batch.user_output_chunks))
+
+    full_text = "".join(user_output_parts)
+    assert full_text == "Hello world!"
+
+
+@pytest.mark.asyncio
+async def test_process_stream_with_mixed_chunk_types():
+    """Test that process_stream handles a mix of string and dict chunks."""
+
+    async def mixed_streaming_handler():
+        yield "Hello"
+        yield {"text": " ", "metadata": {"response_metadata": {"model_provider": "openai"}}}
+        yield {"text": "world", "metadata": {"response_metadata": {"model_provider": "openai"}}}
+        yield "!"
+
+    buffer_strategy = RollingBuffer(buffer_context_size=1, buffer_chunk_size=2)
+
+    user_output_parts = []
+    async for chunk_batch in buffer_strategy(mixed_streaming_handler()):
+        for chunk in chunk_batch.processing_context:
+            assert isinstance(chunk, str)
+        user_output_parts.append(buffer_strategy.format_chunks(chunk_batch.user_output_chunks))
+
+    full_text = "".join(user_output_parts)
+    assert full_text == "Hello world!"
+
+
+@pytest.mark.asyncio
 async def test_total_yielded_tracking():
     """Test that total_yielded is correctly tracked and reset."""
     buffer_strategy = RollingBuffer(buffer_context_size=1, buffer_chunk_size=2)


### PR DESCRIPTION
## Summary

- **Bug**: `RollingBuffer` crashes with `TypeError` when `LLMRails.stream_async(include_metadata=True)` is used with output rails streaming enabled. The `StreamingHandler` yields dict chunks (`{"text": ..., "metadata": ...}`) but `format_chunks()` calls `"".join()` which cannot join dicts. Affects both direct `LLMRails` and `RunnableRails` usage.
- **Fix**: Normalize dict chunks to strings in `process_stream()` at the input boundary, preserving `List[str]` typing throughout the buffer internals
- **Tests**: Add tests for `process_stream` with dict chunks and mixed string/dict chunks
