### PR TITLE
fix: handle empty string values in create_event (#1700)

### DIFF
--- a/nemoguardrails/actions/core.py
+++ b/nemoguardrails/actions/core.py
@@ -41,7 +41,7 @@ async def create_event(
 
     # We add basic support for referring variables as values
     for k, v in event_dict.items():
-        if isinstance(v, str) and v[0] == "$":
+        if isinstance(v, str) and v.startswith("$"):
             event_dict[k] = context.get(v[1:], None) if context else None
 
     return ActionResult(events=[event_dict])

--- a/tests/test_create_event.py
+++ b/tests/test_create_event.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.actions.core import create_event
+
+
+@pytest.mark.asyncio
+async def test_create_event_empty_string_value():
+    """Empty string values must not raise an IndexError (issue #1700)."""
+    result = await create_event(event={"_type": "SomeEvent", "param": ""})
+    assert len(result.events) == 1
+    assert result.events[0]["param"] == ""
+
+
+@pytest.mark.asyncio
+async def test_create_event_variable_reference():
+    """A '$'-prefixed value should be resolved from context."""
+    result = await create_event(
+        event={"_type": "UserMessage", "text": "$user_message"},
+        context={"user_message": "Hello!"},
+    )
+    assert result.events[0]["text"] == "Hello!"
+
+
+@pytest.mark.asyncio
+async def test_create_event_variable_reference_missing_context():
+    """A '$'-prefixed value with no matching context key resolves to None."""
+    result = await create_event(
+        event={"_type": "UserMessage", "text": "$missing_key"},
+        context={"other_key": "value"},
+    )
+    assert result.events[0]["text"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_event_variable_reference_no_context():
+    """A '$'-prefixed value with context=None resolves to None."""
+    result = await create_event(
+        event={"_type": "UserMessage", "text": "$user_message"},
+    )
+    assert result.events[0]["text"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_event_plain_string_value():
+    """Regular strings without '$' prefix should pass through unchanged."""
+    result = await create_event(event={"_type": "SomeEvent", "param": "hello world"})
+    assert result.events[0]["param"] == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_create_event_non_string_values():
+    """Non-string values (int, list, dict) should pass through unchanged."""
+    result = await create_event(
+        event={"_type": "SomeEvent", "count": 42, "tags": ["a", "b"], "meta": {"k": "v"}},
+    )
+    assert result.events[0]["count"] == 42
+    assert result.events[0]["tags"] == ["a", "b"]
+    assert result.events[0]["meta"] == {"k": "v"}


### PR DESCRIPTION
## Summary

- Fixed `IndexError` in `create_event` when event parameters contain empty string values
- Replaced `v[0] == "$"` with `v.startswith("$")` which safely handles empty strings without raising an exception
- This is consistent with how the `$` prefix check is done elsewhere in teh codebase (e.g. `colang/v2_x/runtime/runtime.py`)

## Details

When `create_event` iterates over event dictionary values to resolve `$`-prefixed variable references, it previously used direct indexing (`v[0] == "$"`) to check for the dollar sign prefix. This raises an `IndexError` when a value is an empty string, since `""[0]` is out of range.

The fix uses `str.startswith("$")` instead, which returns `False` for empty strings and is already the recognised pattern used throughout the rest of the codebase.

## Test plan

- [x] Added `tests/test_create_event.py` with the following cases:
  - Empty string values pass through without `IndexError`
  - `$`-prefixed values are correctly resolved from context
  - `$`-prefixed values with missing context keys resolve to `None`
  - `$`-prefixed values with `context=None` resolve to `None`
  - Plain string values pass through unchanged
  - Non-string values (int, list, dict) pass through unchanged
- [x] All 6 new tests pass locally
- [x] Verified the original bug reproduces on unfixed code

Closes #1700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of placeholder variables to prevent potential errors with empty strings while preserving existing substitution behavior.

* **Tests**
  * Added comprehensive test coverage for event creation, including empty string values, context references, and various input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->