### PR TITLE
fix: prevent IndexError in create_event for empty string values

### DIFF
--- a/nemoguardrails/actions/core.py
+++ b/nemoguardrails/actions/core.py
@@ -41,7 +41,7 @@ async def create_event(
 
     # We add basic support for referring variables as values
     for k, v in event_dict.items():
-        if isinstance(v, str) and v[0] == "$":
+        if isinstance(v, str) and v.startswith("$"):
             event_dict[k] = context.get(v[1:], None) if context else None
 
     return ActionResult(events=[event_dict])

--- a/tests/test_create_event_empty_string.py
+++ b/tests/test_create_event_empty_string.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails.actions.core import create_event
+
+
+@pytest.mark.asyncio
+async def test_create_event_empty_string_value():
+    """Test that create_event handles empty string values without raising IndexError.
+
+    Regression test for https://github.com/NVIDIA-NeMo/Guardrails/issues/1700
+    """
+    result = await create_event(event={"_type": "SomeEvent", "param": ""})
+    assert len(result.events) == 1
+    assert result.events[0]["param"] == ""
+
+
+@pytest.mark.asyncio
+async def test_create_event_dollar_prefix_resolved():
+    """Test that $-prefixed string values are resolved from context."""
+    result = await create_event(
+        event={"_type": "SomeEvent", "param": "$user_name"},
+        context={"user_name": "Alice"},
+    )
+    assert result.events[0]["param"] == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_create_event_dollar_prefix_no_context():
+    """Test that $-prefixed values resolve to None when no context is provided."""
+    result = await create_event(
+        event={"_type": "SomeEvent", "param": "$missing"},
+    )
+    assert result.events[0]["param"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_event_regular_string():
+    """Test that regular string values pass through unchanged."""
+    result = await create_event(event={"_type": "SomeEvent", "param": "hello"})
+    assert result.events[0]["param"] == "hello"


### PR DESCRIPTION
## Summary

Fixes an `IndexError: string index out of range` raised when `create_event` in `nemoguardrails/actions/core.py` receives an event dict containing an empty string value.

## Problem

The \$-prefix check on line 44 used direct indexing (`v[0] == "\$"`), which raises `IndexError` when `v` is an empty string (`""`).

## Fix

Replaced `v[0] == "\$"` with `v.startswith("\$")`, which safely returns `False` for empty strings. This is consistent with similar checks elsewhere in the codebase.

## Tests

Added regression tests in `tests/test_create_event_empty_string.py`:
- Empty string values pass through without error
- \$-prefixed values resolve from context
- \$-prefixed values resolve to `None` without context
- Regular strings pass through unchanged

Fixes #1700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of context variable references in event creation to correctly recognize variables prefixed with `$`.

* **Tests**
  * Added regression tests covering event creation with empty strings, context variable resolution, and parameter value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->