### PR TITLE
Fix:  Utils bugs removing extra space from UtteranceBotActionScriptUpdated #

### DIFF
--- a/nemoguardrails/utils.py
+++ b/nemoguardrails/utils.py
@@ -110,7 +110,7 @@ _event_validators = [
     ),
     Validator(
         "***UtteranceBotActionScriptUpdated events need to provide 'interim_script' of type 'str'",
-        lambda e: e["type"] != "UtteranceBotActionScriptUpdated " or _has_property(e, Property("interim_script", str)),
+        lambda e: e["type"] != "UtteranceBotActionScriptUpdated" or _has_property(e, Property("interim_script", str)),
     ),
     Validator(
         "***UtteranceBotActionFinished events need to provide 'final_script' of type 'str'",


### PR DESCRIPTION
## Description
This fix removes the trailing space so the validator correctly rejects `UtteranceBotActionScriptUpdated` events that are missing the `interim_script` property.


## Related Issue(s)
N/A — this is a newly discovered bug not previously reported. 
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a validation condition that was incorrectly triggering for certain event types, ensuring proper handling of script update events and improving validation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->