### PR TITLE
fix(server): prioritize env var API key over forwarded client header

### DIFF
--- a/nemoguardrails/server/schemas/utils.py
+++ b/nemoguardrails/server/schemas/utils.py
@@ -140,16 +140,11 @@ async def fetch_models(
     headers: Dict[str, str] = {}
     forwarded = request_headers.get("Authorization", "")
 
-    # Check if the auth header is a Bearer token
-    if forwarded and auth_header_name == "Authorization":
-        headers["Authorization"] = forwarded
-    else:
-        # Extract the key from the forwarded header or from the env var.
+    raw_key = os.environ.get(api_key_env, "")
+    if not raw_key:
         raw_key = forwarded.removeprefix("Bearer ").strip() if forwarded else ""
-        if not raw_key:
-            raw_key = os.environ.get(api_key_env, "")
-        if raw_key:
-            headers[auth_header_name] = f"Bearer {raw_key}" if use_bearer else raw_key
+    if raw_key:
+        headers[auth_header_name] = f"Bearer {raw_key}" if use_bearer else raw_key
 
     headers.update(provider.get("extra_headers", {}))
 


### PR DESCRIPTION
- Fix auth key priority in `fetch_models()` so the server's env var API key (e.g. `OPENAI_API_KEY`) is used first, falling back to the forwarded client `Authorization` header only when no env var is set
- before this PR, for OpenAI-compatible providers, the client's `Authorization` header was forwarded directly to the upstream API, bypassing the server's configured credentials
- this caused `test_list_models_openai` and `test_list_models_openai_fields` to fail when `OPENAI_API_KEY` was set, because the test client's dummy key was sent upstream instead of the real key from the env var


Test plan: 

run
```bash
poetry run pytest tests/server/test_openai_integration.py
```

Fails before this fix (you must have server deps and OPENAI_API_KEY set)
