### PR TITLE
refactor: use parallel LLM calls for hallucination

### DIFF
--- a/nemoguardrails/library/hallucination/actions.py
+++ b/nemoguardrails/library/hallucination/actions.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -54,44 +55,27 @@ async def self_check_hallucination(
 
     if bot_response and last_bot_prompt_string:
         num_responses = HALLUCINATION_NUM_EXTRA_RESPONSES
-        # Use beam search for the LLM call, to get several completions with only one call.
-        # At the current moment, only OpenAI LLM engines are supported for computing the additional completions.
 
-        if "openai" not in str(type(llm)).lower():
-            log.warning(
-                f"Hallucination rail is optimized for OpenAI LLM engines. "
-                f"Current LLM engine is {type(llm).__name__}, which may not support all features."
-            )
-
-            if "n" not in llm.model_fields:
-                log.warning(
-                    f"LLM engine {type(llm).__name__} does not support the 'n' parameter for generating multiple completion choices. "
-                    f"Please use an OpenAI LLM engine or a model that supports the 'n' parameter for optimal performance."
-                )
-                return False
-
-        # Use the "generate" call from langchain to get all completions in the same response.
         last_bot_prompt = PromptTemplate(template="{text}", input_variables=["text"])
-
-        # Format the prompt manually
         formatted_prompt = last_bot_prompt.format(text=last_bot_prompt_string)
 
-        llm_with_config = llm.bind(temperature=1.0, n=num_responses)
-        extra_llm_response = await llm_with_config.agenerate([formatted_prompt])
+        async def _generate_extra_response(index: int) -> Optional[str]:
+            llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_HALLUCINATION.value))
+            try:
+                result = await llm_call(
+                    llm,
+                    formatted_prompt,
+                    llm_params={"temperature": 1.0},
+                )
+                result = get_multiline_response(result)
+                result = strip_quotes(result)
+                return result
+            except Exception as e:
+                log.warning(f"Extra LLM response {index + 1}/{num_responses} failed: {e}")
+                return None
 
-        extra_llm_completions = []
-        if len(extra_llm_response.generations) > 0:
-            extra_llm_completions = extra_llm_response.generations[0]
-
-        extra_responses = []
-        i = 0
-        while i < num_responses and i < len(extra_llm_completions):
-            result = extra_llm_completions[i].text
-            # We need the same post-processing of responses as in "generate_bot_message"
-            result = get_multiline_response(result)
-            result = strip_quotes(result)
-            extra_responses.append(result)
-            i += 1
+        results = await asyncio.gather(*[_generate_extra_response(i) for i in range(num_responses)])
+        extra_responses = [r for r in results if r is not None]
 
         if len(extra_responses) == 0:
             # Log message and return that no hallucination was found

--- a/tests/test_hallucination_check.py
+++ b/tests/test_hallucination_check.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemoguardrails import RailsConfig
+from tests.utils import TestChat
+
+COLANG_CONTENT = """
+    define user express greeting
+        "hello"
+        "hi"
+
+    define flow greeting
+        user express greeting
+        $check_hallucination = True
+        bot express greeting
+"""
+
+YAML_CONTENT = """
+    models: []
+    rails:
+        output:
+            flows:
+                - self check hallucination
+    prompts:
+        - task: self_check_hallucination
+          content: |
+            You are given a task to identify if the hypothesis is in agreement with the context below.
+            You will only use the contents of the context and not rely on external knowledge.
+            Answer with yes/no. "context": {{ paragraph }} "hypothesis": {{ statement }} "agreement":
+
+    enable_rails_exceptions: True
+"""
+
+config = RailsConfig.from_content(
+    colang_content=COLANG_CONTENT,
+    yaml_content=YAML_CONTENT,
+)
+
+
+@pytest.mark.asyncio
+async def test_no_hallucination_detected():
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello there!"',
+            "Hello there!",
+            "Hello there!",
+            "yes",
+        ],
+    )
+    messages = [{"role": "user", "content": "hi"}]
+    result = await chat.app.generate_async(messages=messages)
+
+    assert result["content"] == "Hello there!"
+
+
+@pytest.mark.asyncio
+async def test_hallucination_detected():
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello there!"',
+            "Something completely different",
+            "Another different response",
+            "no",
+        ],
+    )
+    messages = [{"role": "user", "content": "hi"}]
+    result = await chat.app.generate_async(messages=messages)
+
+    assert result["role"] == "exception"
+    assert result["content"]["type"] == "SelfCheckHallucinationRailException"
+
+
+@pytest.mark.asyncio
+async def test_hallucination_blocked_response():
+    config_no_exceptions = RailsConfig.from_content(
+        colang_content=COLANG_CONTENT,
+        yaml_content="""
+            models: []
+            rails:
+                output:
+                    flows:
+                        - self check hallucination
+            prompts:
+                - task: self_check_hallucination
+                  content: |
+                    Answer with yes/no. "context": {{ paragraph }} "hypothesis": {{ statement }} "agreement":
+        """,
+    )
+
+    chat = TestChat(
+        config_no_exceptions,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello there!"',
+            "Something different",
+            "Another different response",
+            "no",
+        ],
+    )
+    messages = [{"role": "user", "content": "hi"}]
+    result = await chat.app.generate_async(messages=messages)
+
+    assert result["content"] == "I don't know the answer to that."


### PR DESCRIPTION
## Description
Resolves the issue mentioned in this comment: https://github.com/NVIDIA-NeMo/Guardrails/pull/1616#discussion_r2983268730

**Performance analysis: `asyncio.gather(N×ainvoke)` vs `agenerate(n=N)`**

`HALLUCINATION_NUM_EXTRA_RESPONSES` is hardcoded to 2, so only n=2 is relevant. Benchmarked on `gpt-4o-mini` over 3 trials:

| Strategy | Mean latency | vs agenerate |
|---|---|---|
| `agenerate(n=2)` (old) | 1.184s | baseline |
| `asyncio.gather(2×ainvoke)` (new) | 1.133s | **-4.3%** |
| sequential loop | 1.837s | +55.2% |

No performance regression at n=2. The gather approach also fixes token accounting where the old `agenerate` duplicated aggregate `usage_metadata` across all generations, causing N× overcounting.

