### PR TITLE
fix(llmrails): backfill embedding model params into search provider config (fixes stale KB cache)

### DIFF
--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -256,6 +256,18 @@ class LLMRails:
                 self.default_embedding_model = model.model
                 self.default_embedding_engine = model.engine
                 self.default_embedding_params = model.parameters or {}
+
+                for esp in [
+                    self.config.core.embedding_search_provider,
+                    self.config.knowledge_base.embedding_search_provider,
+                ]:
+                    if esp.name != "default":
+                        continue
+                    if "embedding_model" not in esp.parameters:
+                        esp.parameters["embedding_model"] = model.model
+                    if "embedding_engine" not in esp.parameters:
+                        esp.parameters["embedding_engine"] = model.engine
+
                 break
 
         # InteractionLogAdapters used for tracing

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -263,9 +263,9 @@ class LLMRails:
                 ]:
                     if esp.name != "default":
                         continue
-                    if "embedding_model" not in esp.parameters:
+                    if "embedding_model" not in esp.parameters and model.model is not None:
                         esp.parameters["embedding_model"] = model.model
-                    if "embedding_engine" not in esp.parameters:
+                    if "embedding_engine" not in esp.parameters and model.engine is not None:
                         esp.parameters["embedding_engine"] = model.engine
 
                 break

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1455,6 +1455,11 @@ def test_embedding_model_no_backfill_for_custom_provider():
     assert "embedding_engine" not in rails.config.core.embedding_search_provider.parameters
     assert rails.config.core.embedding_search_provider.parameters["some_param"] == "value"
 
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert (
+        rails.config.knowledge_base.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+    )
+
 
 def test_embedding_model_no_backfill_when_no_embeddings_model():
     config = RailsConfig.parse_object(

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -1353,3 +1353,122 @@ async def test_generate_async_no_thinking_tags_when_no_reasoning():
 
         assert not result["content"].startswith("<think>")
         assert result["content"] == "Regular response"
+
+
+EMBEDDING_MODEL_CONFIG_BASE = {
+    "models": [
+        {"type": "main", "engine": "fake", "model": "fake"},
+        {"type": "embeddings", "engine": "SentenceTransformers", "model": "intfloat/e5-large-v2"},
+    ],
+    "user_messages": {"express greeting": ["Hello!"]},
+    "flows": [{"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}],
+    "bot_messages": {"express greeting": ["Hello! How are you?"]},
+}
+
+
+def test_embedding_model_backfills_search_provider_parameters():
+    config = RailsConfig.parse_object(EMBEDDING_MODEL_CONFIG_BASE)
+
+    assert "embedding_model" not in config.core.embedding_search_provider.parameters
+    assert "embedding_model" not in config.knowledge_base.embedding_search_provider.parameters
+
+    rails = LLMRails(config=config, llm=FakeLLM(responses=["  express greeting"]))
+
+    assert rails.config.core.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert rails.config.core.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert (
+        rails.config.knowledge_base.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+    )
+
+
+def test_embedding_model_does_not_overwrite_explicit_parameters():
+    config = RailsConfig.parse_object(
+        {
+            **EMBEDDING_MODEL_CONFIG_BASE,
+            "core": {
+                "embedding_search_provider": {
+                    "name": "default",
+                    "parameters": {"embedding_model": "my-core-model", "embedding_engine": "MyEngine"},
+                }
+            },
+            "knowledge_base": {
+                "embedding_search_provider": {
+                    "name": "default",
+                    "parameters": {"embedding_model": "my-kb-model", "embedding_engine": "MyKBEngine"},
+                }
+            },
+        }
+    )
+
+    rails = LLMRails(config=config, llm=FakeLLM(responses=["  express greeting"]))
+
+    assert rails.config.core.embedding_search_provider.parameters["embedding_model"] == "my-core-model"
+    assert rails.config.core.embedding_search_provider.parameters["embedding_engine"] == "MyEngine"
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_model"] == "my-kb-model"
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_engine"] == "MyKBEngine"
+
+
+def test_embedding_model_partial_backfill_only_fills_missing():
+    config = RailsConfig.parse_object(
+        {
+            **EMBEDDING_MODEL_CONFIG_BASE,
+            "core": {
+                "embedding_search_provider": {
+                    "name": "default",
+                    "parameters": {"embedding_model": "my-core-model"},
+                }
+            },
+            "knowledge_base": {
+                "embedding_search_provider": {
+                    "name": "default",
+                    "parameters": {"embedding_engine": "MyKBEngine"},
+                }
+            },
+        }
+    )
+
+    rails = LLMRails(config=config, llm=FakeLLM(responses=["  express greeting"]))
+
+    assert rails.config.core.embedding_search_provider.parameters["embedding_model"] == "my-core-model"
+    assert rails.config.core.embedding_search_provider.parameters["embedding_engine"] == "SentenceTransformers"
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_model"] == "intfloat/e5-large-v2"
+    assert rails.config.knowledge_base.embedding_search_provider.parameters["embedding_engine"] == "MyKBEngine"
+
+
+def test_embedding_model_no_backfill_for_custom_provider():
+    config = RailsConfig.parse_object(
+        {
+            **EMBEDDING_MODEL_CONFIG_BASE,
+            "core": {
+                "embedding_search_provider": {
+                    "name": "custom",
+                    "parameters": {"some_param": "value"},
+                }
+            },
+        }
+    )
+
+    rails = LLMRails(config=config, llm=FakeLLM(responses=["  express greeting"]))
+
+    assert "embedding_model" not in rails.config.core.embedding_search_provider.parameters
+    assert "embedding_engine" not in rails.config.core.embedding_search_provider.parameters
+    assert rails.config.core.embedding_search_provider.parameters["some_param"] == "value"
+
+
+def test_embedding_model_no_backfill_when_no_embeddings_model():
+    config = RailsConfig.parse_object(
+        {
+            "models": [{"type": "main", "engine": "fake", "model": "fake"}],
+            "user_messages": {"express greeting": ["Hello!"]},
+            "flows": [{"elements": [{"user": "express greeting"}, {"bot": "express greeting"}]}],
+            "bot_messages": {"express greeting": ["Hello! How are you?"]},
+        }
+    )
+
+    rails = LLMRails(config=config, llm=FakeLLM(responses=["  express greeting"]))
+
+    assert "embedding_model" not in rails.config.core.embedding_search_provider.parameters
+    assert "embedding_engine" not in rails.config.core.embedding_search_provider.parameters
+    assert "embedding_model" not in rails.config.knowledge_base.embedding_search_provider.parameters
+    assert "embedding_engine" not in rails.config.knowledge_base.embedding_search_provider.parameters


### PR DESCRIPTION
#‪# Description

Resolves https://github.com/NVIDIA-NeMo/Guardrails/issues/1751

- fix KB annoy index cache not invalidating when the embedding model is changed via the `models: [{type: embeddings, ...}]` config section
- When a `models[type=embeddings]` entry is found, backfill `embedding_model` and `embedding_engine` into `embedding_search_provider.parameters` for both `core` and `knowledge_base` configs so the cache hash includes the actual model name
- Previously, switching embedding models (e.g., FastEmbed to OpenAI) caused `IndexError: Vector has wrong length` at runtime with no clear error message

## Test plan

- [x] run with default FastEmbed model to create KB cache (e.g., `poetry run nemoguardrails chat --config=./examples/bots/abc`)
- [x] switch to OpenAI embeddings via `models` section (add   
```yaml
- type: embeddings
    engine: openai
    model: text-embedding-3-small
```
- [x] verify new cache file is created (different hash) and no vector length error
- [x] run existing embedding tests: `pytest tests/ -k embedding`

or just run (ensure .cache dir is deleted prior running it):
```python
from nemoguardrails import LLMRails, RailsConfig
from nemoguardrails.rails.llm.config import Model

config1 = RailsConfig.from_path("./examples/bots/abc")
rails1 = LLMRails(config1)
r1 = rails1.generate(messages=[{"role": "user", "content": "Hello"}])
print(f"Run 1 (default FastEmbed): {r1['content']}")

config2 = RailsConfig.from_path("./examples/bots/abc")
config2.models.append(Model(type="embeddings", engine="openai", model="text-embedding-3-small"))
rails2 = LLMRails(config2)
r2 = rails2.generate(messages=[{"role": "user", "content": "Hello"}])
print(f"Run 2 (OpenAI embeddings): {r2['content']}")

```
**Expected Output:**

**After the Fix**:

```
Run 1 (default FastEmbed): Hello! How can I assist you today?
Run 2 (OpenAI embeddings): Hello! How can I assist you today?

```
**Prior to the Fix**:

```
Run 1 (default FastEmbed): Hello! How can I help you today?
WARNING:nemoguardrails.actions.action_dispatcher:Error while execution 'retrieve_relevant_chunks' with parameters '{'context': {'last_user_message': 'Hello', 'last_bot_message': None, 'user_message': 'Hello', 'input_flows': ['self check input'], 'i': 1, 'triggered_input_rail': None, 'allowed': True, 'event': {'type': 'StartInternalSystemAction', 'uid': '341a946f-75e5-49b0-a44a-a811f47851f0', 'event_created_at': '2026-03-31T13:16:09.424440+00:00', 'source_uid': 'NeMoGuardrails', 'action_name': 'retrieve_relevant_chunks', 'action_params': {}, 'action_result_key': None, 'action_uid': 'ed2433e0-7c6c-43a4-88bd-ede638ee8e0c', 'is_system_action': True}}, 'kb': <nemoguardrails.kb.kb.KnowledgeBase object at 0x10f30ad50>}': Vector has wrong length (expected 384, got 1536)
ERROR:nemoguardrails.actions.action_dispatcher:Vector has wrong length (expected 384, got 1536)
Traceback (most recent call last):
  File "develop/nemoguardrails/actions/action_dispatcher.py", line 217, in execute_action
    result = await result
             ^^^^^^^^^^^^
  File "develop/nemoguardrails/actions/retrieve_relevant_chunks.py", line 65, in retrieve_relevant_chunks
    chunks = [chunk["body"] for chunk in await kb.search_relevant_chunks(user_message)]
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "develop/nemoguardrails/kb/kb.py", line 179, in search_relevant_chunks
    results = await self.index.search(text, max_results=max_results)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "nemoguardrails/embeddings/basic.py", line 282, in search
    results = self._index.get_nns_by_vector(
        _embedding,
        max_results,
        include_distances=True,
    )
IndexError: Vector has wrong length (expected 384, got 1536)
Run 2 (OpenAI embeddings): I'm sorry, an internal error has occurred.

```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Embedding search provider configuration now automatically injects embedding model and engine parameters during initialization for default providers when values are not explicitly provided, while preserving any user-specified settings.

* **Tests**
  * Added comprehensive test coverage validating embedding search provider parameter configuration, including backfilling behavior, explicit value preservation, and custom provider handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->