### PR TITLE
fix(actions): remove redundant embedding search in generate_user_intent

### DIFF
--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -393,29 +393,18 @@ class LLMGenerationActions:
                 text = event["text"]
 
             if self.user_message_index is not None:
-                threshold = None
-
-                if config.rails.dialog.user_messages:
+                if config.rails.dialog.user_messages and config.rails.dialog.user_messages.embeddings_only:
                     threshold = config.rails.dialog.user_messages.embeddings_only_similarity_threshold
+                    results = await self.user_message_index.search(text=text, max_results=5, threshold=threshold)
 
-                results = await self.user_message_index.search(text=text, max_results=5, threshold=threshold)
+                    if results:
+                        intent = results[0].meta["intent"]
+                        return ActionResult(events=[new_event_dict("UserIntent", intent=intent)])
+                    elif config.rails.dialog.user_messages.embeddings_only_fallback_intent:
+                        intent = config.rails.dialog.user_messages.embeddings_only_fallback_intent
+                        return ActionResult(events=[new_event_dict("UserIntent", intent=intent)])
 
-                # If the option to use only the embeddings is activated, we take the first
-                # canonical form.
-                if results and config.rails.dialog.user_messages.embeddings_only:
-                    intent = results[0].meta["intent"]
-
-                    return ActionResult(events=[new_event_dict("UserIntent", intent=intent)])
-
-                elif (
-                    config.rails.dialog.user_messages.embeddings_only
-                    and config.rails.dialog.user_messages.embeddings_only_fallback_intent
-                ):
-                    intent = config.rails.dialog.user_messages.embeddings_only_fallback_intent
-
-                    return ActionResult(events=[new_event_dict("UserIntent", intent=intent)])
-                else:
-                    results = await self.user_message_index.search(text=text, max_results=5, threshold=None)
+                results = await self.user_message_index.search(text=text, max_results=5, threshold=None)
                 # We add these in reverse order so the most relevant is towards the end.
                 for result in reversed(results):
                     examples += f'user "{result.text}"\n  {result.meta["intent"]}\n\n'

--- a/tests/test_embeddings_only_user_messages.py
+++ b/tests/test_embeddings_only_user_messages.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+import textwrap
+
 import pytest
 
 from nemoguardrails import LLMRails, RailsConfig
@@ -227,3 +229,56 @@ def test_no_llm_calls_embedding_only(colang_2_config):
     assert new_message["content"] == "Hello!"
 
     assert rails.explain_info.llm_calls == []
+
+
+def test_user_message_index_searched_once_when_embeddings_only_disabled():
+    config = RailsConfig.from_content(
+        colang_content=textwrap.dedent("""\
+            define user express greeting
+              "hello"
+              "hi there"
+
+            define bot express greeting
+              "Hello! How can I help you?"
+
+            define flow greeting
+              user express greeting
+              bot express greeting
+        """),
+        yaml_content=textwrap.dedent("""\
+            models:
+              - type: main
+                engine: openai
+                model: gpt-4o
+        """),
+    )
+
+    chat = TestChat(
+        config,
+        llm_completions=[
+            "  express greeting",
+            '  "Hello! How can I help you?"',
+            "  express greeting",
+            '  "Hello! How can I help you?"',
+        ],
+    )
+    actions = chat.app.llm_generation_actions
+
+    chat.app.generate(messages=[{"role": "user", "content": "hello"}])
+
+    original_search = actions.user_message_index.search
+    call_count = 0
+
+    async def counting_search(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return await original_search(*args, **kwargs)
+
+    actions.user_message_index.search = counting_search
+
+    chat.app.generate(messages=[{"role": "user", "content": "hey there"}])
+
+    assert call_count == 1, (
+        f"user_message_index.search should be called exactly once "
+        f"when embeddings_only is disabled, but was called {call_count} times"
+    )

--- a/tests/test_embeddings_only_user_messages.py
+++ b/tests/test_embeddings_only_user_messages.py
@@ -15,6 +15,7 @@
 
 
 import textwrap
+from unittest.mock import patch
 
 import pytest
 
@@ -266,19 +267,10 @@ def test_user_message_index_searched_once_when_embeddings_only_disabled():
 
     chat.app.generate(messages=[{"role": "user", "content": "hello"}])
 
-    original_search = actions.user_message_index.search
-    call_count = 0
+    with patch.object(actions.user_message_index, "search", wraps=actions.user_message_index.search) as mock_search:
+        chat.app.generate(messages=[{"role": "user", "content": "hey there"}])
 
-    async def counting_search(*args, **kwargs):
-        nonlocal call_count
-        call_count += 1
-        return await original_search(*args, **kwargs)
-
-    actions.user_message_index.search = counting_search
-
-    chat.app.generate(messages=[{"role": "user", "content": "hey there"}])
-
-    assert call_count == 1, (
+    assert mock_search.call_count == 1, (
         f"user_message_index.search should be called exactly once "
-        f"when embeddings_only is disabled, but was called {call_count} times"
+        f"when embeddings_only is disabled, but was called {mock_search.call_count} times"
     )


### PR DESCRIPTION
### Description

When `embeddings_only` is disabled (the default), `user_message_index.search()` was called **twice** with the same text per request. The first search result was never used andboth conditional branches that consume it gate on `embeddings_only=True`, so execution always fell through to the `else` branch which searched again with `threshold=None`.

### Fix

Restructure the conditional so the threshold-based search only runs when `embeddings_only=True`. The `threshold=None` search runs exactly once in the default path.

### Impact
Removes 1 redundant embedding API call per request (2 -> 1 on `user_message_index`).

### Known limitation (pre-existing, not introduced by this PR)

When `embeddings_only=True` but no results pass the similarity threshold **and** no `embeddings_only_fallback_intent` is configured, execution still falls through to a second search and an LLM call.

This path remains 2 searches and contradicts the `embeddings_only` intent. This was the same behavior before this change. fixing it would alter observable behavior and is tracked separately.

Refs: ‪#1127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized intent resolution logic to reduce redundant search operations

* **Tests**
  * Added test verifying search efficiency for intent resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->