### PR TITLE
ci: upgrade GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ${{ inputs.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ inputs.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -32,9 +32,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
             - name: Set up Python ${{ env.PYTHON_VERSION }}
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ env.PYTHON_VERSION }}
             - name: Bootstrap poetry (Linux and macOS)
@@ -55,7 +55,7 @@ jobs:
                   sudo find _build -name .doctrees -prune -exec rm -rf {} \;
                   sudo find _build -name .buildinfo -exec rm {} \;
             - name: Upload HTML
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: html-build-artifact
                   path: _build/docs
@@ -70,7 +70,7 @@ jobs:
                   echo ${{ github.event.action }}              > ./pr/action.txt
             - name: Upload PR information
               if: github.event_name == 'pull_request'
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v6
               with:
                   name: pr
                   path: pr/
@@ -80,7 +80,7 @@ jobs:
         needs: [build-docs]
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: "gh-pages"
             - name: Initialize Git configuration
@@ -88,7 +88,7 @@ jobs:
                   git config user.name docs-build
                   git config user.email do-not-send@github.com
             - name: Download artifacts
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v7
               with:
                   name: html-build-artifact
                   path: ${{ github.ref_name }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
     name: Lint Code
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/publish-pypi-approval.yml
+++ b/.github/workflows/publish-pypi-approval.yml
@@ -43,7 +43,7 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.version.outputs.tag }}
           fetch-depth: 0
@@ -59,7 +59,7 @@ jobs:
           echo "✅ Version validated: $VERSION_IN_FILE matches tag $TAG_VERSION"
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ steps.version.outputs.artifact_name }}
           path: dist

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: nemoguardrails-${{ github.event.inputs.version }}.whl
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test-and-build-wheel.yml
+++ b/.github/workflows/test-and-build-wheel.yml
@@ -19,10 +19,10 @@ jobs:
     outputs:
       artifact_name: ${{ steps.set-artifact-name.outputs.artifact_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact_name }}
           path: dist/*
@@ -88,12 +88,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.build-wheel.outputs.artifact_name }}
 

--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -24,7 +24,7 @@ jobs:
       #
       # Checkout the code
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Get runner architecture
       - name: Get runner architecture

--- a/.github/workflows/test-published-dist.yml
+++ b/.github/workflows/test-published-dist.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions to versions compatible with the Node.js 24 runtime, which GitHub is rolling out as the new runner default.

**Action upgrades:**
- `actions/checkout`: any version → `v6`
- `actions/upload-artifact`: any version → `v6`
- `actions/download-artifact`: any version → `v7`
- `actions/github-script`: any version → `v8`
- `actions/setup-python`: any version → `v6`

Mirrors: https://github.com/NVIDIA/Megatron-LM/commit/1d5e68b0749f0fc075250fae4e36081d972379a8

## Test plan
- [ ] Verify CI pipelines pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies across all automated CI/CD pipelines to use newer major versions. Specifically upgraded checkout, setup-python, upload-artifact, and download-artifact actions to their latest stable releases. These dependency updates enhance compatibility with current GitHub infrastructure, improve overall workflow reliability, and strengthen security practices across the project's automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->