### PR TITLE
fix: remove trailing space in UtteranceBotActionScriptUpdated validator

### DIFF
--- a/nemoguardrails/utils.py
+++ b/nemoguardrails/utils.py
@@ -110,7 +110,7 @@ _event_validators = [
     ),
     Validator(
         "***UtteranceBotActionScriptUpdated events need to provide 'interim_script' of type 'str'",
-        lambda e: e["type"] != "UtteranceBotActionScriptUpdated " or _has_property(e, Property("interim_script", str)),
+        lambda e: e["type"] != "UtteranceBotActionScriptUpdated" or _has_property(e, Property("interim_script", str)),
     ),
     Validator(
         "***UtteranceBotActionFinished events need to provide 'final_script' of type 'str'",

--- a/tests/test_event_validation.py
+++ b/tests/test_event_validation.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import sys
+
+import pytest
+
+
+def _import_utils():
+    """Import nemoguardrails.utils directly, bypassing the top-level package __init__."""
+    spec = importlib.util.spec_from_file_location(
+        "nemoguardrails.utils",
+        "nemoguardrails/utils.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+utils = _import_utils()
+ensure_valid_event = utils.ensure_valid_event
+is_valid_event = utils.is_valid_event
+
+
+def _make_base_event(event_type, **extra):
+    """Build a minimal event dict that satisfies common validators."""
+    event = {
+        "type": event_type,
+        "uid": "test-uid",
+        "event_created_at": "2026-01-01T00:00:00+00:00",
+        "source_uid": "test",
+        "action_uid": "test-action-uid",
+    }
+    event.update(extra)
+    return event
+
+
+class TestUtteranceBotActionScriptUpdatedValidation:
+    """Tests for UtteranceBotActionScriptUpdated event validation."""
+
+    def test_valid_event_with_interim_script(self):
+        """An UtteranceBotActionScriptUpdated event with interim_script should pass."""
+        event = _make_base_event(
+            "UtteranceBotActionScriptUpdated",
+            interim_script="Hello there",
+        )
+        assert is_valid_event(event) is True
+
+    def test_missing_interim_script_is_invalid(self):
+        """An UtteranceBotActionScriptUpdated event without interim_script should fail."""
+        event = _make_base_event("UtteranceBotActionScriptUpdated")
+        assert is_valid_event(event) is False
+
+    def test_missing_interim_script_raises(self):
+        """ensure_valid_event should raise AssertionError when interim_script is missing."""
+        event = _make_base_event("UtteranceBotActionScriptUpdated")
+        with pytest.raises(AssertionError, match="interim_script"):
+            ensure_valid_event(event)
+
+    def test_interim_script_wrong_type_is_invalid(self):
+        """An UtteranceBotActionScriptUpdated event with non-str interim_script should fail."""
+        event = _make_base_event(
+            "UtteranceBotActionScriptUpdated",
+            interim_script=42,
+        )
+        assert is_valid_event(event) is False

--- a/tests/test_event_validation.py
+++ b/tests/test_event_validation.py
@@ -13,27 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
-import sys
-
 import pytest
 
-
-def _import_utils():
-    """Import nemoguardrails.utils directly, bypassing the top-level package __init__."""
-    spec = importlib.util.spec_from_file_location(
-        "nemoguardrails.utils",
-        "nemoguardrails/utils.py",
-    )
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = mod
-    spec.loader.exec_module(mod)
-    return mod
-
-
-utils = _import_utils()
-ensure_valid_event = utils.ensure_valid_event
-is_valid_event = utils.is_valid_event
+from nemoguardrails.utils import ensure_valid_event, is_valid_event
 
 
 def _make_base_event(event_type, **extra):


### PR DESCRIPTION
## Summary

- Removed a trailing space from the string literal `"UtteranceBotActionScriptUpdated "` in `nemoguardrails/utils.py` (line 113), which caused teh type comparison to never match
- This meant the validator for `UtteranceBotActionScriptUpdated` events was silently ineffective -- events missing the required `interim_script` field were never recognised as invalid
- Added unit tests covering the corrected behaviour: valid events pass, and events with a missing or wrongly-typed `interim_script` are properly rejected

## Test plan

- [x] Verified locally that the four new tests in `tests/test_event_validation.py` pass
- [ ] CI should confirm no regressions across the existing test suite

Fixes #1696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event type validation to accurately identify and validate UtteranceBotActionScriptUpdated events, ensuring required fields are properly enforced.

* **Tests**
  * Added comprehensive test coverage for event validation functionality to verify correct handling of event types and field requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->