### PR TITLE
refactor(llm)!: atomic switch to LLMModel protocol

### DIFF
--- a/nemoguardrails/__init__.py
+++ b/nemoguardrails/__init__.py
@@ -48,5 +48,17 @@ else:
     # Use the original LLMRails class
     from nemoguardrails.rails import LLMRails
 
+from nemoguardrails.llm.frameworks import (  # noqa: E402
+    get_default_framework,
+    register_framework,
+    set_default_framework,
+)
+
 __version__ = version("nemoguardrails")
-__all__ = ["LLMRails", "RailsConfig"]
+__all__ = [
+    "LLMRails",
+    "RailsConfig",
+    "get_default_framework",
+    "register_framework",
+    "set_default_framework",
+]

--- a/nemoguardrails/actions/llm/generation.py
+++ b/nemoguardrails/actions/llm/generation.py
@@ -23,11 +23,10 @@ import sys
 from dataclasses import asdict
 from functools import lru_cache
 from time import time
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 from jinja2 import meta
 from jinja2.sandbox import SandboxedEnvironment
-from langchain_core.language_models import BaseChatModel, BaseLLM
 
 from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.actions.llm.utils import (
@@ -61,6 +60,7 @@ from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.rails.llm.config import EmbeddingSearchProvider, RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import (
     new_event_dict,
     new_uuid,
@@ -79,7 +79,7 @@ class LLMGenerationActions:
     def __init__(
         self,
         config: RailsConfig,
-        llm: Optional[Union[BaseLLM, BaseChatModel]],
+        llm: Optional[LLMModel],
         llm_task_manager: LLMTaskManager,
         get_embedding_search_provider_instance: Callable[[Optional[EmbeddingSearchProvider]], EmbeddingsIndex],
         verbose: bool = False,
@@ -350,7 +350,7 @@ class LLMGenerationActions:
         events: List[dict],
         context: dict,
         config: RailsConfig,
-        llm: Optional[Union[BaseLLM, BaseChatModel]] = None,
+        llm: Optional[LLMModel] = None,
         kb: Optional[KnowledgeBase] = None,
     ):
         """Generate the canonical form for what the user said i.e. user intent."""
@@ -369,7 +369,7 @@ class LLMGenerationActions:
 
         # Use action specific llm if registered else fallback to main llm
         # This can be None as some code-paths use embedding lookups rather than LLM generation
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         streaming_handler = streaming_handler_var.get()
 
@@ -424,11 +424,13 @@ class LLMGenerationActions:
             llm_call_info_var.set(LLMCallInfo(task=Task.GENERATE_USER_INTENT.value))
 
             # We make this call with temperature 0 to have it as deterministic as possible.
-            result = await llm_call(
-                generation_llm,
-                prompt,
-                llm_params={"temperature": self.config.lowest_temperature},
-            )
+            result = (
+                await llm_call(
+                    generation_llm,
+                    prompt,
+                    llm_params={"temperature": self.config.lowest_temperature},
+                )
+            ).content
 
             # Parse the output using the associated parser
             result = self.llm_task_manager.parse_task_output(Task.GENERATE_USER_INTENT, output=result)
@@ -501,12 +503,14 @@ class LLMGenerationActions:
 
                     streaming_handler: Optional[StreamingHandler] = streaming_handler_var.get()
 
-                    text = await llm_call(
-                        generation_llm,
-                        prompt,
-                        streaming_handler=streaming_handler,
-                        llm_params=llm_params,
-                    )
+                    text = (
+                        await llm_call(
+                            generation_llm,
+                            prompt,
+                            streaming_handler=streaming_handler,
+                            llm_params=llm_params,
+                        )
+                    ).content
                     text = self.llm_task_manager.parse_task_output(Task.GENERAL, output=text)
 
             else:
@@ -530,13 +534,15 @@ class LLMGenerationActions:
                 generation_options: Optional[GenerationOptions] = generation_options_var.get()
                 llm_params = (generation_options and generation_options.llm_params) or {}
 
-                result = await llm_call(
-                    generation_llm,
-                    prompt,
-                    streaming_handler=streaming_handler,
-                    stop=["User:"],
-                    llm_params=llm_params,
-                )
+                result = (
+                    await llm_call(
+                        generation_llm,
+                        prompt,
+                        streaming_handler=streaming_handler,
+                        stop=["User:"],
+                        llm_params=llm_params,
+                    )
+                ).content
 
                 text = self.llm_task_manager.parse_task_output(Task.GENERAL, output=result)
                 text = text.strip()
@@ -588,7 +594,7 @@ class LLMGenerationActions:
         return final_results[0:max_results]
 
     @action(is_system_action=True)
-    async def generate_next_steps(self, events: List[dict], llm: Optional[BaseLLM] = None):
+    async def generate_next_steps(self, events: List[dict], llm: Optional[LLMModel] = None):
         """Generate the next step in the current conversation flow.
 
         Currently, only generates a next step after a user intent.
@@ -596,7 +602,7 @@ class LLMGenerationActions:
         log.info("Phase 2 :: Generating next step ...")
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         # The last event should be the "StartInternalSystemAction" and the one before it the "UserIntent".
         event = get_last_user_intent_event(events)
@@ -633,11 +639,13 @@ class LLMGenerationActions:
             llm_call_info_var.set(LLMCallInfo(task=Task.GENERATE_NEXT_STEPS.value))
 
             # We use temperature 0 for next step prediction as well
-            result = await llm_call(
-                generation_llm,
-                prompt,
-                llm_params={"temperature": self.config.lowest_temperature},
-            )
+            result = (
+                await llm_call(
+                    generation_llm,
+                    prompt,
+                    llm_params={"temperature": self.config.lowest_temperature},
+                )
+            ).content
 
             # Parse the output using the associated parser
             result = self.llm_task_manager.parse_task_output(Task.GENERATE_NEXT_STEPS, output=result)
@@ -743,12 +751,12 @@ class LLMGenerationActions:
         return template.render(render_context)
 
     @action(is_system_action=True)
-    async def generate_bot_message(self, events: List[dict], context: dict, llm: Optional[BaseLLM] = None):
+    async def generate_bot_message(self, events: List[dict], context: dict, llm: Optional[LLMModel] = None):
         """Generate a bot message based on the desired bot intent."""
         log.info("Phase 3 :: Generating bot message ...")
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         # The last event should be the "StartInternalSystemAction" and the one before it the "BotIntent".
         event = get_last_bot_intent_event(events)
@@ -894,12 +902,14 @@ class LLMGenerationActions:
 
                     if not prompt:
                         raise RuntimeError("No prompt found to generate bot message")
-                    result = await llm_call(
-                        generation_llm,
-                        prompt,
-                        streaming_handler=streaming_handler,
-                        llm_params=llm_params,
-                    )
+                    result = (
+                        await llm_call(
+                            generation_llm,
+                            prompt,
+                            streaming_handler=streaming_handler,
+                            llm_params=llm_params,
+                        )
+                    ).content
 
                     result = self.llm_task_manager.parse_task_output(Task.GENERAL, output=result)
 
@@ -948,12 +958,14 @@ class LLMGenerationActions:
                 generation_options: Optional[GenerationOptions] = generation_options_var.get()
                 llm_params = (generation_options and generation_options.llm_params) or {}
 
-                result = await llm_call(
-                    generation_llm,
-                    prompt,
-                    streaming_handler=streaming_handler,
-                    llm_params=llm_params,
-                )
+                result = (
+                    await llm_call(
+                        generation_llm,
+                        prompt,
+                        streaming_handler=streaming_handler,
+                        llm_params=llm_params,
+                    )
+                ).content
 
                 log.info(
                     "--- :: LLM Bot Message Generation call took %.2f seconds",
@@ -1016,7 +1028,7 @@ class LLMGenerationActions:
         instructions: str,
         events: List[dict],
         var_name: Optional[str] = None,
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ):
         """Generate a value in the context of the conversation.
 
@@ -1027,7 +1039,7 @@ class LLMGenerationActions:
         :param llm: Custom llm model to generate_value
         """
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         last_event = events[-1]
         assert last_event["type"] == "StartInternalSystemAction"
@@ -1062,11 +1074,13 @@ class LLMGenerationActions:
         # Initialize the LLMCallInfo object
         llm_call_info_var.set(LLMCallInfo(task=Task.GENERATE_VALUE.value))
 
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         # Parse the output using the associated parser
         result = self.llm_task_manager.parse_task_output(Task.GENERATE_VALUE, output=result)
@@ -1092,7 +1106,7 @@ class LLMGenerationActions:
     async def generate_intent_steps_message(
         self,
         events: List[dict],
-        llm: Optional[Union[BaseLLM, BaseChatModel]] = None,
+        llm: Optional[LLMModel] = None,
         kb: Optional[KnowledgeBase] = None,
     ):
         """Generate all three main Guardrails phases with a single LLM call.
@@ -1110,7 +1124,7 @@ class LLMGenerationActions:
                 "Cannot generate user intent from this event type."
             )
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         streaming_handler = streaming_handler_var.get()
 
@@ -1274,7 +1288,7 @@ class LLMGenerationActions:
                     **llm_params,
                     "temperature": self.config.lowest_temperature,
                 }
-                result = await llm_call(generation_llm, prompt, llm_params=additional_params)
+                result = (await llm_call(generation_llm, prompt, llm_params=additional_params)).content
 
             # Parse the output using the associated parser
             result = self.llm_task_manager.parse_task_output(Task.GENERATE_INTENT_STEPS_MESSAGE, output=result)
@@ -1341,7 +1355,7 @@ class LLMGenerationActions:
             # We make this call with temperature 0 to have it as deterministic as possible.
             gen_options: Optional[GenerationOptions] = generation_options_var.get()
             llm_params = (gen_options and gen_options.llm_params) or {}
-            result = await llm_call(generation_llm, prompt, llm_params=llm_params)
+            result = (await llm_call(generation_llm, prompt, llm_params=llm_params)).content
 
             result = self.llm_task_manager.parse_task_output(Task.GENERAL, output=result)
             text = result.strip()

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -277,12 +277,15 @@ def _raise_llm_call_exception(
     llm_call_info = llm_call_info_var.get()
     model_name = llm_call_info.llm_model_name if llm_call_info else model.model_name
     provider_name = llm_call_info.llm_provider_name if llm_call_info else model.provider_name
+    endpoint_url = model.provider_url
 
     context_parts = []
     if model_name:
         context_parts.append(f"model={model_name}")
     if provider_name:
         context_parts.append(f"provider={provider_name}")
+    if endpoint_url:
+        context_parts.append(f"endpoint={endpoint_url}")
 
     if context_parts:
         detail = f"Error invoking LLM ({', '.join(context_parts)})"

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -233,9 +233,9 @@ def _update_token_stats(response: LLMResponse) -> None:
         llm_call_info.completion_tokens = 0
 
     if response.usage:
-        llm_call_info.total_tokens += response.usage.total_tokens
-        llm_call_info.prompt_tokens += response.usage.input_tokens
-        llm_call_info.completion_tokens += response.usage.output_tokens
+        llm_call_info.total_tokens = response.usage.total_tokens
+        llm_call_info.prompt_tokens = response.usage.input_tokens
+        llm_call_info.completion_tokens = response.usage.output_tokens
 
         if llm_stats:
             llm_stats.inc("total_tokens", response.usage.total_tokens)

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -82,9 +82,9 @@ async def llm_call(
     except Exception as e:
         _raise_llm_call_exception(e, model)
 
+    _store_reasoning_traces(response)
     _log_completion(response)
     _update_token_stats(response)
-    _store_reasoning_traces(response)
     _store_tool_calls(response)
     _store_response_metadata(response)
     return response

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -15,10 +15,7 @@
 
 import logging
 import re
-from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union
-
-from langchain_core.language_models import BaseLanguageModel
-from langchain_core.runnables.base import Runnable
+from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union, cast
 
 from nemoguardrails.colang.v2_x.lang.colang_ast import Flow
 from nemoguardrails.colang.v2_x.runtime.flows import InternalEvent, InternalEvents
@@ -30,249 +27,84 @@ from nemoguardrails.context import (
     tool_calls_var,
 )
 from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.integrations.langchain.message_utils import dicts_to_messages
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.llm_tracker import track_llm_call
+from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk
 
 if TYPE_CHECKING:
     from nemoguardrails.streaming import StreamingHandler
 
 logger = logging.getLogger(__name__)
 
-# Since different providers have different attributes for the base URL, we'll use this list
-# to attempt to extract the base URL from a `BaseLanguageModel` instance.
-BASE_URL_ATTRIBUTES = [
-    "base_url",
-    "endpoint_url",
-    "server_url",
-    "azure_endpoint",
-    "openai_api_base",
-    "api_base",
-    "api_host",
-    "endpoint",
-]
+
+def _ensure_chat_messages(prompt: Union[str, list]) -> Union[str, List[ChatMessage]]:
+    if isinstance(prompt, str):
+        return prompt
+    if not prompt:
+        return cast(List[ChatMessage], [])
+    if isinstance(prompt[0], ChatMessage):
+        return cast(List[ChatMessage], prompt)
+    return [ChatMessage.from_dict(d) for d in prompt]
 
 
-def _infer_provider_from_module(llm: BaseLanguageModel) -> Optional[str]:
-    """Infer provider name from the LLM's module path.
-
-    This function extracts the provider name from LangChain package naming conventions:
-    - langchain_openai -> openai
-    - langchain_anthropic -> anthropic
-    - langchain_google_genai -> google_genai
-    - langchain_nvidia_ai_endpoints -> nvidia_ai_endpoints
-    - langchain_community.chat_models.ollama -> ollama
-
-    For patched/wrapped classes, checks base classes as well.
-
-    Args:
-        llm: The LLM instance
-
-    Returns:
-        The inferred provider name, or None if it cannot be determined
-    """
-    module = type(llm).__module__
-
-    if module.startswith("langchain_"):
-        package = module.split(".")[0]
-        provider = package.replace("langchain_", "")
-
-        if provider == "community":
-            parts = module.split(".")
-            if len(parts) >= 3:
-                provider = parts[-1]
-                return provider
-        else:
-            return provider
-
-    for base_class in type(llm).__mro__[1:]:
-        base_module = base_class.__module__
-        if base_module.startswith("langchain_"):
-            package = base_module.split(".")[0]
-            provider = package.replace("langchain_", "")
-
-            if provider == "community":
-                parts = base_module.split(".")
-                if len(parts) >= 3:
-                    provider = parts[-1]
-                    return provider
-            else:
-                return provider
-
-    return None
-
-
-def get_llm_provider(llm: BaseLanguageModel) -> Optional[str]:
-    """Get the provider name for an LLM instance by inferring from module path.
-
-    This function extracts the provider name from LangChain package naming conventions.
-    See _infer_provider_from_module for details on the inference logic.
-
-    Args:
-        llm: The LLM instance
-
-    Returns:
-        The provider name if it can be inferred, None otherwise
-    """
-    return _infer_provider_from_module(llm)
-
-
-def _infer_model_name(llm: BaseLanguageModel):
-    """Helper to infer the model name based from an LLM instance.
-
-    Because not all models implement correctly _identifying_params from LangChain, we have to
-    try to do this manually.
-    """
-    for attr in ["model", "model_name"]:
-        if hasattr(llm, attr):
-            val = getattr(llm, attr)
-            if isinstance(val, str):
-                return val
-
-    model_kwargs = getattr(llm, "model_kwargs", None)
-    if model_kwargs and isinstance(model_kwargs, Dict):
-        for attr in ["model", "model_name", "name"]:
-            val = model_kwargs.get(attr)
-            if isinstance(val, str):
-                return val
-
-    # If we still can't figure out, return "unknown".
-    return "unknown"
-
-
-def _filter_params_for_openai_reasoning_models(llm: BaseLanguageModel, llm_params: Optional[dict]) -> Optional[dict]:
-    """Filter out unsupported parameters for OpenAI reasoning models.
-
-    OpenAI reasoning models (o1, o3, gpt-5 excluding gpt-5-chat) do only allow
-    specific parameters (e.g. temperature, which is always fixed at 1, or stop).
-    When using .bind() with different values for these parameters, the API
-    returns an error. This function removes the unsupported parameters for specific
-    OpenAI reasoning models to ensure correct functionality for the API calls.
-
-    See also: https://github.com/langchain-ai/langchain/blob/master/libs/partners/openai/langchain_openai/chat_models/base.py
-
-    Stop not supported as a parameter in the following models (as of Jan 26):
-    gpt5+ (only gpt-5-chat-latest works), o3, o3-pro (but o3-mini works), o4-mini
-    """
-    if not llm_params or ("temperature" not in llm_params and "stop" not in llm_params):
-        return llm_params
-
-    model_name = _infer_model_name(llm).lower()
-
-    # Models that do not support temperature as a param, or changing its default value
-    is_temperature_not_supported = (
-        model_name.startswith("o1")
-        or model_name.startswith("o3")
-        or (model_name.startswith("gpt-5") and "chat" not in model_name)
-    )
-    # Models that do not support stop as a param
-    is_stop_not_supported = (
-        (model_name.startswith("o3") and "o3-mini" not in model_name)
-        or model_name.startswith("o4-mini")
-        or (model_name.startswith("gpt-5") and "gpt-5-chat" not in model_name)
-    )
-
-    if is_temperature_not_supported or is_stop_not_supported:
-        filtered = llm_params.copy()
-        if is_temperature_not_supported:
-            filtered.pop("temperature", None)
-        if is_stop_not_supported:
-            filtered.pop("stop", None)
-        return filtered
-
-    return llm_params
-
-
+# TODO: we must drop prompt in the codebase completely and use messages everywhere.
 @track_llm_call
 async def llm_call(
-    llm: Optional[BaseLanguageModel],
+    llm: Optional[Any],
     prompt: Union[str, List[dict]],
     model_name: Optional[str] = None,
     model_provider: Optional[str] = None,
     stop: Optional[List[str]] = None,
     llm_params: Optional[dict] = None,
     streaming_handler: Optional["StreamingHandler"] = None,
-) -> str:
-    """Calls the LLM with a prompt and returns the generated text.
-
-    If streaming_handler is provided, uses astream() to push chunks to the handler
-    as they arrive. The handler can be iterated over concurrently by other code.
-
-    Args:
-        llm: The language model instance to use
-        prompt: The prompt string or list of messages
-        model_name: Optional model name for tracking
-        model_provider: Optional model provider for tracking
-        stop: Optional list of stop tokens
-        llm_params: Optional configuration dictionary to pass to the LLM (e.g., temperature, max_tokens)
-        streaming_handler: Optional StreamingHandler to receive streaming chunks
-
-    Returns:
-        The generated text response
-    """
+) -> LLMResponse:
     if llm is None:
         raise LLMCallException(ValueError("No LLM provided to llm_call()"))
-    _setup_llm_call_info(llm, model_name, model_provider)
-    _log_prompt(prompt)
 
-    llm_params_with_stop: Optional[dict]
-    if stop:
-        llm_params_with_stop = llm_params.copy() if llm_params else {}
-        llm_params_with_stop["stop"] = stop
+    model: LLMModel
+    if isinstance(llm, LLMModel):
+        model = llm
     else:
-        llm_params_with_stop = llm_params
+        raise TypeError(
+            f"Expected an LLMModel instance, got {type(llm).__name__}. "
+            "Wrap your LLM with an appropriate adapter before passing it to llm_call()."
+        )
 
-    filtered_params = _filter_params_for_openai_reasoning_models(llm, llm_params_with_stop)
-    generation_llm: Union[BaseLanguageModel, Runnable] = llm.bind(**filtered_params) if filtered_params else llm
+    _setup_llm_call_info(model, model_name, model_provider)
+    _log_prompt(prompt)
+    chat_prompt = _ensure_chat_messages(prompt)
 
     if streaming_handler:
-        return await _stream_llm_call(generation_llm, prompt, streaming_handler)
-    else:
-        if isinstance(prompt, str):
-            response = await _invoke_with_string_prompt(generation_llm, prompt)
-        else:
-            response = await _invoke_with_message_list(generation_llm, prompt)
+        return await _stream_llm_call(model, chat_prompt, streaming_handler, stop, llm_params)
 
-        _store_reasoning_traces(response)
-        _log_completion(response)
-        _update_token_stats(response)
-        _store_tool_calls(response)
-        _store_response_metadata(response)
-        return _extract_content(response)
+    try:
+        response: LLMResponse = await model.generate(chat_prompt, stop=stop, **(llm_params or {}))
+    except Exception as e:
+        _raise_llm_call_exception(e, model)
+
+    _log_completion(response)
+    _update_token_stats(response)
+    _store_reasoning_traces(response)
+    _store_tool_calls(response)
+    _store_response_metadata(response)
+    return response
 
 
 async def _stream_llm_call(
-    llm: Union[BaseLanguageModel, Runnable],
-    prompt: Union[str, List[dict]],
+    model: LLMModel,
+    prompt: Union[str, List[ChatMessage]],
     handler: "StreamingHandler",
-) -> str:
-    """Stream LLM response using astream().
-
-    Pushes each chunk to the handler's queue. Another consumer can
-    iterate over the handler concurrently to receive chunks.
-    """
-    if isinstance(prompt, list):
-        messages = _convert_messages_to_langchain_format(prompt)
-    else:
-        messages = prompt
-
-    stop = []
-    if hasattr(llm, "kwargs"):
-        current_params = getattr(llm, "kwargs", {})
-        stop = current_params.get("stop", [])
-    if not stop:
-        stop = getattr(llm, "stop", [])
-    handler.stop = stop
+    stop: Optional[List[str]],
+    llm_params: Optional[dict] = None,
+) -> LLMResponse:
+    handler.stop = stop or []
     accumulated_metadata: Dict[str, Any] = {}
-    last_chunk = None
+    last_chunk: Optional[LLMResponseChunk] = None
 
     try:
-        async for chunk in llm.astream(messages):
+        async for chunk in model.stream(prompt, stop=stop, **(llm_params or {})):
             last_chunk = chunk
-            if hasattr(chunk, "content"):
-                content = chunk.content
-            else:
-                content = str(chunk)
+            content = chunk.delta_content or ""
 
             chunk_metadata = _extract_chunk_metadata(chunk)
             if chunk_metadata:
@@ -292,30 +124,38 @@ async def _stream_llm_call(
         if last_chunk is not None:
             _update_token_stats_from_chunk(last_chunk)
 
-        return handler.completion
+        return LLMResponse(
+            content=handler.completion,
+            usage=last_chunk.usage if last_chunk else None,
+            provider_metadata=accumulated_metadata if accumulated_metadata else None,
+        )
 
     except Exception as e:
-        _raise_llm_call_exception(e, llm)
+        _raise_llm_call_exception(e, model)
 
 
-def _extract_chunk_metadata(chunk) -> Optional[Dict[str, Any]]:
+def _extract_chunk_metadata(chunk: LLMResponseChunk) -> Optional[Dict[str, Any]]:
     metadata: Dict[str, Any] = {}
-    if hasattr(chunk, "response_metadata") and chunk.response_metadata:
-        metadata["response_metadata"] = chunk.response_metadata
-    if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
-        metadata["usage_metadata"] = chunk.usage_metadata
+    if chunk.provider_metadata:
+        metadata["provider_metadata"] = chunk.provider_metadata
+    if chunk.usage:
+        metadata["usage"] = {
+            "input_tokens": chunk.usage.input_tokens,
+            "output_tokens": chunk.usage.output_tokens,
+            "total_tokens": chunk.usage.total_tokens,
+        }
     return metadata if metadata else None
 
 
-def _setup_llm_call_info(llm: BaseLanguageModel, model_name: Optional[str], model_provider: Optional[str]) -> None:
+def _setup_llm_call_info(model: LLMModel, model_name: Optional[str], model_provider: Optional[str]) -> None:
     """Initialize or update LLM call info in context."""
     llm_call_info = llm_call_info_var.get()
     if llm_call_info is None:
         llm_call_info = LLMCallInfo()
         llm_call_info_var.set(llm_call_info)
 
-    llm_call_info.llm_model_name = model_name or _infer_model_name(llm)
-    llm_call_info.llm_provider_name = model_provider or _infer_provider_from_module(llm)
+    llm_call_info.llm_model_name = model_name or model.model_name
+    llm_call_info.llm_provider_name = model_provider or model.provider_name
 
 
 def _log_prompt(prompt: Union[str, List[dict]]) -> None:
@@ -358,8 +198,7 @@ def _log_prompt(prompt: Union[str, List[dict]]) -> None:
         )
 
 
-def _log_completion(response) -> None:
-    """Log the completion from the response."""
+def _log_completion(response: LLMResponse) -> None:
     llm_call_info = llm_call_info_var.get()
     if llm_call_info is None:
         return
@@ -367,12 +206,8 @@ def _log_completion(response) -> None:
     completion_text = _extract_content(response)
     llm_call_info.completion = completion_text
 
-    reasoning_content = None
-    if hasattr(response, "additional_kwargs"):
-        reasoning_content = response.additional_kwargs.get("reasoning_content")
-
-    if reasoning_content:
-        full_completion = f"{reasoning_content}\n---\n{completion_text}"
+    if response.reasoning:
+        full_completion = f"{response.reasoning}\n---\n{completion_text}"
     else:
         full_completion = completion_text
 
@@ -383,8 +218,7 @@ def _log_completion(response) -> None:
     )
 
 
-def _update_token_stats(response) -> None:
-    """Update token usage statistics from the response."""
+def _update_token_stats(response: LLMResponse) -> None:
     llm_call_info = llm_call_info_var.get()
     llm_stats = llm_stats_var.get()
 
@@ -398,51 +232,20 @@ def _update_token_stats(response) -> None:
     if not llm_call_info.completion_tokens:
         llm_call_info.completion_tokens = 0
 
-    token_stats_found = False
-
-    if hasattr(response, "usage_metadata") and response.usage_metadata:
-        token_stats_found = True
-        usage = response.usage_metadata
-        total = usage.get("total_tokens", 0)
-        input_tokens = usage.get("input_tokens", 0)
-        output_tokens = usage.get("output_tokens", 0)
-
-        llm_call_info.total_tokens = total
-        llm_call_info.prompt_tokens = input_tokens
-        llm_call_info.completion_tokens = output_tokens
+    if response.usage:
+        llm_call_info.total_tokens += response.usage.total_tokens
+        llm_call_info.prompt_tokens += response.usage.input_tokens
+        llm_call_info.completion_tokens += response.usage.output_tokens
 
         if llm_stats:
-            llm_stats.inc("total_tokens", total)
-            llm_stats.inc("total_prompt_tokens", input_tokens)
-            llm_stats.inc("total_completion_tokens", output_tokens)
-
-    if not token_stats_found and hasattr(response, "response_metadata") and response.response_metadata:
-        token_usage = response.response_metadata.get("token_usage", {})
-        if token_usage:
-            token_stats_found = True
-            total = token_usage.get("total_tokens", 0)
-            prompt_tokens = token_usage.get("prompt_tokens", 0)
-            completion_tokens = token_usage.get("completion_tokens", 0)
-
-            llm_call_info.total_tokens = total
-            llm_call_info.prompt_tokens = prompt_tokens
-            llm_call_info.completion_tokens = completion_tokens
-
-            if llm_stats:
-                llm_stats.inc("total_tokens", total)
-                llm_stats.inc("total_prompt_tokens", prompt_tokens)
-                llm_stats.inc("total_completion_tokens", completion_tokens)
-
-    if not token_stats_found:
+            llm_stats.inc("total_tokens", response.usage.total_tokens)
+            llm_stats.inc("total_prompt_tokens", response.usage.input_tokens)
+            llm_stats.inc("total_completion_tokens", response.usage.output_tokens)
+    else:
         logger.info("Token stats in LLM call info cannot be computed for current model!")
 
 
-def _update_token_stats_from_chunk(chunk) -> None:
-    """Update token usage statistics from a streaming chunk.
-
-    For streaming, token usage is often provided in the last chunk's response_metadata,
-    usage_metadata, or generation_info with a slightly different format than non-streaming.
-    """
+def _update_token_stats_from_chunk(chunk: LLMResponseChunk) -> None:
     llm_call_info = llm_call_info_var.get()
     llm_stats = llm_stats_var.get()
 
@@ -456,107 +259,30 @@ def _update_token_stats_from_chunk(chunk) -> None:
     if not llm_call_info.completion_tokens:
         llm_call_info.completion_tokens = 0
 
-    token_stats_found = False
-
-    if hasattr(chunk, "usage_metadata") and chunk.usage_metadata:
-        token_stats_found = True
-        usage = chunk.usage_metadata
-        total = usage.get("total_tokens", 0)
-        input_tokens = usage.get("input_tokens", 0)
-        output_tokens = usage.get("output_tokens", 0)
-
-        llm_call_info.total_tokens = total
-        llm_call_info.prompt_tokens = input_tokens
-        llm_call_info.completion_tokens = output_tokens
+    if chunk.usage:
+        llm_call_info.total_tokens = chunk.usage.total_tokens
+        llm_call_info.prompt_tokens = chunk.usage.input_tokens
+        llm_call_info.completion_tokens = chunk.usage.output_tokens
 
         if llm_stats:
-            llm_stats.inc("total_tokens", total)
-            llm_stats.inc("total_prompt_tokens", input_tokens)
-            llm_stats.inc("total_completion_tokens", output_tokens)
-
-    if not token_stats_found and hasattr(chunk, "response_metadata") and chunk.response_metadata:
-        token_usage = chunk.response_metadata.get("token_usage", {})
-        if not token_usage:
-            token_usage = chunk.response_metadata.get("usage", {})
-        if token_usage:
-            token_stats_found = True
-            total = token_usage.get("total_tokens", 0)
-            prompt_tokens = token_usage.get("prompt_tokens", token_usage.get("input_tokens", 0))
-            completion_tokens = token_usage.get("completion_tokens", token_usage.get("output_tokens", 0))
-
-            llm_call_info.total_tokens = total
-            llm_call_info.prompt_tokens = prompt_tokens
-            llm_call_info.completion_tokens = completion_tokens
-
-            if llm_stats:
-                llm_stats.inc("total_tokens", total)
-                llm_stats.inc("total_prompt_tokens", prompt_tokens)
-                llm_stats.inc("total_completion_tokens", completion_tokens)
-
-    if not token_stats_found and hasattr(chunk, "generation_info") and chunk.generation_info:
-        token_usage = chunk.generation_info.get("token_usage", {})
-        if not token_usage:
-            token_usage = chunk.generation_info.get("usage", {})
-        if token_usage:
-            token_stats_found = True
-            total = token_usage.get("total_tokens", 0)
-            prompt_tokens = token_usage.get("prompt_tokens", token_usage.get("input_tokens", 0))
-            completion_tokens = token_usage.get("completion_tokens", token_usage.get("output_tokens", 0))
-
-            llm_call_info.total_tokens = total
-            llm_call_info.prompt_tokens = prompt_tokens
-            llm_call_info.completion_tokens = completion_tokens
-
-            if llm_stats:
-                llm_stats.inc("total_tokens", total)
-                llm_stats.inc("total_prompt_tokens", prompt_tokens)
-                llm_stats.inc("total_completion_tokens", completion_tokens)
+            llm_stats.inc("total_tokens", chunk.usage.total_tokens)
+            llm_stats.inc("total_prompt_tokens", chunk.usage.input_tokens)
+            llm_stats.inc("total_completion_tokens", chunk.usage.output_tokens)
 
 
 def _raise_llm_call_exception(
     exception: Exception,
-    llm: Union[BaseLanguageModel, Runnable],
+    model: LLMModel,
 ) -> NoReturn:
-    """Raise an LLMCallException with enriched context about the failed invocation.
-
-    Args:
-        exception: The original exception that occurred
-        llm: The LLM instance that was being invoked
-
-    Raises:
-        LLMCallException with context message including model name and endpoint
-    """
-    # Extract model name from context
     llm_call_info = llm_call_info_var.get()
-    model_name = (
-        llm_call_info.llm_model_name
-        if llm_call_info
-        else _infer_model_name(llm)
-        if isinstance(llm, BaseLanguageModel)
-        else ""
-    )
+    model_name = llm_call_info.llm_model_name if llm_call_info else model.model_name
+    provider_name = llm_call_info.llm_provider_name if llm_call_info else model.provider_name
 
-    # Extract endpoint URL from the LLM instance
-    endpoint_url = None
-    for attr in BASE_URL_ATTRIBUTES:
-        if hasattr(llm, attr):
-            value = getattr(llm, attr, None)
-            if value:
-                endpoint_url = str(value)
-                break
-
-    # If we didn't find endpoint URL, check the nested client object.
-    if not endpoint_url and hasattr(llm, "client"):
-        client = getattr(llm, "client", None)
-        if client and hasattr(client, "base_url"):
-            endpoint_url = str(client.base_url)
-
-    # Build context message with model and endpoint info
     context_parts = []
     if model_name:
         context_parts.append(f"model={model_name}")
-    if endpoint_url:
-        context_parts.append(f"endpoint={endpoint_url}")
+    if provider_name:
+        context_parts.append(f"provider={provider_name}")
 
     if context_parts:
         detail = f"Error invoking LLM ({', '.join(context_parts)})"
@@ -565,88 +291,16 @@ def _raise_llm_call_exception(
         raise LLMCallException(exception) from exception
 
 
-async def _invoke_with_string_prompt(
-    llm: Union[BaseLanguageModel, Runnable],
-    prompt: str,
-):
-    """Invoke LLM with string prompt."""
-    try:
-        return await llm.ainvoke(prompt)
-    except Exception as e:
-        _raise_llm_call_exception(e, llm)
-
-
-async def _invoke_with_message_list(
-    llm: Union[BaseLanguageModel, Runnable],
-    prompt: List[dict],
-):
-    """Invoke LLM with message list after converting to LangChain format."""
-    messages = _convert_messages_to_langchain_format(prompt)
-
-    try:
-        return await llm.ainvoke(messages)
-    except Exception as e:
-        _raise_llm_call_exception(e, llm)
-
-
-def _convert_messages_to_langchain_format(prompt: List[dict]) -> List:
-    """Convert message list to LangChain message format."""
-    return dicts_to_messages(prompt)
-
-
-def _store_reasoning_traces(response) -> None:
-    """Store reasoning traces from response in context variable.
-
-    Tries multiple extraction methods in order of preference:
-    1. content_blocks with type="reasoning" (LangChain v1 standard)
-    2. additional_kwargs["reasoning_content"] (provider-specific)
-    3. <think> tags in content (legacy fallback)
-
-    Args:
-        response: The LLM response object
-    """
-    reasoning_content = _extract_reasoning_from_content_blocks(response)
+def _store_reasoning_traces(response: LLMResponse) -> None:
+    reasoning_content = response.reasoning
 
     if not reasoning_content:
-        reasoning_content = _extract_reasoning_from_additional_kwargs(response)
-
-    if not reasoning_content:
-        # Some LLM providers (e.g., certain NVIDIA models) embed reasoning in <think> tags
-        # instead of properly populating reasoning_content in additional_kwargs, so we need
-        # both extraction methods to support different provider implementations.
         reasoning_content = _extract_and_remove_think_tags(response)
 
-    # Always set the variable, even if reasoning_content is None.
-    # This ensures each LLM call has a clean slate and prevents stale reasoning
-    # traces from previous LLM calls (e.g., safety checks) from leaking through.
     reasoning_trace_var.set(reasoning_content)
 
 
-def _extract_reasoning_from_content_blocks(response) -> Optional[str]:
-    """Extract reasoning from content_blocks with type='reasoning'.
-
-    This is the LangChain v1 standard for structured content blocks.
-    """
-    if hasattr(response, "content_blocks"):
-        for block in response.content_blocks:
-            if block.get("type") == "reasoning":
-                return block.get("reasoning")
-    return None
-
-
-def _extract_reasoning_from_additional_kwargs(response) -> Optional[str]:
-    """Extract reasoning from additional_kwargs['reasoning_content'].
-
-    This is used by some providers for backward compatibility.
-    """
-    if hasattr(response, "additional_kwargs"):
-        additional_kwargs = response.additional_kwargs
-        if isinstance(additional_kwargs, dict):
-            return additional_kwargs.get("reasoning_content")
-    return None
-
-
-def _extract_and_remove_think_tags(response) -> Optional[str]:
+def _extract_and_remove_think_tags(response: LLMResponse) -> Optional[str]:
     """Extract reasoning from <think> tags and remove them from `response.content`.
 
     This function looks for <think>...</think> tags in the response content,
@@ -659,9 +313,6 @@ def _extract_and_remove_think_tags(response) -> Optional[str]:
     Returns:
         The extracted reasoning content, or None if no <think> tags found
     """
-    if not hasattr(response, "content"):
-        return None
-
     content = response.content
     has_opening_tag = "<think>" in content
     has_closing_tag = "</think>" in content
@@ -685,49 +336,20 @@ def _extract_and_remove_think_tags(response) -> Optional[str]:
     return None
 
 
-def _store_tool_calls(response) -> None:
-    """Extract and store tool calls from response in context."""
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    if not tool_calls:
-        tool_calls = _extract_tool_calls_from_attribute(response)
-    tool_calls_var.set(tool_calls)
-
-
-def _extract_tool_calls_from_content_blocks(response) -> List | None:
-    if hasattr(response, "content_blocks"):
-        tool_calls = []
-        for block in response.content_blocks:
-            if block.get("type") == "tool_call":
-                tool_calls.append(block)
-        return tool_calls if tool_calls else None
-    return None
-
-
-def _extract_tool_calls_from_attribute(response) -> List | None:
-    return getattr(response, "tool_calls", None)
-
-
-def _store_response_metadata(response) -> None:
-    """Store response metadata excluding content for metadata preservation.
-
-    Also extracts reasoning content from additional_kwargs if available from LangChain.
-    """
-    if hasattr(response, "model_fields"):
-        metadata = {}
-        for field_name in response.model_fields:
-            if field_name != "content":  # Exclude content since it may be modified by rails
-                metadata[field_name] = getattr(response, field_name)
-        llm_response_metadata_var.set(metadata)
-
+def _store_tool_calls(response: LLMResponse) -> None:
+    if response.tool_calls:
+        tool_calls_var.set([tc.to_dict() for tc in response.tool_calls])
     else:
-        llm_response_metadata_var.set(None)
+        tool_calls_var.set(None)
 
 
-def _extract_content(response) -> str:
+def _store_response_metadata(response: LLMResponse) -> None:
+    llm_response_metadata_var.set(response.provider_metadata)
+
+
+def _extract_content(response: LLMResponse) -> str:
     """Extract text content from response."""
-    if hasattr(response, "content"):
-        return response.content
-    return str(response)
+    return response.content
 
 
 def get_colang_history(

--- a/nemoguardrails/actions/v2_x/generation.py
+++ b/nemoguardrails/actions/v2_x/generation.py
@@ -19,9 +19,8 @@ import logging
 import re
 import textwrap
 from ast import literal_eval
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
-from langchain_core.language_models import BaseChatModel, BaseLLM
 from rich.text import Text
 
 from nemoguardrails.actions.actions import action
@@ -60,6 +59,7 @@ from nemoguardrails.logging import verbose
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.rails.llm.options import GenerationOptions
 from nemoguardrails.streaming import StreamingHandler
+from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import console, new_uuid
 
 log = logging.getLogger(__name__)
@@ -249,7 +249,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         return potential_user_intents, examples, is_embedding_only
 
     @action(name="GetLastUserMessageAction", is_system_action=True)
-    async def get_last_user_message(self, events: List[dict], llm: Optional[BaseLLM] = None) -> str:
+    async def get_last_user_message(self, events: List[dict], llm: Optional[LLMModel] = None) -> str:
         event = get_last_user_utterance_event_v2_x(events)
         assert event and event["type"] == "UtteranceUserActionFinished"
         return event["final_transcript"]
@@ -261,12 +261,12 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         events: List[dict],
         user_action: str,
         max_example_flows: int = 5,
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> str:
         """Generate the canonical form for what the user said i.e. user intent."""
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         log.info("Phase 1 :: Generating user intent")
         (
@@ -292,12 +292,14 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_USER_INTENT_FROM_USER_ACTION)
 
         # We make this call with lowest temperature to have it as deterministic as possible.
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            stop=stop,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                stop=stop,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         # Parse the output using the associated parser
         result = self.llm_task_manager.parse_task_output(Task.GENERATE_USER_INTENT_FROM_USER_ACTION, output=result)
@@ -330,12 +332,12 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         events: List[dict],
         user_action: str,
         max_example_flows: int = 5,
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> dict:
         """Generate the canonical form for what the user said i.e. user intent and a suitable bot action."""
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
         log.info("Phase 1 :: Generating user intent and bot action")
 
         (
@@ -359,12 +361,14 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_USER_INTENT_AND_BOT_ACTION_FROM_USER_ACTION)
 
         # We make this call with lowest temperature to have it as deterministic as possible.
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            stop=stop,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                stop=stop,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         # Parse the output using the associated parser
         result = self.llm_task_manager.parse_task_output(
@@ -407,7 +411,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         user_message: str,
         state: State,
         events: List[dict],
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ):
         if not llm:
             raise RuntimeError("No LLM provided to passthrough LLM Action")
@@ -445,12 +449,14 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         streaming_handler: Optional[StreamingHandler] = streaming_handler_var.get()
 
         generation_llm_params = generation_options and generation_options.llm_params
-        text = await llm_call(
-            llm,
-            user_message,
-            streaming_handler=streaming_handler,
-            llm_params=generation_llm_params,
-        )
+        text = (
+            await llm_call(
+                llm,
+                user_message,
+                streaming_handler=streaming_handler,
+                llm_params=generation_llm_params,
+            )
+        ).content
 
         text = self.llm_task_manager.parse_task_output(Task.GENERAL, output=text)
 
@@ -489,7 +495,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         state: State,
         instructions: str,
         events: List[dict],
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> dict:
         """Generate a flow from the provided instructions."""
 
@@ -499,7 +505,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             raise RuntimeError("No instruction flows index has been created.")
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
         log.info("Generating flow for instructions: %s", instructions)
 
         results = await self.instruction_flows_index.search(text=instructions, max_results=5, threshold=None)
@@ -525,11 +531,13 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         )
 
         # We make this call with temperature 0 to have it as deterministic as possible.
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         result = self.llm_task_manager.parse_task_output(task=Task.GENERATE_FLOW_FROM_INSTRUCTIONS, output=result)
 
@@ -561,7 +569,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         state: State,
         name: str,
         events: List[dict],
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> str:
         """Generate a flow from the provided NAME."""
 
@@ -572,7 +580,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             raise RuntimeError("No flows index has been created.")
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
         log.info("Generating flow for name: {name}")
 
         if not self.instruction_flows_index:
@@ -599,12 +607,14 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_FLOW_FROM_NAME)
 
         # We make this call with temperature 0 to have it as deterministic as possible.
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            stop=stop,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                stop=stop,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         result = self.llm_task_manager.parse_task_output(task=Task.GENERATE_FLOW_FROM_NAME, output=result)
 
@@ -621,7 +631,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         state: State,
         events: List[dict],
         temperature: Optional[float] = None,
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> dict:
         """Generate a continuation for the flow representing the current conversation."""
 
@@ -635,7 +645,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
             raise RuntimeError("No instruction flows index has been created.")
 
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         log.info("Generating flow continuation.")
 
@@ -668,7 +678,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         )
 
         # We make this call with temperature 0 to have it as deterministic as possible.
-        result = await llm_call(generation_llm, prompt, llm_params={"temperature": temperature})
+        result = (await llm_call(generation_llm, prompt, llm_params={"temperature": temperature})).content
 
         # TODO: Currently, we only support generating a bot action as continuation. This could be generalized
         # Colang statements.
@@ -745,7 +755,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         instructions: str,
         events: List[dict],
         var_name: Optional[str] = None,
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
     ) -> Any:
         """Generate a value in the context of the conversation.
 
@@ -755,7 +765,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         :param llm: Custom llm model to generate_value
         """
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         await self._ensure_flows_index()
 
@@ -789,7 +799,7 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
         stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_USER_INTENT_FROM_USER_ACTION)
 
-        result = await llm_call(generation_llm, prompt, stop=stop, llm_params={"temperature": 0.1})
+        result = (await llm_call(generation_llm, prompt, stop=stop, llm_params={"temperature": 0.1})).content
 
         # Parse the output using the associated parser
         result = self.llm_task_manager.parse_task_output(Task.GENERATE_VALUE_FROM_INSTRUCTION, output=result)
@@ -823,12 +833,12 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
         self,
         state: State,
         events: List[dict],
-        llm: Optional[BaseLLM] = None,
+        llm: Optional[LLMModel] = None,
         flow_id: Optional[str] = None,
     ) -> dict:
         """Generate the body for a flow."""
         # Use action specific llm if registered else fallback to main llm
-        generation_llm: Optional[Union[BaseLLM, BaseChatModel]] = llm if llm else self.llm
+        generation_llm: Optional[LLMModel] = llm if llm else self.llm
 
         triggering_flow_id = flow_id
         if not triggering_flow_id:
@@ -897,12 +907,14 @@ class LLMGenerationActionsV2dotx(LLMGenerationActions):
 
         stop = self.llm_task_manager.get_stop_tokens(Task.GENERATE_FLOW_CONTINUATION_FROM_NLD)
 
-        result = await llm_call(
-            generation_llm,
-            prompt,
-            stop=stop,
-            llm_params={"temperature": self.config.lowest_temperature},
-        )
+        result = (
+            await llm_call(
+                generation_llm,
+                prompt,
+                stop=stop,
+                llm_params={"temperature": self.config.lowest_temperature},
+            )
+        ).content
 
         # Parse the output using the associated parser
         result = self.llm_task_manager.parse_task_output(Task.GENERATE_FLOW_CONTINUATION_FROM_NLD, output=result)

--- a/nemoguardrails/eval/check.py
+++ b/nemoguardrails/eval/check.py
@@ -266,7 +266,7 @@ class LLMJudgeComplianceChecker:
                     self.print_prompt(prompt)
 
             # We run this with temperature 0 for deterministic results.
-            result = await llm_call(self.llm, prompt, llm_params={"temperature": 0})
+            result = (await llm_call(self.llm, prompt, llm_params={"temperature": 0})).content
 
             if self.verbose:
                 # If concurrency is greater than 1, we also print the prompt

--- a/nemoguardrails/evaluate/evaluate_factcheck.py
+++ b/nemoguardrails/evaluate/evaluate_factcheck.py
@@ -147,7 +147,7 @@ class FactCheckEvaluation:
                 force_string_to_message=True,
             )
             stop = self.llm_task_manager.get_stop_tokens(Task.SELF_CHECK_FACTS)
-            fact_check = asyncio.run(llm_call(prompt=fact_check_prompt, llm=self.llm, stop=stop))
+            fact_check = asyncio.run(llm_call(prompt=fact_check_prompt, llm=self.llm, stop=stop)).content
             end_time = time.time()
             time.sleep(0.5)  # avoid rate-limits
             fact_check = fact_check.lower().strip()

--- a/nemoguardrails/evaluate/evaluate_moderation.py
+++ b/nemoguardrails/evaluate/evaluate_moderation.py
@@ -97,7 +97,7 @@ class ModerationRailsEvaluation:
         num_tries = 0
         while not completed and num_tries < max_tries:
             try:
-                jailbreak = asyncio.run(llm_call(prompt=check_input_prompt, llm=self.llm))
+                jailbreak = asyncio.run(llm_call(prompt=check_input_prompt, llm=self.llm)).content
                 jailbreak = jailbreak.lower().strip()
                 print(jailbreak)
 
@@ -139,7 +139,7 @@ class ModerationRailsEvaluation:
                     llm=self.llm,
                     llm_params={"temperature": 0.1, "max_tokens": 100},
                 )
-            )
+            ).content
 
             check_output_check_prompt = self.llm_task_manager.render_task_prompt(
                 Task.SELF_CHECK_OUTPUT,
@@ -147,7 +147,7 @@ class ModerationRailsEvaluation:
                 force_string_to_message=True,
             )
             print(check_output_check_prompt)
-            check_output = asyncio.run(llm_call(prompt=check_output_check_prompt, llm=self.llm))
+            check_output = asyncio.run(llm_call(prompt=check_output_check_prompt, llm=self.llm)).content
             check_output = check_output.lower().strip()
             print(check_output)
 

--- a/nemoguardrails/evaluate/utils.py
+++ b/nemoguardrails/evaluate/utils.py
@@ -26,6 +26,7 @@ def initialize_llm(model_config: Model):
         model_name=model_config.model,
         provider_name=model_config.engine,
         kwargs=model_config.parameters,
+        mode="chat",
     )
 
 

--- a/nemoguardrails/guardrails/guardrails.py
+++ b/nemoguardrails/guardrails/guardrails.py
@@ -24,8 +24,6 @@ LLM responses with programmable guardrails.
 import logging
 from typing import AsyncIterator, Optional, Tuple, Union, cast, overload
 
-from langchain_core.language_models import BaseChatModel, BaseLLM
-
 from nemoguardrails.guardrails import configure_logging
 from nemoguardrails.guardrails.async_work_queue import AsyncWorkQueue
 from nemoguardrails.guardrails.guardrails_types import LLMMessages
@@ -34,6 +32,7 @@ from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import RailsConfig, _get_flow_name
 from nemoguardrails.rails.llm.llmrails import LLMRails
 from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.types import LLMModel
 
 # Queue configuration constants
 MAX_QUEUE_SIZE = 256
@@ -54,7 +53,7 @@ class Guardrails:
     def __init__(
         self,
         config: RailsConfig,
-        llm: Optional[Union[BaseLLM, BaseChatModel]] = None,
+        llm: Optional[LLMModel] = None,
         verbose: bool = False,
         *,
         use_iorails: bool = True,  # False -> fall back to LLMRails instead
@@ -204,7 +203,7 @@ class Guardrails:
         llmrails = cast(LLMRails, self.rails_engine)
         return llmrails.explain()
 
-    def update_llm(self, llm: Union[BaseLLM, BaseChatModel]) -> None:
+    def update_llm(self, llm: LLMModel) -> None:
         """Replace the main LLM with a new one.
         Only supported for LLMRails, since IORails doesn't take LLM as argument
         """

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -139,8 +139,6 @@ class LangChainLLMAdapter:
 
     @property
     def provider_url(self) -> Optional[str]:
-        # temp: uses _BASE_URL_ATTRIBUTES which duplicates utils.py BASE_URL_ATTRIBUTES.
-        # utils.py copy will be removed in stack-3 when it switches to model.provider_url.
         for attr in _BASE_URL_ATTRIBUTES:
             value = getattr(self._llm, attr, None)
             if value:

--- a/nemoguardrails/integrations/langchain/message_utils.py
+++ b/nemoguardrails/integrations/langchain/message_utils.py
@@ -308,7 +308,7 @@ def chatmessage_to_langchain_message(msg: ChatMessage) -> BaseMessage:
     if cls is ToolMessage:
         kwargs["tool_call_id"] = msg.tool_call_id or ""
 
-    return cls(content=msg.content, **kwargs)
+    return cls(content=msg.content or "", **kwargs)
 
 
 def chatmessages_to_langchain_messages(msgs: List[ChatMessage]) -> List[BaseMessage]:

--- a/nemoguardrails/integrations/langchain/message_utils.py
+++ b/nemoguardrails/integrations/langchain/message_utils.py
@@ -26,6 +26,8 @@ from langchain_core.messages import (
     ToolMessage,
 )
 
+from nemoguardrails.types import ChatMessage, Role
+
 
 def get_message_role(msg: BaseMessage) -> str:
     """Get the role string for a BaseMessage."""
@@ -145,36 +147,6 @@ def is_message_type(obj: Any, message_type: Type[BaseMessage]) -> bool:
 def is_base_message(obj: Any) -> bool:
     """Check if an object is any type of BaseMessage."""
     return isinstance(obj, BaseMessage)
-
-
-def chatmessage_to_langchain_message(msg: "ChatMessage") -> BaseMessage:
-    from nemoguardrails.types import Role
-
-    content = msg.content or ""
-    if msg.role == Role.USER:
-        return HumanMessage(content=content)
-    elif msg.role == Role.SYSTEM:
-        return SystemMessage(content=content)
-    elif msg.role == Role.TOOL:
-        return ToolMessage(content=content, tool_call_id=msg.tool_call_id or "")
-    elif msg.role == Role.ASSISTANT:
-        kwargs: Dict[str, Any] = {}
-        if msg.tool_calls:
-            kwargs["tool_calls"] = [
-                {
-                    "name": tc.function.name,
-                    "args": tc.function.arguments,
-                    "id": tc.id,
-                    "type": "tool_call",
-                }
-                for tc in msg.tool_calls
-            ]
-        return AIMessage(content=content, **kwargs)
-    raise ValueError(f"Unsupported ChatMessage role: {msg.role}")
-
-
-def chatmessages_to_langchain_messages(msgs: List["ChatMessage"]) -> List[BaseMessage]:
-    return [chatmessage_to_langchain_message(m) for m in msgs]
 
 
 def is_ai_message(obj: Any) -> bool:
@@ -308,3 +280,54 @@ def create_tool_message(
         kwargs["status"] = status
 
     return ToolMessage(content=content, **kwargs)
+
+
+_ROLE_TO_LANGCHAIN = {
+    Role.USER: HumanMessage,
+    Role.ASSISTANT: AIMessage,
+    Role.SYSTEM: SystemMessage,
+    Role.TOOL: ToolMessage,
+}
+
+
+def chatmessage_to_langchain_message(msg: ChatMessage) -> BaseMessage:
+    cls = _ROLE_TO_LANGCHAIN.get(msg.role)
+    if cls is None:
+        raise ValueError(f"Unsupported role: {msg.role}")
+
+    kwargs: Dict[str, Any] = {}
+    if msg.name is not None:
+        kwargs["name"] = msg.name
+
+    if cls is AIMessage and msg.tool_calls:
+        kwargs["tool_calls"] = [
+            {"name": tc.function.name, "args": tc.function.arguments, "id": tc.id, "type": tc.type}
+            for tc in msg.tool_calls
+        ]
+
+    if cls is ToolMessage:
+        kwargs["tool_call_id"] = msg.tool_call_id or ""
+
+    return cls(content=msg.content, **kwargs)
+
+
+def chatmessages_to_langchain_messages(msgs: List[ChatMessage]) -> List[BaseMessage]:
+    return [chatmessage_to_langchain_message(m) for m in msgs]
+
+
+def tool_calls_to_langchain_format(tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    result = []
+    for tc in tool_calls:
+        func = tc.get("function")
+        if func:
+            result.append(
+                {
+                    "name": func.get("name", ""),
+                    "args": func.get("arguments", {}),
+                    "id": tc.get("id", ""),
+                    "type": "tool_call",
+                }
+            )
+        else:
+            result.append(tc)
+    return result

--- a/nemoguardrails/integrations/langchain/runnable_rails.py
+++ b/nemoguardrails/integrations/langchain/runnable_rails.py
@@ -31,6 +31,7 @@ from nemoguardrails.integrations.langchain.message_utils import (
     create_ai_message_chunk,
     is_base_message,
     message_to_dict,
+    tool_calls_to_langchain_format,
 )
 from nemoguardrails.integrations.langchain.utils import async_wrap
 from nemoguardrails.rails.llm.options import GenerationOptions
@@ -498,9 +499,11 @@ class RunnableRails(Runnable[Input, Output]):
         Raises:
             ValueError: If the input type cannot be handled.
         """
-        # Standardize result format if it's a list
         if isinstance(result, list) and len(result) > 0:
             result = result[0]
+
+        if tool_calls:
+            tool_calls = tool_calls_to_langchain_format(tool_calls)
 
         if self.passthrough and self.passthrough_runnable:
             return self._format_passthrough_output(result, context)

--- a/nemoguardrails/library/content_safety/actions.py
+++ b/nemoguardrails/library/content_safety/actions.py
@@ -16,8 +16,6 @@
 import logging
 from typing import Dict, FrozenSet, Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails.actions.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
 from nemoguardrails.context import llm_call_info_var
@@ -31,6 +29,7 @@ from nemoguardrails.llm.cache.utils import (
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ def _get_reasoning_enabled(llm_task_manager: LLMTaskManager) -> bool:
 
 @action()
 async def content_safety_check_input(
-    llms: Dict[str, BaseLLM],
+    llms: Dict[str, LLMModel],
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
@@ -98,12 +97,14 @@ async def content_safety_check_input(
             log.debug(f"Content safety cache hit for model '{model_name}'")
             return cached_result
 
-    result = await llm_call(
-        llm,
-        check_input_prompt,
-        stop=stop,
-        llm_params={"temperature": 1e-20, "max_tokens": max_tokens},
-    )
+    result = (
+        await llm_call(
+            llm,
+            check_input_prompt,
+            stop=stop,
+            llm_params={"temperature": 1e-20, "max_tokens": max_tokens},
+        )
+    ).content
 
     result = llm_task_manager.parse_task_output(task, output=result)
 
@@ -142,7 +143,7 @@ def content_safety_check_output_mapping(result: dict) -> bool:
 
 @action(output_mapping=content_safety_check_output_mapping)
 async def content_safety_check_output(
-    llms: Dict[str, BaseLLM],
+    llms: Dict[str, LLMModel],
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
@@ -202,12 +203,14 @@ async def content_safety_check_output(
             log.debug(f"Content safety output cache hit for model '{model_name}'")
             return cached_result
 
-    result = await llm_call(
-        llm,
-        check_output_prompt,
-        stop=stop,
-        llm_params={"temperature": 1e-20, "max_tokens": max_tokens},
-    )
+    result = (
+        await llm_call(
+            llm,
+            check_output_prompt,
+            stop=stop,
+            llm_params={"temperature": 1e-20, "max_tokens": max_tokens},
+        )
+    ).content
 
     result = llm_task_manager.parse_task_output(task, output=result)
 

--- a/nemoguardrails/library/factchecking/align_score/actions.py
+++ b/nemoguardrails/library/factchecking/align_score/actions.py
@@ -16,13 +16,12 @@
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.library.factchecking.align_score.request import alignscore_request
 from nemoguardrails.library.self_check.facts.actions import self_check_facts
 from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -42,7 +41,7 @@ def alignscore_check_facts_mapping(result: float) -> bool:
 async def alignscore_check_facts(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llm: Optional[BaseLLM] = None,
+    llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     **kwargs,
 ):

--- a/nemoguardrails/library/hallucination/actions.py
+++ b/nemoguardrails/library/hallucination/actions.py
@@ -17,7 +17,6 @@ import asyncio
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseLLM
 from langchain_core.prompts import PromptTemplate
 
 from nemoguardrails import RailsConfig
@@ -31,6 +30,7 @@ from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ HALLUCINATION_NUM_EXTRA_RESPONSES = 2
 
 @action(output_mapping=lambda value: value)
 async def self_check_hallucination(
-    llm: BaseLLM,
+    llm: LLMModel,
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
     use_llm_checking: bool = True,
@@ -62,12 +62,12 @@ async def self_check_hallucination(
         async def _generate_extra_response(index: int) -> Optional[str]:
             llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_HALLUCINATION.value))
             try:
-                result = await llm_call(
+                response = await llm_call(
                     llm,
                     formatted_prompt,
                     llm_params={"temperature": 1.0},
                 )
-                result = get_multiline_response(result)
+                result = get_multiline_response(response.content)
                 result = strip_quotes(result)
                 return result
             except Exception as e:
@@ -101,12 +101,14 @@ async def self_check_hallucination(
             llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_HALLUCINATION.value))
             stop = llm_task_manager.get_stop_tokens(task=Task.SELF_CHECK_HALLUCINATION)
 
-            agreement = await llm_call(
-                llm,
-                prompt,
-                stop=stop,
-                llm_params={"temperature": config.lowest_temperature},
-            )
+            agreement = (
+                await llm_call(
+                    llm,
+                    prompt,
+                    stop=stop,
+                    llm_params={"temperature": config.lowest_temperature},
+                )
+            ).content
 
             agreement = agreement.lower().strip()
             log.info(f"Agreement result for looking for hallucination is {agreement}.")

--- a/nemoguardrails/library/llama_guard/actions.py
+++ b/nemoguardrails/library/llama_guard/actions.py
@@ -16,14 +16,13 @@
 import logging
 from typing import List, Optional, Tuple
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
 from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ def parse_llama_guard_response(response: str) -> Tuple[bool, Optional[List[str]]
 async def llama_guard_check_input(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llama_guard_llm: Optional[BaseLLM] = None,
+    llama_guard_llm: Optional[LLMModel] = None,
     **kwargs,
 ) -> dict:
     """
@@ -75,7 +74,7 @@ async def llama_guard_check_input(
     # Initialize the LLMCallInfo object
     llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_INPUT.value))
 
-    result = await llm_call(llama_guard_llm, check_input_prompt, stop=stop, llm_params={"temperature": 0.0})
+    result = (await llm_call(llama_guard_llm, check_input_prompt, stop=stop, llm_params={"temperature": 0.0})).content
 
     allowed, policy_violations = parse_llama_guard_response(result)
     return {"allowed": allowed, "policy_violations": policy_violations}
@@ -101,7 +100,7 @@ def llama_guard_check_output_mapping(result: dict) -> bool:
 async def llama_guard_check_output(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llama_guard_llm: Optional[BaseLLM] = None,
+    llama_guard_llm: Optional[LLMModel] = None,
 ) -> dict:
     """
     Check the bot response using the configured Llama Guard model
@@ -122,7 +121,7 @@ async def llama_guard_check_output(
     # Initialize the LLMCallInfo object
     llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_OUTPUT.value))
 
-    result = await llm_call(llama_guard_llm, check_output_prompt, stop=stop, llm_params={"temperature": 0.0})
+    result = (await llm_call(llama_guard_llm, check_output_prompt, stop=stop, llm_params={"temperature": 0.0})).content
 
     allowed, policy_violations = parse_llama_guard_response(result)
     return {"allowed": allowed, "policy_violations": policy_violations}

--- a/nemoguardrails/library/patronusai/actions.py
+++ b/nemoguardrails/library/patronusai/actions.py
@@ -19,7 +19,6 @@ import re
 from typing import List, Literal, Optional, Tuple, Union
 
 import aiohttp
-from langchain_core.language_models import BaseLLM
 
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
@@ -27,6 +26,7 @@ from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ def patronus_lynx_check_output_hallucination_mapping(result: dict) -> bool:
 async def patronus_lynx_check_output_hallucination(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    patronus_lynx_llm: Optional[BaseLLM] = None,
+    patronus_lynx_llm: Optional[LLMModel] = None,
     **kwargs,
 ) -> dict:
     """
@@ -104,12 +104,14 @@ async def patronus_lynx_check_output_hallucination(
     # Initialize the LLMCallInfo object
     llm_call_info_var.set(LLMCallInfo(task=Task.PATRONUS_LYNX_CHECK_OUTPUT_HALLUCINATION.value))
 
-    result = await llm_call(
-        patronus_lynx_llm,
-        check_output_hallucination_prompt,
-        stop=stop,
-        llm_params={"temperature": 0.0},
-    )
+    result = (
+        await llm_call(
+            patronus_lynx_llm,
+            check_output_hallucination_prompt,
+            stop=stop,
+            llm_params={"temperature": 0.0},
+        )
+    ).content
 
     hallucination, reasoning = parse_patronus_lynx_response(result)
     return {"hallucination": hallucination, "reasoning": reasoning}

--- a/nemoguardrails/library/self_check/facts/actions.py
+++ b/nemoguardrails/library/self_check/facts/actions.py
@@ -16,8 +16,6 @@
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
@@ -25,6 +23,7 @@ from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ def mapping_self_check_facts(result: float) -> bool:
 async def self_check_facts(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llm: Optional[BaseLLM] = None,
+    llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     **kwargs,
 ):
@@ -71,12 +70,14 @@ async def self_check_facts(
     # Initialize the LLMCallInfo object
     llm_call_info_var.set(LLMCallInfo(task=task.value))
 
-    response = await llm_call(
-        llm,
-        prompt,
-        stop=stop,
-        llm_params={"temperature": config.lowest_temperature, "max_tokens": max_tokens},
-    )
+    response = (
+        await llm_call(
+            llm,
+            prompt,
+            stop=stop,
+            llm_params={"temperature": config.lowest_temperature, "max_tokens": max_tokens},
+        )
+    ).content
 
     if llm_task_manager.has_output_parser(task):
         result = llm_task_manager.parse_task_output(task, output=response)

--- a/nemoguardrails/library/self_check/input_check/actions.py
+++ b/nemoguardrails/library/self_check/input_check/actions.py
@@ -16,8 +16,6 @@
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
 from nemoguardrails.actions.llm.utils import llm_call
@@ -25,6 +23,7 @@ from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import new_event_dict
 
 log = logging.getLogger(__name__)
@@ -34,7 +33,7 @@ log = logging.getLogger(__name__)
 async def self_check_input(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llm: Optional[BaseLLM] = None,
+    llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     **kwargs,
 ):
@@ -65,15 +64,17 @@ async def self_check_input(
         # Initialize the LLMCallInfo object
         llm_call_info_var.set(LLMCallInfo(task=task.value))
 
-        response = await llm_call(
-            llm,
-            prompt,
-            stop=stop,
-            llm_params={
-                "temperature": config.lowest_temperature,
-                "max_tokens": max_tokens,
-            },
-        )
+        response = (
+            await llm_call(
+                llm,
+                prompt,
+                stop=stop,
+                llm_params={
+                    "temperature": config.lowest_temperature,
+                    "max_tokens": max_tokens,
+                },
+            )
+        ).content
 
         log.info(f"Input self-checking result is: `{response}`.")
 

--- a/nemoguardrails/library/self_check/output_check/actions.py
+++ b/nemoguardrails/library/self_check/output_check/actions.py
@@ -16,8 +16,6 @@
 import logging
 from typing import Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
@@ -25,6 +23,7 @@ from nemoguardrails.context import llm_call_info_var
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.llm.types import Task
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -33,7 +32,7 @@ log = logging.getLogger(__name__)
 async def self_check_output(
     llm_task_manager: LLMTaskManager,
     context: Optional[dict] = None,
-    llm: Optional[BaseLLM] = None,
+    llm: Optional[LLMModel] = None,
     config: Optional[RailsConfig] = None,
     **kwargs,
 ):
@@ -72,15 +71,17 @@ async def self_check_output(
         # Initialize the LLMCallInfo object
         llm_call_info_var.set(LLMCallInfo(task=task.value))
 
-        response = await llm_call(
-            llm,
-            prompt,
-            stop=stop,
-            llm_params={
-                "temperature": config.lowest_temperature,
-                "max_tokens": max_tokens,
-            },
-        )
+        response = (
+            await llm_call(
+                llm,
+                prompt,
+                stop=stop,
+                llm_params={
+                    "temperature": config.lowest_temperature,
+                    "max_tokens": max_tokens,
+                },
+            )
+        ).content
 
         log.info(f"Output self-checking result is: `{response}`.")
 

--- a/nemoguardrails/library/topic_safety/actions.py
+++ b/nemoguardrails/library/topic_safety/actions.py
@@ -16,8 +16,6 @@
 import logging
 from typing import Dict, List, Optional
 
-from langchain_core.language_models import BaseLLM
-
 from nemoguardrails.actions.actions import action
 from nemoguardrails.actions.llm.utils import llm_call
 from nemoguardrails.context import llm_call_info_var
@@ -32,6 +30,7 @@ from nemoguardrails.llm.cache.utils import (
 from nemoguardrails.llm.filters import to_chat_messages
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.types import LLMModel
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +45,7 @@ TOPIC_SAFETY_MAX_TOKENS = 10
 
 @action()
 async def topic_safety_check_input(
-    llms: Dict[str, BaseLLM],
+    llms: Dict[str, LLMModel],
     llm_task_manager: LLMTaskManager,
     model_name: Optional[str] = None,
     context: Optional[dict] = None,
@@ -122,7 +121,8 @@ async def topic_safety_check_input(
             log.debug(f"Topic safety cache hit for model '{model_name}'")
             return cached_result
 
-    result = await llm_call(llm, messages, stop=stop, llm_params={"temperature": TOPIC_SAFETY_TEMPERATURE})
+    response = await llm_call(llm, messages, stop=stop, llm_params={"temperature": TOPIC_SAFETY_TEMPERATURE})
+    result = response.content
 
     if result.lower().strip() == "off-topic":
         on_topic = False

--- a/nemoguardrails/llm/models/initializer.py
+++ b/nemoguardrails/llm/models/initializer.py
@@ -15,33 +15,25 @@
 
 """Module for initializing LLM models with proper error handling and type checking."""
 
-from typing import Any, Dict, Literal, Union
+from typing import Any, Dict, Literal
 
-from langchain_core.language_models import BaseChatModel, BaseLLM
-
-from nemoguardrails.llm.models.langchain_initializer import (
-    ModelInitializationError,
-    init_langchain_model,
-)
+from nemoguardrails.llm.models.langchain_initializer import ModelInitializationError
+from nemoguardrails.types import LLMModel
 
 
-# later we can easily convert it to a class
 def init_llm_model(
     model_name: str,
     provider_name: str,
-    mode: Literal["chat", "text"],
     kwargs: Dict[str, Any],
-) -> Union[BaseChatModel, BaseLLM]:
+    mode: Literal["chat", "text"] = "chat",
+) -> LLMModel:
     """Initialize an LLM model with proper error handling.
-
-    Currently, this function only supports LangChain models.
-    In the future, it may support other model backends.
 
     Args:
         model_name: Name of the model to initialize
         provider_name: Name of the provider to use
-        mode: Literal taking either "chat" or "text" values
         kwargs: Additional arguments to pass to the model initialization
+        mode: Literal taking either "chat" or "text" values
 
     Returns:
         An initialized LLM model
@@ -49,12 +41,16 @@ def init_llm_model(
     Raises:
         ModelInitializationError: If model initialization fails
     """
-    # currently we only support LangChain models
-    return init_langchain_model(
+    from nemoguardrails.llm.frameworks import get_default_framework, get_framework
+
+    model_kwargs = dict(kwargs) if kwargs else {}
+    model_kwargs["mode"] = mode
+
+    framework = get_framework(get_default_framework())
+    return framework.create_model(
         model_name=model_name,
         provider_name=provider_name,
-        mode=mode,
-        kwargs=kwargs,
+        model_kwargs=model_kwargs,
     )
 
 

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -1468,7 +1468,7 @@ class LLMRails:
             messages: List of message dicts with 'role' and 'content' fields.
                      Messages can contain any roles, but only user/assistant roles
                      determine which rails execute when ``rail_types`` is not provided.
-            rails: Optional list of rail types to run, e.g.
+            rail_types: Optional list of rail types to run, e.g.
                   ``[RailType.INPUT]`` or ``[RailType.OUTPUT]``.
                   When provided, overrides automatic detection.
 
@@ -1537,7 +1537,7 @@ class LLMRails:
 
         Args:
             messages: List of message dicts with 'role' and 'content' fields.
-            rails: Optional list of rail types to run. See check_async() for details.
+            rail_types: Optional list of rail types to run. See check_async() for details.
 
         Returns:
             RailsResult containing status, content, and optional blocking rail name.

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -40,7 +40,6 @@ from typing import (
     overload,
 )
 
-from langchain_core.language_models import BaseChatModel, BaseLLM
 from typing_extensions import Self
 
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
@@ -106,6 +105,7 @@ from nemoguardrails.rails.llm.utils import (
     get_history_cache_key,
 )
 from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
+from nemoguardrails.types import LLMModel
 from nemoguardrails.utils import (
     extract_error_json,
     get_or_create_event_loop,
@@ -118,17 +118,34 @@ log = logging.getLogger(__name__)
 process_events_semaphore = asyncio.Semaphore(1)
 
 
+def _wrap_legacy_llm(llm):
+    try:
+        from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
+    except ImportError:
+        raise TypeError(
+            "Passing a raw LangChain LLM requires langchain to be installed. "
+            "Either install langchain or pass an LLMModel instance."
+        )
+    warnings.warn(
+        "Passing a raw LangChain LLM is deprecated. "
+        "Use LangChainLLMAdapter(llm) explicitly or pass an LLMModel instance.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return LangChainLLMAdapter(llm)
+
+
 class LLMRails:
     """Rails based on a given configuration."""
 
     config: RailsConfig
-    llm: Optional[Union[BaseLLM, BaseChatModel]]
+    llm: Optional[LLMModel]
     runtime: Runtime
 
     def __init__(
         self,
         config: RailsConfig,
-        llm: Optional[Union[BaseLLM, BaseChatModel]] = None,
+        llm: Optional[LLMModel] = None,
         verbose: bool = False,
     ):
         """Initializes the LLMRails instance.
@@ -140,7 +157,10 @@ class LLMRails:
             verbose: Whether the logging should be verbose or not.
         """
         self.config = config
-        self.llm = llm
+        if llm is not None and not isinstance(llm, LLMModel):
+            self.llm = _wrap_legacy_llm(llm)
+        else:
+            self.llm = llm
         self.verbose = verbose
 
         if self.verbose:
@@ -317,12 +337,14 @@ class LLMRails:
         # Reference to the general ExplainInfo object.
         self.explain_info = None
 
-    def update_llm(self, llm):
+    def update_llm(self, llm: LLMModel):
         """Replace the main LLM with the provided one.
 
         Arguments:
             llm: The new LLM that should be used.
         """
+        if not isinstance(llm, LLMModel):
+            llm = _wrap_legacy_llm(llm)
         self.llm = llm
         self.llm_generation_actions.llm = llm
         self.runtime.register_action_param("llm", llm)
@@ -752,8 +774,9 @@ class LLMRails:
     ) -> Union[str, dict, GenerationResponse, Tuple[dict, dict]]:
         """Generate a completion or a next message.
 
-        The format for messages is the following::
+        The format for messages is the following:
 
+        ```python
             [
                 {"role": "context", "content": {"user_name": "John"}},
                 {"role": "user", "content": "Hello! How are you?"},
@@ -761,6 +784,7 @@ class LLMRails:
                 {"role": "event", "event": {"type": "UserSilent"}},
                 ...
             ]
+        ```
 
         Args:
             prompt: The prompt to be used for completion.
@@ -768,13 +792,12 @@ class LLMRails:
             options: Options specific for the generation.
             state: The state object that should be used as the starting point.
             streaming_handler: If specified, and the config supports streaming, the
-                provided handler will be used for streaming.
+              provided handler will be used for streaming.
 
         Returns:
             The completion (when a prompt is provided) or the next message.
 
-        System messages are not yet supported.
-        """
+        System messages are not yet supported."""
         # convert options to gen_options of type GenerationOptions
         gen_options: Optional[GenerationOptions] = None
 
@@ -981,7 +1004,7 @@ class LLMRails:
             log.info(f"Conversation history so far: \n{self.explain_info.colang_history}")
 
         total_time = time.time() - t0
-        log.info("--- :: Total processing took %.2f seconds. Stats: %s" % (total_time, llm_stats))
+        log.info("--- :: Total processing took %.2f seconds. LLM Stats: %s" % (total_time, llm_stats))
 
         # If there is a streaming handler, we make sure we close it now
         streaming_handler = streaming_handler_var.get()
@@ -1317,18 +1340,22 @@ class LLMRails:
     ) -> List[dict]:
         """Generate the next events based on the provided history.
 
-        The format for events is the following::
+        The format for events is the following:
 
+        ```python
             [
                 {"type": "...", ...},
                 ...
             ]
+        ```
 
         Args:
             events: The history of events to be used to generate the next events.
+            options: The options to be used for the generation.
 
         Returns:
-            The newly generated event(s).
+            The newly generate event(s).
+
         """
         t0 = time.time()
 
@@ -1429,7 +1456,6 @@ class LLMRails:
 
         When ``rail_types`` is not provided, automatically determines which rails
         to run based on message roles:
-
         - Only user messages: runs input rails
         - Only assistant messages: runs output rails
         - Both user and assistant messages: runs both input and output rails
@@ -1439,39 +1465,33 @@ class LLMRails:
         skipping the auto-detection logic.
 
         Args:
-            messages: List of message dicts with ``role`` and ``content`` fields.
-                Messages can contain any roles, but only user/assistant roles
-                determine which rails execute when ``rail_types`` is not provided.
-            rail_types: Optional list of rail types to run, e.g.
-                ``[RailType.INPUT]`` or ``[RailType.OUTPUT]``.
-                When provided, overrides automatic detection.
+            messages: List of message dicts with 'role' and 'content' fields.
+                     Messages can contain any roles, but only user/assistant roles
+                     determine which rails execute when ``rail_types`` is not provided.
+            rails: Optional list of rail types to run, e.g.
+                  ``[RailType.INPUT]`` or ``[RailType.OUTPUT]``.
+                  When provided, overrides automatic detection.
 
         Returns:
             RailsResult containing:
+            - status: PASSED, MODIFIED, or BLOCKED
+            - content: The final content after rails processing
+            - rail: Name of the rail that blocked (if blocked)
 
-            - **status**: PASSED, MODIFIED, or BLOCKED
-            - **content**: The final content after rails processing
-            - **rail**: Name of the rail that blocked (if blocked)
+        Examples:
+            Check user input (auto-detected):
+                result = await rails.check_async([{"role": "user", "content": "Hello!"}])
+                if result.status == RailStatus.BLOCKED:
+                    print(f"Blocked by: {result.rail}")
 
-        Examples::
+            Check bot output with context (auto-detected):
+                result = await rails.check_async([
+                    {"role": "user", "content": "Hello!"},
+                    {"role": "assistant", "content": "Hi there!"}
+                ])
 
-            # Check user input (auto-detected)
-            result = await rails.check_async(
-                [{"role": "user", "content": "Hello!"}]
-            )
-            if result.status == RailStatus.BLOCKED:
-                print(f"Blocked by: {result.rail}")
-
-            # Check bot output with context (auto-detected)
-            result = await rails.check_async([
-                {"role": "user", "content": "Hello!"},
-                {"role": "assistant", "content": "Hi there!"}
-            ])
-
-            # Run only input rails explicitly
-            result = await rails.check_async(
-                messages, rail_types=[RailType.INPUT]
-            )
+            Run only input rails explicitly:
+                result = await rails.check_async(messages, rail_types=[RailType.INPUT])
         """
         if rail_types is not None:
             options: Optional[dict] = {"rails": [r.value for r in rail_types]}

--- a/nemoguardrails/types.py
+++ b/nemoguardrails/types.py
@@ -131,7 +131,7 @@ class ChatMessage:
         captured into ``provider_metadata``.
         """
 
-        raw_role = d.get("role")
+        raw_role = d.get("role") or d.get("type")
         if raw_role is None:
             raise ValueError("Missing required key: 'role'")
         role = _ROLE_ALIASES.get(raw_role)

--- a/tests/test_actions_llm_utils.py
+++ b/tests/test_actions_llm_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,32 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from langchain_core.language_models import BaseLanguageModel
-from langchain_core.messages import AIMessage
 
 from nemoguardrails.actions.llm.utils import (
-    _extract_reasoning_from_additional_kwargs,
-    _extract_reasoning_from_content_blocks,
-    _extract_tool_calls_from_attribute,
-    _extract_tool_calls_from_content_blocks,
-    _filter_params_for_openai_reasoning_models,
-    _infer_provider_from_module,
     _log_completion,
     _store_reasoning_traces,
     _store_tool_calls,
-    _stream_llm_call,
     _update_token_stats_from_chunk,
     llm_call,
 )
 from nemoguardrails.context import llm_call_info_var, llm_stats_var, reasoning_trace_var, tool_calls_var
 from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.integrations.langchain.llm_adapter import (
+    LangChainLLMAdapter,
+    _infer_provider_from_module,
+)
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.stats import LLMStats
-from tests.utils import get_bound_llm_magic_mock
+from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, Role, ToolCall, ToolCallFunction, UsageInfo
 
 
 @pytest.fixture(autouse=True)
@@ -70,24 +64,6 @@ class MockCommunityOllama:
 
 class MockUnknownLLM:
     __module__ = "some_custom_package.models"
-
-
-class MockTRTLLM:
-    __module__ = "nemoguardrails.llm.providers.trtllm.llm"
-
-
-class MockAzureLLM:
-    __module__ = "langchain_openai.chat_models"
-
-
-class MockLLMWithClient:
-    __module__ = "langchain_openai.chat_models"
-
-    class _MockClient:
-        base_url = "https://custom.endpoint.com/v1"
-
-    def __init__(self):
-        self.client = self._MockClient()
 
 
 def test_infer_provider_openai():
@@ -165,603 +141,183 @@ def test_infer_provider_deeply_nested_inheritance():
     assert provider == "anthropic"
 
 
-class MockResponse:
-    def __init__(self, content_blocks=None, additional_kwargs=None, tool_calls=None):
-        if content_blocks is not None:
-            self.content_blocks = content_blocks
-        if additional_kwargs is not None:
-            self.additional_kwargs = additional_kwargs
-        if tool_calls is not None:
-            self.tool_calls = tool_calls
-
-
-def test_extract_reasoning_from_content_blocks_single_reasoning():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "reasoning", "reasoning": "foo"},
-        ]
-    )
-    reasoning = _extract_reasoning_from_content_blocks(response)
-    assert reasoning == "foo"
-
-
-def test_extract_reasoning_from_content_blocks_with_text_and_reasoning():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "bar"},
-            {"type": "reasoning", "reasoning": "Let me think about this problem..."},
-        ]
-    )
-    reasoning = _extract_reasoning_from_content_blocks(response)
-    assert reasoning == "Let me think about this problem..."
-
-
-def test_extract_reasoning_from_content_blocks_returns_first_reasoning():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "reasoning", "reasoning": "First thought"},
-            {"type": "reasoning", "reasoning": "Second thought"},
-        ]
-    )
-    reasoning = _extract_reasoning_from_content_blocks(response)
-    assert reasoning == "First thought"
-
-
-def test_extract_reasoning_from_content_blocks_no_reasoning():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Hello"},
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-        ]
-    )
-    reasoning = _extract_reasoning_from_content_blocks(response)
-    assert reasoning is None
-
-
-def test_extract_reasoning_from_content_blocks_no_attribute():
-    response = MockResponse()
-    reasoning = _extract_reasoning_from_content_blocks(response)
-    assert reasoning is None
-
-
-def test_extract_reasoning_from_additional_kwargs_with_reasoning_content():
-    response = MockResponse(additional_kwargs={"reasoning_content": "Let me think about this problem..."})
-    reasoning = _extract_reasoning_from_additional_kwargs(response)
-    assert reasoning == "Let me think about this problem..."
-
-
-def test_extract_reasoning_from_additional_kwargs_no_reasoning_content():
-    response = MockResponse(additional_kwargs={"other_field": "some value"})
-    reasoning = _extract_reasoning_from_additional_kwargs(response)
-    assert reasoning is None
-
-
-def test_extract_reasoning_from_additional_kwargs_no_attribute():
-    response = MockResponse()
-    reasoning = _extract_reasoning_from_additional_kwargs(response)
-    assert reasoning is None
-
-
-def test_extract_reasoning_from_additional_kwargs_not_dict():
-    response = MockResponse(additional_kwargs="not a dict")
-    reasoning = _extract_reasoning_from_additional_kwargs(response)
-    assert reasoning is None
-
-
-def test_extract_tool_calls_from_content_blocks_single_tool_call():
-    expected_tool_call = {
-        "type": "tool_call",
-        "name": "foo",
-        "args": {"a": "b"},
-        "id": "abc_123",
-    }
-    response = MockResponse(content_blocks=[expected_tool_call])
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    assert tool_calls is not None
-    assert len(tool_calls) == 1
-    assert tool_calls[0] == expected_tool_call
-
-
-def test_extract_tool_calls_from_content_blocks_multiple_tool_calls():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-            {"type": "tool_call", "name": "bar", "args": {"c": "d"}, "id": "abc_234"},
-        ]
-    )
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    assert tool_calls is not None
-    assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[1]["name"] == "bar"
-
-
-def test_extract_tool_calls_from_content_blocks_mixed_content():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Hello"},
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-            {"type": "reasoning", "reasoning": "Thinking..."},
-            {"type": "tool_call", "name": "bar", "args": {"c": "d"}, "id": "abc_234"},
-        ]
-    )
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    assert tool_calls is not None
-    assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[1]["name"] == "bar"
-
-
-def test_extract_tool_calls_from_content_blocks_no_tool_calls():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Hello"},
-            {"type": "reasoning", "reasoning": "Thinking..."},
-        ]
-    )
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    assert tool_calls is None
-
-
-def test_extract_tool_calls_from_content_blocks_no_attribute():
-    response = MockResponse()
-    tool_calls = _extract_tool_calls_from_content_blocks(response)
-    assert tool_calls is None
-
-
-def test_extract_tool_calls_from_attribute_with_tool_calls():
-    response = MockResponse(
-        tool_calls=[
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-            {"type": "tool_call", "name": "bar", "args": {"c": "d"}, "id": "abc_234"},
-        ]
-    )
-    tool_calls = _extract_tool_calls_from_attribute(response)
-    assert tool_calls is not None
-    assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[1]["name"] == "bar"
-
-
-def test_extract_tool_calls_from_attribute_no_attribute():
-    response = MockResponse()
-    tool_calls = _extract_tool_calls_from_attribute(response)
-    assert tool_calls is None
-
-
-def test_store_reasoning_traces_from_content_blocks():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "The answer is 42."},
-            {"type": "reasoning", "reasoning": "Let me think about this problem..."},
-        ]
+def test_store_reasoning_traces_from_reasoning_field():
+    response = LLMResponse(
+        content="The answer is 42.",
+        reasoning="Let me think about this problem...",
     )
     _store_reasoning_traces(response)
 
     reasoning = reasoning_trace_var.get()
     assert reasoning == "Let me think about this problem..."
-
-
-def test_store_reasoning_traces_from_additional_kwargs():
-    response = MockResponse(additional_kwargs={"reasoning_content": "Provider specific reasoning"})
-    _store_reasoning_traces(response)
-
-    reasoning = reasoning_trace_var.get()
-    assert reasoning == "Provider specific reasoning"
-
-
-def test_store_reasoning_traces_prefers_content_blocks_over_additional_kwargs():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "reasoning", "reasoning": "Content blocks reasoning"},
-        ],
-        additional_kwargs={"reasoning_content": "Additional kwargs reasoning"},
-    )
-    _store_reasoning_traces(response)
-
-    reasoning = reasoning_trace_var.get()
-    assert reasoning == "Content blocks reasoning"
-
-
-def test_store_reasoning_traces_fallback_to_additional_kwargs():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "No reasoning here"},
-        ],
-        additional_kwargs={"reasoning_content": "Fallback reasoning"},
-    )
-    _store_reasoning_traces(response)
-
-    reasoning = reasoning_trace_var.get()
-    assert reasoning == "Fallback reasoning"
 
 
 def test_store_reasoning_traces_no_reasoning():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Just text"},
-        ]
-    )
+    response = LLMResponse(content="Just text")
     _store_reasoning_traces(response)
 
     reasoning = reasoning_trace_var.get()
     assert reasoning is None
 
 
-def test_store_tool_calls_from_content_blocks():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Hello"},
-            {
-                "type": "tool_call",
-                "name": "search",
-                "args": {"query": "weather"},
-                "id": "call_1",
-            },
-            {
-                "type": "tool_call",
-                "name": "calculator",
-                "args": {"expr": "2+2"},
-                "id": "call_2",
-            },
-        ]
-    )
-    _store_tool_calls(response)
-
-    tool_calls = tool_calls_var.get()
-    assert tool_calls is not None
-    assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "search"
-    assert tool_calls[1]["name"] == "calculator"
-
-
 def test_store_tool_calls_from_attribute():
-    response = MockResponse(
+    response = LLMResponse(
+        content="",
         tool_calls=[
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-            {"type": "tool_call", "name": "bar", "args": {"c": "d"}, "id": "abc_234"},
-        ]
+            ToolCall(id="abc_123", function=ToolCallFunction(name="foo", arguments={"a": "b"})),
+            ToolCall(id="abc_234", function=ToolCallFunction(name="bar", arguments={"c": "d"})),
+        ],
     )
     _store_tool_calls(response)
 
     tool_calls = tool_calls_var.get()
     assert tool_calls is not None
     assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[1]["name"] == "bar"
-
-
-def test_store_tool_calls_prefers_content_blocks_over_attribute():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "tool_call", "name": "from_blocks", "args": {}, "id": "1"},
-        ],
-        tool_calls=[
-            {"type": "tool_call", "name": "from_attribute", "args": {}, "id": "2"},
-        ],
-    )
-    _store_tool_calls(response)
-
-    tool_calls = tool_calls_var.get()
-    assert tool_calls is not None
-    assert len(tool_calls) == 1
-    assert tool_calls[0]["name"] == "from_blocks"
-
-
-def test_store_tool_calls_fallback_to_attribute():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "No tool calls here"},
-        ],
-        tool_calls=[
-            {"type": "tool_call", "name": "fallback_tool", "args": {}, "id": "1"},
-        ],
-    )
-    _store_tool_calls(response)
-
-    tool_calls = tool_calls_var.get()
-    assert tool_calls is not None
-    assert len(tool_calls) == 1
-    assert tool_calls[0]["name"] == "fallback_tool"
+    assert tool_calls[0]["function"]["name"] == "foo"
+    assert tool_calls[0]["function"]["arguments"] == {"a": "b"}
+    assert tool_calls[1]["function"]["name"] == "bar"
+    assert tool_calls[1]["function"]["arguments"] == {"c": "d"}
 
 
 def test_store_tool_calls_no_tool_calls():
-    response = MockResponse(
-        content_blocks=[
-            {"type": "text", "text": "Just text"},
-        ]
-    )
+    response = LLMResponse(content="Just text")
     _store_tool_calls(response)
 
     tool_calls = tool_calls_var.get()
     assert tool_calls is None
 
 
-def test_store_reasoning_traces_with_real_aimessage_from_content_blocks():
-    message = AIMessage(
+def test_store_reasoning_traces_with_reasoning():
+    response = LLMResponse(
         content="The answer is 42.",
-        additional_kwargs={"reasoning_content": "Let me think about this problem..."},
+        reasoning="Let me think about this problem...",
     )
 
-    _store_reasoning_traces(message)
+    _store_reasoning_traces(response)
 
     reasoning = reasoning_trace_var.get()
     assert reasoning == "Let me think about this problem..."
 
 
-def test_store_reasoning_traces_with_real_aimessage_no_reasoning():
-    message = AIMessage(
-        content="The answer is 42.",
-        additional_kwargs={"other_field": "some value"},
-    )
+def test_store_reasoning_traces_with_no_reasoning():
+    response = LLMResponse(content="The answer is 42.")
 
-    _store_reasoning_traces(message)
+    _store_reasoning_traces(response)
 
     reasoning = reasoning_trace_var.get()
     assert reasoning is None
 
 
-def test_store_tool_calls_with_real_aimessage_from_content_blocks():
-    message = AIMessage(
-        "",
-        tool_calls=[{"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"}],
+def test_store_tool_calls_with_tool_call_objects():
+    response = LLMResponse(
+        content="",
+        tool_calls=[ToolCall(id="abc_123", function=ToolCallFunction(name="foo", arguments={"a": "b"}))],
     )
 
-    _store_tool_calls(message)
+    _store_tool_calls(response)
 
     tool_calls = tool_calls_var.get()
     assert tool_calls is not None
     assert len(tool_calls) == 1
-    assert tool_calls[0]["type"] == "tool_call"
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[0]["args"] == {"a": "b"}
+    assert tool_calls[0]["type"] == "function"
+    assert tool_calls[0]["function"]["name"] == "foo"
+    assert tool_calls[0]["function"]["arguments"] == {"a": "b"}
     assert tool_calls[0]["id"] == "abc_123"
 
 
-def test_store_tool_calls_with_real_aimessage_mixed_content():
-    message = AIMessage(
-        "foo",
-        tool_calls=[{"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"}],
+def test_store_tool_calls_with_content_and_tool_calls():
+    response = LLMResponse(
+        content="foo",
+        tool_calls=[ToolCall(id="abc_123", function=ToolCallFunction(name="foo", arguments={"a": "b"}))],
     )
 
-    _store_tool_calls(message)
+    _store_tool_calls(response)
 
     tool_calls = tool_calls_var.get()
     assert tool_calls is not None
     assert len(tool_calls) == 1
-    assert tool_calls[0]["type"] == "tool_call"
-    assert tool_calls[0]["name"] == "foo"
+    assert tool_calls[0]["type"] == "function"
+    assert tool_calls[0]["function"]["name"] == "foo"
 
 
-def test_store_tool_calls_with_real_aimessage_multiple_tool_calls():
-    message = AIMessage(
-        "",
+def test_store_tool_calls_with_multiple_tool_call_objects():
+    response = LLMResponse(
+        content="",
         tool_calls=[
-            {"type": "tool_call", "name": "foo", "args": {"a": "b"}, "id": "abc_123"},
-            {"type": "tool_call", "name": "bar", "args": {"c": "d"}, "id": "abc_234"},
+            ToolCall(id="abc_123", function=ToolCallFunction(name="foo", arguments={"a": "b"})),
+            ToolCall(id="abc_234", function=ToolCallFunction(name="bar", arguments={"c": "d"})),
         ],
     )
 
-    _store_tool_calls(message)
+    _store_tool_calls(response)
 
     tool_calls = tool_calls_var.get()
     assert tool_calls is not None
     assert len(tool_calls) == 2
-    assert tool_calls[0]["name"] == "foo"
-    assert tool_calls[1]["name"] == "bar"
+    assert tool_calls[0]["function"]["name"] == "foo"
+    assert tool_calls[1]["function"]["name"] == "bar"
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm_params", [None, {}])
-@pytest.mark.parametrize("stop", [None, ["User:"]])
-async def test_llm_call_stop_tokens_passed_without_llm_params(llm_params, stop):
-    """Stop tokens must be passed to bind or ainvoke even when llm_params is None or empty."""
+async def test_llm_call_stop_tokens_passed_without_llm_params(llm_params):
+    from unittest.mock import AsyncMock, MagicMock
+
     from nemoguardrails.actions.llm.utils import llm_call
 
-    mock_llm = get_bound_llm_magic_mock(ainvoke_return_value={"content": "response"})
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke.return_value = MagicMock(content="response")
 
-    await llm_call(mock_llm, "prompt", stop=stop, llm_params=llm_params)
+    wrapped = LangChainLLMAdapter(mock_llm)
+    await llm_call(wrapped, "prompt", stop=["User:"], llm_params=llm_params)
 
-    if mock_llm.bind.called:
-        # Option A: Check if .bind() was called with the stop tokens
-        args, kwargs = mock_llm.bind.call_args
-        assert kwargs.get("stop", None) == stop
-    else:
-        # Option B: Check if it fell back to passing stop to .ainvoke
-        args, kwargs = mock_llm.ainvoke.call_args
-        assert kwargs.get("stop", None) == stop
+    assert mock_llm.ainvoke.call_args[1]["stop"] == ["User:"]
 
 
 @pytest.mark.asyncio
-async def test_llm_call_exception_enrichment_with_model_and_endpoint():
-    """Test that LLM invocation errors include model and endpoint context."""
+async def test_llm_call_exception_enrichment_with_model_and_provider():
     mock_llm = MockOpenAILLM()
     mock_llm.model_name = "gpt-4"
-    mock_llm.base_url = "https://api.openai.com/v1"
     mock_llm.ainvoke = AsyncMock(side_effect=ConnectionError("Connection refused"))
 
+    wrapped = LangChainLLMAdapter(mock_llm)
     with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(cast(BaseLanguageModel, mock_llm), "test prompt")
+        await llm_call(wrapped, "test prompt")
 
     exc_str = str(exc_info.value)
     assert "gpt-4" in exc_str
-    assert "https://api.openai.com/v1" in exc_str
+    assert "provider=openai" in exc_str
     assert "Connection refused" in exc_str
     assert isinstance(exc_info.value.inner_exception, ConnectionError)
 
 
 @pytest.mark.asyncio
-async def test_llm_call_exception_without_endpoint():
-    """Test exception enrichment when endpoint URL is not available."""
-    mock_llm = AsyncMock()
-    mock_llm.__module__ = "langchain_openai.chat_models"
+async def test_llm_call_exception_without_provider():
+    mock_llm = MockUnknownLLM()
     mock_llm.model_name = "custom-model"
-    # No base_url attribute
     mock_llm.ainvoke = AsyncMock(side_effect=ValueError("Invalid request"))
 
+    wrapped = LangChainLLMAdapter(mock_llm)
     with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(mock_llm, "test prompt")
+        await llm_call(wrapped, "test prompt")
 
-    # Should still have model name but no endpoint
-    assert "custom-model" in str(exc_info.value)
-    assert "Invalid request" in str(exc_info.value)
+    exc_str = str(exc_info.value)
+    assert "custom-model" in exc_str
+    assert "Invalid request" in exc_str
 
 
 @pytest.mark.asyncio
-async def test_llm_call_exception_extracts_azure_endpoint():
-    """Test that Azure-style endpoint URLs are extracted."""
-    mock_llm = MockAzureLLM()
+async def test_llm_call_kwargs_flow_through_to_generate():
+    mock_llm = MagicMock()
     mock_llm.model_name = "gpt-4"
-    mock_llm.azure_endpoint = "https://example.openai.azure.com"
-    mock_llm.ainvoke = AsyncMock(side_effect=Exception("Azure error"))
+    bound_llm = AsyncMock()
+    bound_llm.ainvoke.return_value = MagicMock(content="response")
+    mock_llm.bind.return_value = bound_llm
 
-    with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(cast(BaseLanguageModel, mock_llm), "test prompt")
+    wrapped = LangChainLLMAdapter(mock_llm)
+    await llm_call(wrapped, "prompt", llm_params={"temperature": 0.5, "max_tokens": 100})
 
-    exc_str = str(exc_info.value)
-    assert "https://example.openai.azure.com" in exc_str
-    assert "gpt-4" in exc_str
-    assert "Azure error" in exc_str
-
-
-@pytest.mark.asyncio
-async def test_llm_call_exception_extracts_server_url():
-    """Test that TRT-style server_url is extracted."""
-    mock_llm = MockTRTLLM()
-    mock_llm.model_name = "llama-2-70b"
-    mock_llm.server_url = "https://triton.example.com:8000"
-    mock_llm.ainvoke = AsyncMock(side_effect=Exception("Triton server error"))
-
-    with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(cast(BaseLanguageModel, mock_llm), "test prompt")
-
-    exc_str = str(exc_info.value)
-    assert "https://triton.example.com:8000" in exc_str
-    assert "llama-2-70b" in exc_str
-    assert "Triton server error" in exc_str
-
-
-@pytest.mark.asyncio
-async def test_llm_call_exception_extracts_nested_client_base_url():
-    """Test that nested client.base_url is extracted."""
-    mock_llm = MockLLMWithClient()
-    mock_llm.model_name = "gpt-4-turbo"
-    mock_llm.ainvoke = AsyncMock(side_effect=Exception("Client error"))
-
-    with pytest.raises(LLMCallException) as exc_info:
-        await llm_call(cast(BaseLanguageModel, mock_llm), "test prompt")
-
-    exc_str = str(exc_info.value)
-    assert "https://custom.endpoint.com/v1" in exc_str
-    assert "gpt-4-turbo" in exc_str
-    assert "Client error" in exc_str
-
-
-def _create_llm(model_name):
-    try:
-        from langchain_openai import ChatOpenAI
-
-        return ChatOpenAI(model=model_name)
-    except Exception:
-
-        class _MockLLM:
-            def __init__(self, model_name):
-                self.model_name = model_name
-
-        return _MockLLM(model_name)
-
-
-class TestFilterParamsForOpenAIReasoningModels:
-    @pytest.mark.parametrize(
-        "model,params,expected",
-        [
-            ("gpt-4", {"temperature": 0.5, "max_tokens": 100}, {"temperature": 0.5, "max_tokens": 100}),
-            ("gpt-4o", {"temperature": 0.7}, {"temperature": 0.7}),
-            ("gpt-4o-mini", {"temperature": 0.3, "max_tokens": 50}, {"temperature": 0.3, "max_tokens": 50}),
-            ("gpt-5-chat", {"temperature": 0.5}, {"temperature": 0.5}),
-            ("o1-preview", {"temperature": 0.001, "max_tokens": 100}, {"max_tokens": 100}),
-            ("o1-mini", {"temperature": 0.5}, {}),
-            ("o3", {"temperature": 0.001, "max_tokens": 200}, {"max_tokens": 200}),
-            ("o3-mini", {"temperature": 0.1}, {}),
-            ("gpt-5", {"temperature": 0.001}, {}),
-            ("gpt-5-mini", {"temperature": 0.5, "max_tokens": 100}, {"max_tokens": 100}),
-            ("gpt-5-nano", {"temperature": 0.001}, {}),
-            ("o1-preview", {"max_tokens": 100}, {"max_tokens": 100}),
-            ("o1-preview", {}, {}),
-            ("gpt-5", {"stop": "stop"}, {}),
-            ("gpt-5-mini", {"temperature": 0.5, "max_tokens": 100, "stop": "stop"}, {"max_tokens": 100}),
-            ("o4-mini", {"stop": "stop"}, {}),
-            ("o3", {"stop": "stop"}, {}),
-            ("o3-pro", {"temperature": 0.5, "stop": "stop"}, {}),
-        ],
-    )
-    def test_filter_params(self, model, params, expected):
-        llm = _create_llm(model)
-        result = _filter_params_for_openai_reasoning_models(llm, params)
-        assert result == expected
-
-    def test_returns_none_when_llm_params_is_none(self):
-        llm = _create_llm("gpt-4")
-        result = _filter_params_for_openai_reasoning_models(llm, None)
-        assert result is None
-
-    def test_does_not_modify_original_params(self):
-        llm = _create_llm("o1-preview")
-        params = {"temperature": 0.5, "max_tokens": 100}
-        _filter_params_for_openai_reasoning_models(llm, params)
-        assert params == {"temperature": 0.5, "max_tokens": 100}
-
-    @pytest.mark.asyncio
-    async def test_llm_call_does_not_mutate_llm_params(self):
-        mock_llm = get_bound_llm_magic_mock(ainvoke_return_value={"content": "response"})
-        original_params = {"max_tokens": 100}
-        await llm_call(mock_llm, "prompt", stop=["User:"], llm_params=original_params)
-        assert original_params == {"max_tokens": 100}
-
-
-async def _empty_astream(*args, **kwargs):
-    return
-    yield
-
-
-class _FakeLLM:
-    def __init__(self, stop=None, kwargs=None):
-        self.stop = stop
-        if kwargs is not None:
-            self.kwargs = kwargs
-        self.astream = _empty_astream
-
-
-class TestStreamLlmCallStopCoercion:
-    @pytest.mark.asyncio
-    async def test_llm_stop_attr_none_coerced_to_list(self):
-        from nemoguardrails.streaming import StreamingHandler
-
-        llm = _FakeLLM(stop=None)
-        handler = StreamingHandler()
-        await _stream_llm_call(llm, "prompt", handler)
-
-        assert handler.stop == []
-
-    @pytest.mark.asyncio
-    async def test_llm_kwargs_stop_none_coerced_to_list(self):
-        from nemoguardrails.streaming import StreamingHandler
-
-        llm = _FakeLLM(kwargs={"stop": None})
-        handler = StreamingHandler()
-        await _stream_llm_call(llm, "prompt", handler)
-
-        assert handler.stop == []
-
-    @pytest.mark.asyncio
-    async def test_llm_with_valid_stop_preserved(self):
-        from nemoguardrails.streaming import StreamingHandler
-
-        llm = _FakeLLM(stop=["User:"])
-        handler = StreamingHandler()
-        await _stream_llm_call(llm, "prompt", handler)
-
-        assert handler.stop == ["User:"]
+    mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
 
 
 class TestLogCompletion:
@@ -769,7 +325,7 @@ class TestLogCompletion:
         llm_call_info = LLMCallInfo()
         llm_call_info_var.set(llm_call_info)
 
-        response = AIMessage(content="This is the response")
+        response = LLMResponse(content="This is the response")
         _log_completion(response)
 
         assert llm_call_info.completion == "This is the response"
@@ -778,9 +334,9 @@ class TestLogCompletion:
         llm_call_info = LLMCallInfo()
         llm_call_info_var.set(llm_call_info)
 
-        response = AIMessage(
+        response = LLMResponse(
             content="Final answer",
-            additional_kwargs={"reasoning_content": "Step 1: Think"},
+            reasoning="Step 1: Think",
         )
         _log_completion(response)
 
@@ -788,17 +344,17 @@ class TestLogCompletion:
 
 
 class TestUpdateTokenStatsFromChunk:
-    def test_extracts_from_generation_info(self):
+    def test_extracts_from_usage(self):
         llm_call_info = LLMCallInfo()
         llm_call_info_var.set(llm_call_info)
 
         llm_stats = LLMStats()
         llm_stats_var.set(llm_stats)
 
-        chunk = MagicMock()
-        chunk.usage_metadata = None
-        chunk.response_metadata = None
-        chunk.generation_info = {"usage": {"total_tokens": 25, "prompt_tokens": 15, "completion_tokens": 10}}
+        chunk = LLMResponseChunk(
+            delta_content="",
+            usage=UsageInfo(total_tokens=25, input_tokens=15, output_tokens=10),
+        )
 
         _update_token_stats_from_chunk(chunk)
 
@@ -806,20 +362,123 @@ class TestUpdateTokenStatsFromChunk:
         assert llm_call_info.prompt_tokens == 15
         assert llm_call_info.completion_tokens == 10
 
-    def test_extracts_from_usage_metadata(self):
+    def test_extracts_from_usage_metadata_via_adapter(self):
         llm_call_info = LLMCallInfo()
         llm_call_info_var.set(llm_call_info)
 
         llm_stats = LLMStats()
         llm_stats_var.set(llm_stats)
 
-        chunk = MagicMock()
-        chunk.usage_metadata = {"total_tokens": 30, "input_tokens": 20, "output_tokens": 10}
-        chunk.response_metadata = None
-        chunk.generation_info = None
+        chunk = LLMResponseChunk(
+            delta_content="",
+            usage=UsageInfo(total_tokens=30, input_tokens=20, output_tokens=10),
+        )
 
         _update_token_stats_from_chunk(chunk)
 
         assert llm_call_info.total_tokens == 30
         assert llm_call_info.prompt_tokens == 20
         assert llm_call_info.completion_tokens == 10
+
+
+class TestLlmCallDictToChatMessageConversion:
+    @pytest.mark.asyncio
+    async def test_llm_call_converts_dict_prompt_to_chat_messages(self):
+        received_prompt = None
+
+        class CaptureLLM:
+            async def generate(self, prompt, *, stop=None, **kwargs):
+                nonlocal received_prompt
+                received_prompt = prompt
+                return LLMResponse(content="ok")
+
+            async def stream(self, prompt, *, stop=None, **kwargs):
+                yield LLMResponseChunk(delta_content="ok")
+
+            @property
+            def model_name(self):
+                return "test"
+
+            @property
+            def provider_name(self):
+                return None
+
+            @property
+            def provider_url(self):
+                return None
+
+        model = CaptureLLM()
+        dict_prompt = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+        ]
+        await llm_call(model, dict_prompt)
+
+        assert received_prompt is not None
+        assert isinstance(received_prompt, list)
+        assert len(received_prompt) == 2
+        assert all(isinstance(m, ChatMessage) for m in received_prompt)
+        assert received_prompt[0].role == Role.SYSTEM
+        assert received_prompt[0].content == "You are helpful."
+        assert received_prompt[1].role == Role.USER
+        assert received_prompt[1].content == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_llm_call_passes_string_prompt_unchanged(self):
+        received_prompt = None
+
+        class CaptureLLM:
+            async def generate(self, prompt, *, stop=None, **kwargs):
+                nonlocal received_prompt
+                received_prompt = prompt
+                return LLMResponse(content="ok")
+
+            async def stream(self, prompt, *, stop=None, **kwargs):
+                yield LLMResponseChunk(delta_content="ok")
+
+            @property
+            def model_name(self):
+                return "test"
+
+            @property
+            def provider_name(self):
+                return None
+
+            @property
+            def provider_url(self):
+                return None
+
+        model = CaptureLLM()
+        await llm_call(model, "simple string prompt")
+
+        assert received_prompt == "simple string prompt"
+
+    @pytest.mark.asyncio
+    async def test_llm_call_handles_empty_list(self):
+        received_prompt = None
+
+        class CaptureLLM:
+            async def generate(self, prompt, *, stop=None, **kwargs):
+                nonlocal received_prompt
+                received_prompt = prompt
+                return LLMResponse(content="ok")
+
+            async def stream(self, prompt, *, stop=None, **kwargs):
+                yield LLMResponseChunk(delta_content="ok")
+
+            @property
+            def model_name(self):
+                return "test"
+
+            @property
+            def provider_name(self):
+                return None
+
+            @property
+            def provider_url(self):
+                return None
+
+        model = CaptureLLM()
+        await llm_call(model, [])
+
+        assert received_prompt == []

--- a/tests/test_content_safety_actions.py
+++ b/tests/test_content_safety_actions.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.library.content_safety.actions import (
     DEFAULT_REFUSAL_MESSAGES,
     SUPPORTED_LANGUAGES,
@@ -42,7 +43,7 @@ requires_fast_langdetect = pytest.mark.skipif(not HAS_FAST_LANGDETECT, reason="f
 @pytest.fixture
 def fake_llm():
     def _factory(response):
-        llm = FakeLLM(responses=[response])
+        llm = LangChainLLMAdapter(FakeLLM(responses=[response]))
         return {"test_model": llm}
 
     return _factory

--- a/tests/test_content_safety_cache.py
+++ b/tests/test_content_safety_cache.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails.context import llm_call_info_var, llm_stats_var
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.library.content_safety.actions import (
     content_safety_check_input,
     content_safety_check_output,
@@ -41,7 +42,7 @@ def mock_task_manager():
 
 @pytest.fixture
 def fake_llm_with_stats():
-    llm = FakeLLM(responses=["safe"])
+    llm = LangChainLLMAdapter(FakeLLM(responses=["safe"]))
     return {"test_model": llm}
 
 

--- a/tests/test_content_safety_integration.py
+++ b/tests/test_content_safety_integration.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.library.content_safety.actions import (
     content_safety_check_input,
     content_safety_check_output,
@@ -40,7 +41,7 @@ from tests.utils import FakeLLM, TestChat
 
 
 def _create_mock_setup(llm_responses, parsed_result):
-    mock_llm = FakeLLM(responses=llm_responses)
+    mock_llm = LangChainLLMAdapter(FakeLLM(responses=llm_responses))
     llms = {"test_model": mock_llm}
 
     mock_task_manager = MagicMock()
@@ -350,7 +351,9 @@ class TestReasoningEnabledEndToEnd:
             llm_completions=["Hello! How can I help you?"],
         )
 
-        chat.app.runtime.registered_action_params["llms"] = {"content_safety_reasoning": content_safety_llm}
+        chat.app.runtime.registered_action_params["llms"] = {
+            "content_safety_reasoning": LangChainLLMAdapter(content_safety_llm)
+        }
 
         user_message = "Hello"
         response = chat.app.generate(messages=[{"role": "user", "content": user_message}])

--- a/tests/test_langchain_llm_adapter.py
+++ b/tests/test_langchain_llm_adapter.py
@@ -539,7 +539,7 @@ class TestChatMessageToLangChain:
     def test_unsupported_role_raises(self):
         msg = ChatMessage(role=Role.USER, content="test")
         msg.role = "unknown"
-        with pytest.raises(ValueError, match="Unsupported ChatMessage role"):
+        with pytest.raises(ValueError, match="Unsupported role"):
             chatmessage_to_langchain_message(msg)
 
     def test_batch_conversion(self):

--- a/tests/test_llama_guard.py
+++ b/tests/test_llama_guard.py
@@ -15,6 +15,7 @@
 
 
 from nemoguardrails import RailsConfig
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from tests.utils import FakeLLM, TestChat
 
 COLANG_CONFIG = """
@@ -66,11 +67,13 @@ def test_llama_guard_check_all_safe():
         ],
     )
 
-    llama_guard_llm = FakeLLM(
-        responses=[
-            "safe",  # llama_guard_check_input
-            "safe",  # llama_guard_check_output
-        ]
+    llama_guard_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                "safe",  # llama_guard_check_input
+                "safe",  # llama_guard_check_output
+            ]
+        )
     )
     chat.app.register_action_param("llama_guard_llm", llama_guard_llm)
 
@@ -92,10 +95,12 @@ def test_llama_guard_check_input_unsafe():
         ],
     )
 
-    llama_guard_llm = FakeLLM(
-        responses=[
-            "unsafe",  # llama_guard_check_input
-        ]
+    llama_guard_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                "unsafe",  # llama_guard_check_input
+            ]
+        )
     )
     chat.app.register_action_param("llama_guard_llm", llama_guard_llm)
 
@@ -117,10 +122,12 @@ def test_llama_guard_check_input_error():
         ],
     )
 
-    llama_guard_llm = FakeLLM(
-        responses=[
-            "error",  # llama_guard_check_input
-        ]
+    llama_guard_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                "error",  # llama_guard_check_input
+            ]
+        )
     )
     chat.app.register_action_param("llama_guard_llm", llama_guard_llm)
 
@@ -142,11 +149,13 @@ def test_llama_guard_check_output_unsafe():
         ],
     )
 
-    llama_guard_llm = FakeLLM(
-        responses=[
-            "safe",  # llama_guard_check_input
-            "unsafe",  # llama_guard_check_output
-        ]
+    llama_guard_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                "safe",  # llama_guard_check_input
+                "unsafe",  # llama_guard_check_output
+            ]
+        )
     )
     chat.app.register_action_param("llama_guard_llm", llama_guard_llm)
 
@@ -168,11 +177,13 @@ def test_llama_guard_check_output_error():
         ],
     )
 
-    llama_guard_llm = FakeLLM(
-        responses=[
-            "safe",  # llama_guard_check_input
-            "error",  # llama_guard_check_output
-        ]
+    llama_guard_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                "safe",  # llama_guard_check_input
+                "error",  # llama_guard_check_output
+            ]
+        )
     )
     chat.app.register_action_param("llama_guard_llm", llama_guard_llm)
 

--- a/tests/test_llmrails.py
+++ b/tests/test_llmrails.py
@@ -18,13 +18,12 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
-from langchain_core.language_models import BaseChatModel
 
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.logging.explain import ExplainInfo
 from nemoguardrails.rails.llm.config import Model
 from tests.conftest import REASONING_TRACE_MOCK_PATH
-from tests.utils import FakeLLM, clean_events, event_sequence_conforms, get_bound_llm_magic_mock
+from tests.utils import FakeLLM, clean_events, event_sequence_conforms
 
 
 @pytest.fixture
@@ -747,7 +746,7 @@ async def test_llm_constructor_with_empty_models_config():
 
     injected_llm = FakeLLM(responses=["express greeting"])
     llm_rails = LLMRails(config=config, llm=injected_llm)
-    assert llm_rails.llm == injected_llm
+    assert llm_rails.llm.raw_llm == injected_llm
 
     events = [{"type": "UtteranceUserActionFinished", "final_transcript": "Hello!"}]
     new_events = await llm_rails.runtime.generate_events(events)
@@ -1059,9 +1058,9 @@ def test_explain_calls_ensure_explain_info():
     """Make sure if no `explain_info` attribute is present in LLMRails it's populated with
     an empty ExplainInfo object"""
 
-    mock_llm = get_bound_llm_magic_mock(ainvoke_return_value={"spec": BaseChatModel})
+    fake_llm = FakeLLM(responses=["express greeting"])
     config = RailsConfig.from_content(config={"models": []})
-    rails = LLMRails(config=config, llm=mock_llm)
+    rails = LLMRails(config=config, llm=fake_llm)
     rails.generate(messages=[{"role": "user", "content": "Hi!"}])
 
     rails.explain_info = None

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 import pytest
 
 from nemoguardrails.actions.llm.utils import _log_prompt, _update_token_stats
@@ -125,6 +127,7 @@ class TestTrackLlmCallDecorator:
 
         @track_llm_call
         async def mock_llm_call():
+            await asyncio.sleep(0.02)
             return "response"
 
         result = await mock_llm_call()
@@ -168,6 +171,7 @@ class TestTrackLlmCallDecorator:
 
         @track_llm_call
         async def mock_llm_call():
+            await asyncio.sleep(0.02)
             return "response"
 
         await mock_llm_call()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -13,36 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
-from unittest.mock import MagicMock
-
 import pytest
-from langchain_core.messages import AIMessage
 
-from nemoguardrails.actions.llm.utils import _log_completion, _log_prompt, _store_reasoning_traces, _update_token_stats
+from nemoguardrails.actions.llm.utils import _log_prompt, _update_token_stats
 from nemoguardrails.context import explain_info_var, llm_call_info_var, llm_stats_var
 from nemoguardrails.logging.explain import ExplainInfo, LLMCallInfo
 from nemoguardrails.logging.llm_tracker import track_llm_call
 from nemoguardrails.logging.processing_log import processing_log_var
 from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.types import LLMResponse, UsageInfo
 
 
 @pytest.mark.asyncio
-async def test_token_usage_tracking_with_usage_metadata():
-    """Test that token usage is tracked when usage_metadata is available."""
-
+async def test_token_usage_tracking_with_usage():
     llm_call_info = LLMCallInfo()
     llm_call_info_var.set(llm_call_info)
 
     llm_stats = LLMStats()
     llm_stats_var.set(llm_stats)
 
-    ai_message = AIMessage(
+    response = LLMResponse(
         content="Hello! How can I help you?",
-        usage_metadata={"input_tokens": 10, "output_tokens": 6, "total_tokens": 16},
+        usage=UsageInfo(input_tokens=10, output_tokens=6, total_tokens=16),
     )
 
-    _update_token_stats(ai_message)
+    _update_token_stats(response)
 
     assert llm_call_info.total_tokens == 16
     assert llm_call_info.prompt_tokens == 10
@@ -54,45 +49,14 @@ async def test_token_usage_tracking_with_usage_metadata():
 
 
 @pytest.mark.asyncio
-async def test_token_usage_tracking_with_response_metadata_fallback():
-    """Test token usage tracking with response_metadata format."""
+async def test_no_token_usage_tracking_without_usage():
     llm_call_info = LLMCallInfo()
     llm_call_info_var.set(llm_call_info)
 
     llm_stats = LLMStats()
     llm_stats_var.set(llm_stats)
 
-    response = MagicMock()
-    response.usage_metadata = None
-    response.response_metadata = {
-        "token_usage": {
-            "total_tokens": 20,
-            "prompt_tokens": 12,
-            "completion_tokens": 8,
-        }
-    }
-
-    _update_token_stats(response)
-
-    assert llm_call_info.total_tokens == 20
-    assert llm_call_info.prompt_tokens == 12
-    assert llm_call_info.completion_tokens == 8
-
-    assert llm_stats.get_stat("total_tokens") == 20
-    assert llm_stats.get_stat("total_prompt_tokens") == 12
-    assert llm_stats.get_stat("total_completion_tokens") == 8
-
-
-@pytest.mark.asyncio
-async def test_no_token_usage_tracking_without_metadata():
-    """Test that no token usage is tracked when metadata is not available."""
-    llm_call_info = LLMCallInfo()
-    llm_call_info_var.set(llm_call_info)
-
-    llm_stats = LLMStats()
-    llm_stats_var.set(llm_stats)
-
-    response = AIMessage(content="Hello! How can I help you?")
+    response = LLMResponse(content="Hello! How can I help you?")
 
     _update_token_stats(response)
 
@@ -161,7 +125,6 @@ class TestTrackLlmCallDecorator:
 
         @track_llm_call
         async def mock_llm_call():
-            await asyncio.sleep(0.02)
             return "response"
 
         result = await mock_llm_call()
@@ -205,78 +168,9 @@ class TestTrackLlmCallDecorator:
 
         @track_llm_call
         async def mock_llm_call():
-            await asyncio.sleep(0.02)
             return "response"
 
         await mock_llm_call()
 
         llm_stats = llm_stats_var.get()
         assert llm_stats.get_stat("total_time") > 0
-
-
-class TestTokenStatsAssignment:
-    def test_usage_metadata_uses_assignment_not_accumulation(self):
-        llm_call_info = LLMCallInfo()
-        llm_call_info.total_tokens = 100
-        llm_call_info.prompt_tokens = 60
-        llm_call_info.completion_tokens = 40
-        llm_call_info_var.set(llm_call_info)
-
-        llm_stats = LLMStats()
-        llm_stats_var.set(llm_stats)
-
-        response = AIMessage(
-            content="test",
-            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
-        )
-
-        _update_token_stats(response)
-
-        assert llm_call_info.total_tokens == 15
-        assert llm_call_info.prompt_tokens == 10
-        assert llm_call_info.completion_tokens == 5
-
-    def test_response_metadata_uses_assignment_not_accumulation(self):
-        llm_call_info = LLMCallInfo()
-        llm_call_info.total_tokens = 100
-        llm_call_info.prompt_tokens = 60
-        llm_call_info.completion_tokens = 40
-        llm_call_info_var.set(llm_call_info)
-
-        llm_stats = LLMStats()
-        llm_stats_var.set(llm_stats)
-
-        response = MagicMock()
-        response.usage_metadata = None
-        response.response_metadata = {"token_usage": {"total_tokens": 20, "prompt_tokens": 12, "completion_tokens": 8}}
-
-        _update_token_stats(response)
-
-        assert llm_call_info.total_tokens == 20
-        assert llm_call_info.prompt_tokens == 12
-        assert llm_call_info.completion_tokens == 8
-
-
-class TestThinkTagsStrippedBeforeCompletion:
-    def test_completion_excludes_think_tags_when_reasoning_extracted_first(self):
-        llm_call_info = LLMCallInfo()
-        llm_call_info_var.set(llm_call_info)
-
-        response = AIMessage(content="<think>internal reasoning</think>Final answer")
-
-        _store_reasoning_traces(response)
-        _log_completion(response)
-
-        assert "<think>" not in llm_call_info.completion
-        assert "internal reasoning" not in llm_call_info.completion
-        assert "Final answer" in llm_call_info.completion
-
-    def test_completion_contains_think_tags_if_logged_before_extraction(self):
-        llm_call_info = LLMCallInfo()
-        llm_call_info_var.set(llm_call_info)
-
-        response = AIMessage(content="<think>internal reasoning</think>Final answer")
-
-        _log_completion(response)
-
-        assert "<think>" in llm_call_info.completion

--- a/tests/test_patronus_lynx.py
+++ b/tests/test_patronus_lynx.py
@@ -17,6 +17,7 @@ import pytest
 
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions.actions import ActionResult, action
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from tests.utils import FakeLLM, TestChat
 
 COLANG_CONFIG = """
@@ -98,10 +99,12 @@ def test_patronus_lynx_returns_no_hallucination():
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"REASONING": ["There is no hallucination."], "SCORE": "PASS"}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"REASONING": ["There is no hallucination."], "SCORE": "PASS"}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 
@@ -127,10 +130,12 @@ def test_patronus_lynx_returns_hallucination():
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"REASONING": ["There is a hallucination."], "SCORE": "FAIL"}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"REASONING": ["There is a hallucination."], "SCORE": "FAIL"}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 
@@ -156,10 +161,12 @@ def test_patronus_lynx_parses_score_when_no_double_quote():
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"REASONING": ["There is no hallucination."], "SCORE": PASS}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"REASONING": ["There is no hallucination."], "SCORE": PASS}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 
@@ -183,10 +190,12 @@ def test_patronus_lynx_returns_no_hallucination_when_no_retrieved_context():
         ],
     )
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"REASONING": ["There is a hallucination."], "SCORE": "FAIL"}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"REASONING": ["There is a hallucination."], "SCORE": "FAIL"}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 
@@ -212,10 +221,12 @@ def test_patronus_lynx_returns_hallucination_when_no_score_in_llm_output():
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"REASONING": ["Mock reasoning."]}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"REASONING": ["Mock reasoning."]}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 
@@ -241,10 +252,12 @@ def test_patronus_lynx_returns_no_hallucination_when_no_reasoning_in_llm_output(
 
     chat.app.register_action(retrieve_relevant_chunks, "retrieve_relevant_chunks")
 
-    patronus_lynx_llm = FakeLLM(
-        responses=[
-            '{"SCORE": "PASS"}',
-        ]
+    patronus_lynx_llm = LangChainLLMAdapter(
+        FakeLLM(
+            responses=[
+                '{"SCORE": "PASS"}',
+            ]
+        )
     )
     chat.app.register_action_param("patronus_lynx_llm", patronus_lynx_llm)
 

--- a/tests/test_reasoning_trace_extraction.py
+++ b/tests/test_reasoning_trace_extraction.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,16 +20,15 @@ from langchain_core.messages import AIMessage
 
 from nemoguardrails.actions.llm.utils import _store_reasoning_traces
 from nemoguardrails.context import reasoning_trace_var
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
+from nemoguardrails.types import LLMResponse
 
 
 class TestStoreReasoningTracesUnit:
     def test_store_reasoning_traces_with_valid_reasoning_content(self):
         test_reasoning = "Step 1: Analyze the question\nStep 2: Formulate response"
 
-        response = AIMessage(
-            content="The answer is 42",
-            additional_kwargs={"reasoning_content": test_reasoning},
-        )
+        response = LLMResponse(content="The answer is 42", reasoning=test_reasoning)
 
         _store_reasoning_traces(response)
 
@@ -39,7 +38,7 @@ class TestStoreReasoningTracesUnit:
         reasoning_trace_var.set(None)
 
     def test_store_reasoning_traces_with_empty_reasoning_content(self):
-        response = AIMessage(content="Response", additional_kwargs={"reasoning_content": ""})
+        response = LLMResponse(content="Response", reasoning="")
 
         reasoning_trace_var.set(None)
         _store_reasoning_traces(response)
@@ -50,7 +49,7 @@ class TestStoreReasoningTracesUnit:
         reasoning_trace_var.set(None)
 
     def test_store_reasoning_traces_with_none_reasoning_content(self):
-        response = AIMessage(content="Response", additional_kwargs={"reasoning_content": None})
+        response = LLMResponse(content="Response", reasoning=None)
 
         reasoning_trace_var.set(None)
         _store_reasoning_traces(response)
@@ -60,50 +59,8 @@ class TestStoreReasoningTracesUnit:
 
         reasoning_trace_var.set(None)
 
-    def test_store_reasoning_traces_without_reasoning_content_key(self):
-        response = AIMessage(content="Response", additional_kwargs={"other_key": "other_value"})
-
-        reasoning_trace_var.set(None)
-        _store_reasoning_traces(response)
-
-        stored_trace = reasoning_trace_var.get()
-        assert stored_trace is None
-
-        reasoning_trace_var.set(None)
-
-    def test_store_reasoning_traces_with_empty_additional_kwargs(self):
-        response = AIMessage(content="Response", additional_kwargs={})
-
-        reasoning_trace_var.set(None)
-        _store_reasoning_traces(response)
-
-        stored_trace = reasoning_trace_var.get()
-        assert stored_trace is None
-
-        reasoning_trace_var.set(None)
-
-    def test_store_reasoning_traces_without_additional_kwargs_attribute(self):
-        class SimpleResponse:
-            def __init__(self, content):
-                self.content = content
-
-        response = SimpleResponse("Response")
-
-        reasoning_trace_var.set(None)
-        _store_reasoning_traces(response)
-
-        stored_trace = reasoning_trace_var.get()
-        assert stored_trace is None
-
-        reasoning_trace_var.set(None)
-
-    def test_store_reasoning_traces_with_non_dict_additional_kwargs(self):
-        class ResponseWithInvalidKwargs:
-            def __init__(self):
-                self.content = "Response"
-                self.additional_kwargs = "not_a_dict"
-
-        response = ResponseWithInvalidKwargs()
+    def test_store_reasoning_traces_without_reasoning(self):
+        response = LLMResponse(content="Response")
 
         reasoning_trace_var.set(None)
         _store_reasoning_traces(response)
@@ -119,7 +76,7 @@ class TestStoreReasoningTracesUnit:
 
         reasoning_trace_var.set(initial_trace)
 
-        response = AIMessage(content="Response", additional_kwargs={"reasoning_content": new_trace})
+        response = LLMResponse(content="Response", reasoning=new_trace)
 
         _store_reasoning_traces(response)
 
@@ -130,21 +87,13 @@ class TestStoreReasoningTracesUnit:
         reasoning_trace_var.set(None)
 
     def test_store_reasoning_traces_clears_previous_when_no_new_reasoning(self):
-        """Test that previous reasoning traces are cleared when new response has no reasoning.
-
-        This prevents stale reasoning from previous LLM calls (e.g., safety checks)
-        from leaking into subsequent responses.
-        """
-        # Set up a previous reasoning trace (simulating a safety check)
         previous_trace = "Previous safety check reasoning that should be cleared"
         reasoning_trace_var.set(previous_trace)
 
-        # Simulate a response with NO reasoning content (like from gpt-4o-mini)
-        response = AIMessage(content="Regular response without reasoning", additional_kwargs={})
+        response = LLMResponse(content="Regular response without reasoning")
 
         _store_reasoning_traces(response)
 
-        # The previous trace should be cleared, not persist
         stored_trace = reasoning_trace_var.get()
         assert stored_trace is None, "Previous reasoning trace should be cleared when new response has no reasoning"
 
@@ -157,10 +106,7 @@ class TestStoreReasoningTracesUnit:
 3. Third, formulate a response
 4. Finally, validate the response"""
 
-        response = AIMessage(
-            content="Response",
-            additional_kwargs={"reasoning_content": multiline_reasoning},
-        )
+        response = LLMResponse(content="Response", reasoning=multiline_reasoning)
 
         _store_reasoning_traces(response)
 
@@ -172,10 +118,7 @@ class TestStoreReasoningTracesUnit:
     def test_store_reasoning_traces_with_special_characters(self):
         special_reasoning = "Thinking: Let's analyze this <step> with \"quotes\" and 'apostrophes' & symbols!"
 
-        response = AIMessage(
-            content="Response",
-            additional_kwargs={"reasoning_content": special_reasoning},
-        )
+        response = LLMResponse(content="Response", reasoning=special_reasoning)
 
         _store_reasoning_traces(response)
 
@@ -200,9 +143,9 @@ class TestReasoningTraceIntegration:
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "What is the answer?")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "What is the answer?")
 
-        assert result == "The answer is 42"
+        assert result.content == "The answer is 42"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == test_reasoning
 
@@ -217,9 +160,9 @@ class TestReasoningTraceIntegration:
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "Hello")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "Hello")
 
-        assert result == "Regular response"
+        assert result.content == "Regular response"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace is None
 
@@ -244,9 +187,9 @@ class TestReasoningTraceIntegration:
         ]
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, messages)
+        result = await llm_call(LangChainLLMAdapter(mock_llm), messages)
 
-        assert result == "Here's my response"
+        assert result.content == "Here's my response"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == test_reasoning
 
@@ -278,12 +221,13 @@ class TestReasoningTraceIntegration:
 
         from nemoguardrails.actions.llm.utils import llm_call
 
+        wrapped = LangChainLLMAdapter(mock_llm)
         reasoning_trace_var.set(None)
-        result1 = await llm_call(mock_llm, "First query")
+        result1 = await llm_call(wrapped, "First query")
         trace1 = reasoning_trace_var.get()
 
         reasoning_trace_var.set(None)
-        result2 = await llm_call(mock_llm, "Second query")
+        result2 = await llm_call(wrapped, "Second query")
         trace2 = reasoning_trace_var.get()
 
         assert trace1 == first_reasoning
@@ -310,9 +254,9 @@ class TestReasoningTraceIntegration:
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "Query")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "Query")
 
-        assert result == "Response"
+        assert result.content == "Response"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == test_reasoning
 
@@ -332,10 +276,10 @@ class TestReasoningTraceIntegration:
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "What is the answer?")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "What is the answer?")
 
-        assert result == "The answer is 42"
-        assert "<think>" not in result
+        assert result.content == "The answer is 42"
+        assert "<think>" not in result.content
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == test_reasoning
 
@@ -356,9 +300,9 @@ class TestReasoningTraceIntegration:
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "Query")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "Query")
 
-        assert result == f"<think>{reasoning_from_tags}</think>Response"
+        assert result.content == f"<think>{reasoning_from_tags}</think>Response"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == reasoning_from_kwargs
 
@@ -380,10 +324,10 @@ Step 3: Formulate the answer"""
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "Question")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "Question")
 
-        assert result == "Final answer"
-        assert "<think>" not in result
+        assert result.content == "Final answer"
+        assert "<think>" not in result.content
         stored_trace = reasoning_trace_var.get()
         assert stored_trace == multiline_reasoning
 
@@ -401,9 +345,9 @@ Step 3: Formulate the answer"""
         from nemoguardrails.actions.llm.utils import llm_call
 
         reasoning_trace_var.set(None)
-        result = await llm_call(mock_llm, "Query")
+        result = await llm_call(LangChainLLMAdapter(mock_llm), "Query")
 
-        assert result == "<think>This is incomplete"
+        assert result.content == "<think>This is incomplete"
         stored_trace = reasoning_trace_var.get()
         assert stored_trace is None
 

--- a/tests/test_tool_calling_passthrough_only.py
+++ b/tests/test_tool_calling_passthrough_only.py
@@ -23,6 +23,7 @@ from langchain_core.messages import AIMessage
 from nemoguardrails import LLMRails, RailsConfig
 from nemoguardrails.actions.llm.generation import LLMGenerationActions
 from nemoguardrails.context import tool_calls_var
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from tests.utils import get_bound_llm_magic_mock
 
 
@@ -106,20 +107,21 @@ class TestToolCallingPassthroughOnly:
     @pytest.mark.asyncio
     async def test_tool_calls_work_in_passthrough_mode(self, config_passthrough, mock_llm_with_tool_calls):
         """Test that tool calls create BotToolCalls events in passthrough mode."""
-        # Set up context with tool calls
         tool_calls = [
             {
                 "id": "call_123",
-                "type": "tool_call",
-                "name": "test_tool",
-                "args": {"param": "value"},
+                "type": "function",
+                "function": {
+                    "name": "test_tool",
+                    "arguments": {"param": "value"},
+                },
             }
         ]
         tool_calls_var.set(tool_calls)
 
         generation_actions = LLMGenerationActions(
             config=config_passthrough,
-            llm=mock_llm_with_tool_calls,
+            llm=LangChainLLMAdapter(mock_llm_with_tool_calls),
             llm_task_manager=MagicMock(),
             get_embedding_search_provider_instance=MagicMock(return_value=None),
         )
@@ -133,7 +135,11 @@ class TestToolCallingPassthroughOnly:
 
         assert len(result.events) == 1
         assert result.events[0]["type"] == "BotToolCalls"
-        assert result.events[0]["tool_calls"] == tool_calls
+        stored = result.events[0]["tool_calls"]
+        assert len(stored) == 1
+        assert stored[0]["function"]["name"] == "test_tool"
+        assert stored[0]["function"]["arguments"] == {"param": "value"}
+        assert stored[0]["id"] == "call_123"
 
     @pytest.mark.asyncio
     async def test_tool_calls_ignored_in_non_passthrough_mode(self, config_no_passthrough, mock_llm_with_tool_calls):
@@ -150,7 +156,7 @@ class TestToolCallingPassthroughOnly:
 
         generation_actions = LLMGenerationActions(
             config=config_no_passthrough,
-            llm=mock_llm_with_tool_calls,
+            llm=LangChainLLMAdapter(mock_llm_with_tool_calls),
             llm_task_manager=MagicMock(),
             get_embedding_search_provider_instance=MagicMock(return_value=None),
         )
@@ -177,7 +183,7 @@ class TestToolCallingPassthroughOnly:
 
         generation_actions = LLMGenerationActions(
             config=config_passthrough,
-            llm=mock_llm_with_tool_calls,
+            llm=LangChainLLMAdapter(mock_llm_with_tool_calls),
             llm_task_manager=MagicMock(),
             get_embedding_search_provider_instance=MagicMock(return_value=None),
         )
@@ -194,12 +200,12 @@ class TestToolCallingPassthroughOnly:
 
     def test_llm_rails_integration_passthrough_mode(self, config_passthrough, mock_llm_with_tool_calls):
         """Test LLMRails with passthrough mode allows tool calls."""
-        rails = LLMRails(config=config_passthrough, llm=mock_llm_with_tool_calls)
+        rails = LLMRails(config=config_passthrough, llm=LangChainLLMAdapter(mock_llm_with_tool_calls))
 
         assert rails.config.passthrough is True
 
     def test_llm_rails_integration_non_passthrough_mode(self, config_no_passthrough, mock_llm_with_tool_calls):
         """Test LLMRails without passthrough mode."""
-        rails = LLMRails(config=config_no_passthrough, llm=mock_llm_with_tool_calls)
+        rails = LLMRails(config=config_no_passthrough, llm=LangChainLLMAdapter(mock_llm_with_tool_calls))
 
         assert rails.config.passthrough is False

--- a/tests/test_tool_calling_utils.py
+++ b/tests/test_tool_calling_utils.py
@@ -50,7 +50,7 @@ def test_get_and_clear_tool_calls_contextvar_empty():
     assert result is None
 
 
-def testdicts_to_messages_user():
+def test_dicts_to_messages_user():
     messages = [{"role": "user", "content": "Hello"}]
 
     result = dicts_to_messages(messages)
@@ -60,7 +60,7 @@ def testdicts_to_messages_user():
     assert result[0].content == "Hello"
 
 
-def testdicts_to_messages_assistant():
+def test_dicts_to_messages_assistant():
     messages = [{"role": "assistant", "content": "Hi there"}]
 
     result = dicts_to_messages(messages)
@@ -70,7 +70,7 @@ def testdicts_to_messages_assistant():
     assert result[0].content == "Hi there"
 
 
-def testdicts_to_messages_bot():
+def test_dicts_to_messages_bot():
     messages = [{"type": "bot", "content": "Hello from bot"}]
 
     result = dicts_to_messages(messages)
@@ -80,7 +80,7 @@ def testdicts_to_messages_bot():
     assert result[0].content == "Hello from bot"
 
 
-def testdicts_to_messages_system():
+def test_dicts_to_messages_system():
     messages = [{"role": "system", "content": "You are a helpful assistant"}]
 
     result = dicts_to_messages(messages)
@@ -90,7 +90,7 @@ def testdicts_to_messages_system():
     assert result[0].content == "You are a helpful assistant"
 
 
-def testdicts_to_messages_tool():
+def test_dicts_to_messages_tool():
     messages = [{"role": "tool", "content": "Tool result", "tool_call_id": "call_123"}]
 
     result = dicts_to_messages(messages)
@@ -101,7 +101,7 @@ def testdicts_to_messages_tool():
     assert result[0].tool_call_id == "call_123"
 
 
-def testdicts_to_messages_tool_no_id():
+def test_dicts_to_messages_tool_no_id():
     messages = [{"role": "tool", "content": "Tool result"}]
 
     result = dicts_to_messages(messages)
@@ -112,7 +112,7 @@ def testdicts_to_messages_tool_no_id():
     assert result[0].tool_call_id == ""
 
 
-def testdicts_to_messages_mixed():
+def test_dicts_to_messages_mixed():
     messages = [
         {"role": "system", "content": "System prompt"},
         {"role": "user", "content": "User message"},
@@ -130,7 +130,7 @@ def testdicts_to_messages_mixed():
     assert result[3].tool_call_id == "call_456"
 
 
-def testdicts_to_messages_unknown_type():
+def test_dicts_to_messages_unknown_type():
     messages = [{"role": "unknown", "content": "Unknown message"}]
 
     with pytest.raises(ValueError, match="Unknown message type: unknown"):

--- a/tests/test_tool_calling_utils.py
+++ b/tests/test_tool_calling_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,6 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from nemoguardrails.actions.llm.utils import (
-    _convert_messages_to_langchain_format,
     _extract_content,
     _store_tool_calls,
     get_and_clear_tool_calls_contextvar,
@@ -27,7 +26,10 @@ from nemoguardrails.actions.llm.utils import (
 )
 from nemoguardrails.context import tool_calls_var
 from nemoguardrails.exceptions import LLMCallException
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
+from nemoguardrails.integrations.langchain.message_utils import dicts_to_messages
 from nemoguardrails.rails.llm.llmrails import GenerationResponse
+from nemoguardrails.types import LLMResponse, ToolCall, ToolCallFunction
 
 
 def test_get_and_clear_tool_calls_contextvar():
@@ -41,7 +43,6 @@ def test_get_and_clear_tool_calls_contextvar():
 
 
 def test_get_and_clear_tool_calls_contextvar_empty():
-    """Test that it returns None when no tool calls exist."""
     tool_calls_var.set(None)
 
     result = get_and_clear_tool_calls_contextvar()
@@ -49,55 +50,50 @@ def test_get_and_clear_tool_calls_contextvar_empty():
     assert result is None
 
 
-def test_convert_messages_to_langchain_format_user():
-    """Test converting user messages to LangChain format."""
+def testdicts_to_messages_user():
     messages = [{"role": "user", "content": "Hello"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], HumanMessage)
     assert result[0].content == "Hello"
 
 
-def test_convert_messages_to_langchain_format_assistant():
-    """Test converting assistant messages to LangChain format."""
+def testdicts_to_messages_assistant():
     messages = [{"role": "assistant", "content": "Hi there"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], AIMessage)
     assert result[0].content == "Hi there"
 
 
-def test_convert_messages_to_langchain_format_bot():
-    """Test converting bot messages to LangChain format."""
+def testdicts_to_messages_bot():
     messages = [{"type": "bot", "content": "Hello from bot"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], AIMessage)
     assert result[0].content == "Hello from bot"
 
 
-def test_convert_messages_to_langchain_format_system():
-    """Test converting system messages to LangChain format."""
+def testdicts_to_messages_system():
     messages = [{"role": "system", "content": "You are a helpful assistant"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], SystemMessage)
     assert result[0].content == "You are a helpful assistant"
 
 
-def test_convert_messages_to_langchain_format_tool():
-    """Test converting tool messages to LangChain format."""
+def testdicts_to_messages_tool():
     messages = [{"role": "tool", "content": "Tool result", "tool_call_id": "call_123"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], ToolMessage)
@@ -105,11 +101,10 @@ def test_convert_messages_to_langchain_format_tool():
     assert result[0].tool_call_id == "call_123"
 
 
-def test_convert_messages_to_langchain_format_tool_no_id():
-    """Test converting tool messages without tool_call_id."""
+def testdicts_to_messages_tool_no_id():
     messages = [{"role": "tool", "content": "Tool result"}]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 1
     assert isinstance(result[0], ToolMessage)
@@ -117,8 +112,7 @@ def test_convert_messages_to_langchain_format_tool_no_id():
     assert result[0].tool_call_id == ""
 
 
-def test_convert_messages_to_langchain_format_mixed():
-    """Test converting mixed message types."""
+def testdicts_to_messages_mixed():
     messages = [
         {"role": "system", "content": "System prompt"},
         {"role": "user", "content": "User message"},
@@ -126,7 +120,7 @@ def test_convert_messages_to_langchain_format_mixed():
         {"role": "tool", "content": "Tool output", "tool_call_id": "call_456"},
     ]
 
-    result = _convert_messages_to_langchain_format(messages)
+    result = dicts_to_messages(messages)
 
     assert len(result) == 4
     assert isinstance(result[0], SystemMessage)
@@ -136,65 +130,57 @@ def test_convert_messages_to_langchain_format_mixed():
     assert result[3].tool_call_id == "call_456"
 
 
-def test_convert_messages_to_langchain_format_unknown_type():
-    """Test that unknown message types raise ValueError."""
+def testdicts_to_messages_unknown_type():
     messages = [{"role": "unknown", "content": "Unknown message"}]
 
     with pytest.raises(ValueError, match="Unknown message type: unknown"):
-        _convert_messages_to_langchain_format(messages)
+        dicts_to_messages(messages)
 
 
 def test_store_tool_calls():
-    """Test storing tool calls from response."""
-    mock_response = MagicMock()
-    test_tool_calls = [{"name": "another_func", "args": {}, "id": "call_789", "type": "tool_call"}]
-    mock_response.tool_calls = test_tool_calls
+    response = LLMResponse(
+        content="",
+        tool_calls=[
+            ToolCall(id="call_789", function=ToolCallFunction(name="another_func", arguments={})),
+        ],
+    )
 
-    _store_tool_calls(mock_response)
+    _store_tool_calls(response)
 
-    assert tool_calls_var.get() == test_tool_calls
+    result = tool_calls_var.get()
+    assert result is not None
+    assert len(result) == 1
+    assert result[0]["function"]["name"] == "another_func"
+    assert result[0]["id"] == "call_789"
 
 
 def test_store_tool_calls_no_tool_calls():
-    """Test storing tool calls when response has no tool_calls attribute."""
-    mock_response = MagicMock()
-    del mock_response.tool_calls
+    response = LLMResponse(content="no tools")
 
-    _store_tool_calls(mock_response)
+    _store_tool_calls(response)
 
     assert tool_calls_var.get() is None
 
 
 def test_extract_content_with_content_attr():
-    """Test extracting content from response with content attribute."""
-    mock_response = MagicMock()
-    mock_response.content = "Response content"
+    response = LLMResponse(content="Response content")
 
-    result = _extract_content(mock_response)
+    result = _extract_content(response)
 
     assert result == "Response content"
 
 
-def test_extract_content_without_content_attr():
-    """Test extracting content from response without content attribute."""
-    mock_response = "Plain string response"
-
-    result = _extract_content(mock_response)
-
-    assert result == "Plain string response"
-
-
 @pytest.mark.asyncio
 async def test_llm_call_with_string_prompt():
-    """Test llm_call with string prompt."""
     mock_llm = AsyncMock()
     mock_response = MagicMock()
     mock_response.content = "LLM response"
     mock_llm.ainvoke.return_value = mock_response
 
-    result = await llm_call(mock_llm, "Test prompt")
+    wrapped = LangChainLLMAdapter(mock_llm)
+    result = await llm_call(wrapped, "Test prompt")
 
-    assert result == "LLM response"
+    assert result.content == "LLM response"
     mock_llm.ainvoke.assert_called_once()
     call_args = mock_llm.ainvoke.call_args
     assert call_args[0][0] == "Test prompt"
@@ -202,16 +188,16 @@ async def test_llm_call_with_string_prompt():
 
 @pytest.mark.asyncio
 async def test_llm_call_with_message_list():
-    """Test llm_call with message list."""
     mock_llm = AsyncMock()
     mock_response = MagicMock()
     mock_response.content = "LLM response"
     mock_llm.ainvoke.return_value = mock_response
 
+    wrapped = LangChainLLMAdapter(mock_llm)
     messages = [{"role": "user", "content": "Hello"}]
-    result = await llm_call(mock_llm, messages)
+    result = await llm_call(wrapped, messages)
 
-    assert result == "LLM response"
+    assert result.content == "LLM response"
     mock_llm.ainvoke.assert_called_once()
     call_args = mock_llm.ainvoke.call_args
     assert len(call_args[0][0]) == 1
@@ -220,23 +206,25 @@ async def test_llm_call_with_message_list():
 
 @pytest.mark.asyncio
 async def test_llm_call_stores_tool_calls():
-    """Test that llm_call stores tool calls from response."""
     mock_llm = AsyncMock()
-    mock_response = MagicMock()
-    mock_response.content = "Response with tools"
-    test_tool_calls = [{"name": "test", "args": {}, "id": "call_test", "type": "tool_call"}]
-    mock_response.tool_calls = test_tool_calls
+    mock_response = AIMessage(
+        content="Response with tools",
+        tool_calls=[{"name": "test", "args": {}, "id": "call_test", "type": "tool_call"}],
+    )
     mock_llm.ainvoke.return_value = mock_response
 
-    result = await llm_call(mock_llm, "Test prompt")
+    wrapped = LangChainLLMAdapter(mock_llm)
+    result = await llm_call(wrapped, "Test prompt")
 
-    assert result == "Response with tools"
-    assert tool_calls_var.get() == test_tool_calls
+    assert result.content == "Response with tools"
+    stored = tool_calls_var.get()
+    assert stored is not None
+    assert len(stored) == 1
+    assert stored[0]["function"]["name"] == "test"
 
 
 @pytest.mark.asyncio
 async def test_llm_call_with_llm_params():
-    """Test that llm_call calls bind() with llm_params."""
     mock_llm = MagicMock()
     mock_bound_llm = AsyncMock()
     mock_response = MagicMock()
@@ -245,47 +233,45 @@ async def test_llm_call_with_llm_params():
     mock_llm.bind = MagicMock(return_value=mock_bound_llm)
     mock_bound_llm.ainvoke.return_value = mock_response
 
+    wrapped = LangChainLLMAdapter(mock_llm)
     llm_params = {"temperature": 0.5, "max_tokens": 100}
-    result = await llm_call(mock_llm, "Test prompt", llm_params=llm_params)
+    result = await llm_call(wrapped, "Test prompt", llm_params=llm_params)
 
-    assert result == "LLM response with params"
+    assert result.content == "LLM response with params"
     mock_llm.bind.assert_called_once_with(**llm_params)
     mock_bound_llm.ainvoke.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_llm_call_with_empty_llm_params():
-    """Test that llm_call doesn't call bind() with empty llm_params (falsy)."""
     mock_llm = AsyncMock()
     mock_response = MagicMock()
     mock_response.content = "LLM response"
     mock_llm.ainvoke.return_value = mock_response
 
-    result = await llm_call(mock_llm, "Test prompt", llm_params={})
+    wrapped = LangChainLLMAdapter(mock_llm)
+    result = await llm_call(wrapped, "Test prompt", llm_params={})
 
-    assert result == "LLM response"
-    mock_llm.bind.assert_not_called()
+    assert result.content == "LLM response"
     mock_llm.ainvoke.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_llm_call_with_none_llm_params():
-    """Test that llm_call works with None llm_params (default behavior)."""
     mock_llm = AsyncMock()
     mock_response = MagicMock()
     mock_response.content = "LLM response no params"
     mock_llm.ainvoke.return_value = mock_response
 
-    result = await llm_call(mock_llm, "Test prompt", llm_params=None)
+    wrapped = LangChainLLMAdapter(mock_llm)
+    result = await llm_call(wrapped, "Test prompt", llm_params=None)
 
-    assert result == "LLM response no params"
-    mock_llm.bind.assert_not_called()
+    assert result.content == "LLM response no params"
     mock_llm.ainvoke.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_llm_call_with_llm_params_temperature_max_tokens():
-    """Test llm_call with specific temperature and max_tokens parameters."""
     mock_llm = MagicMock()
     mock_bound_llm = AsyncMock()
     mock_response = MagicMock()
@@ -294,23 +280,22 @@ async def test_llm_call_with_llm_params_temperature_max_tokens():
     mock_llm.bind = MagicMock(return_value=mock_bound_llm)
     mock_bound_llm.ainvoke.return_value = mock_response
 
+    wrapped = LangChainLLMAdapter(mock_llm)
     llm_params = {"temperature": 0.8, "max_tokens": 50}
-    result = await llm_call(mock_llm, "Test prompt", llm_params=llm_params)
+    result = await llm_call(wrapped, "Test prompt", llm_params=llm_params)
 
-    assert result == "Response with temp and tokens"
+    assert result.content == "Response with temp and tokens"
     mock_llm.bind.assert_called_once_with(temperature=0.8, max_tokens=50)
     mock_bound_llm.ainvoke.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_llm_call_with_none_llm_and_params():
-    """Test that llm_call handles None llm gracefully even with params."""
     with pytest.raises(LLMCallException):
         await llm_call(None, "Test prompt", llm_params={"temperature": 0.5})
 
 
 def test_generation_response_tool_calls_field():
-    """Test that GenerationResponse can store tool calls."""
     test_tool_calls = [{"name": "test_function", "args": {}, "id": "call_test", "type": "tool_call"}]
 
     response = GenerationResponse(response=[{"role": "assistant", "content": "Hello"}], tool_calls=test_tool_calls)

--- a/tests/test_tool_calls_event_extraction.py
+++ b/tests/test_tool_calls_event_extraction.py
@@ -32,7 +32,8 @@ async def validate_tool_parameters(tool_calls, context=None, **kwargs):
     dangerous_patterns = ["eval", "exec", "system", "../", "rm -", "DROP", "DELETE"]
 
     for tool_call in tool_calls:
-        args = tool_call.get("args", {})
+        func = tool_call.get("function", {})
+        args = func.get("arguments", {})
         for param_value in args.values():
             if isinstance(param_value, str):
                 if any(pattern.lower() in param_value.lower() for pattern in dangerous_patterns):
@@ -45,7 +46,7 @@ async def self_check_tool_calls(tool_calls, context=None, **kwargs):
     """Test implementation of tool call validation."""
     tool_calls = tool_calls or (context.get("tool_calls", []) if context else [])
 
-    return all(isinstance(call, dict) and "name" in call and "id" in call for call in tool_calls)
+    return all(isinstance(call, dict) and "function" in call and "id" in call for call in tool_calls)
 
 
 @pytest.mark.asyncio
@@ -143,10 +144,12 @@ async def test_llmrails_extracts_tool_calls_from_events():
 
     test_tool_calls = [
         {
-            "name": "extract_test",
-            "args": {"data": "test"},
             "id": "call_extract",
-            "type": "tool_call",
+            "type": "function",
+            "function": {
+                "name": "extract_test",
+                "arguments": {"data": "test"},
+            },
         }
     ]
 
@@ -158,7 +161,7 @@ async def test_llmrails_extracts_tool_calls_from_events():
 
     assert extracted_tool_calls is not None
     assert len(extracted_tool_calls) == 1
-    assert extracted_tool_calls[0]["name"] == "extract_test"
+    assert extracted_tool_calls[0]["function"]["name"] == "extract_test"
 
 
 @pytest.mark.asyncio
@@ -167,10 +170,12 @@ async def test_tool_rails_cannot_clear_context_variable():
 
     test_tool_calls = [
         {
-            "name": "blocked_tool",
-            "args": {"param": "rm -rf /"},
             "id": "call_blocked",
-            "type": "tool_call",
+            "type": "function",
+            "function": {
+                "name": "blocked_tool",
+                "arguments": {"param": "rm -rf /"},
+            },
         }
     ]
 
@@ -181,7 +186,7 @@ async def test_tool_rails_cannot_clear_context_variable():
 
     assert result is False
     assert tool_calls_var.get() is not None, "Context variable should not be cleared by tool rails"
-    assert tool_calls_var.get()[0]["name"] == "blocked_tool"
+    assert tool_calls_var.get()[0]["function"]["name"] == "blocked_tool"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_output_rails.py
+++ b/tests/test_tool_output_rails.py
@@ -32,7 +32,8 @@ async def validate_tool_parameters(tool_calls, context=None, **kwargs):
     dangerous_patterns = ["eval", "exec", "system", "../", "rm -", "DROP", "DELETE"]
 
     for tool_call in tool_calls:
-        args = tool_call.get("args", {})
+        func = tool_call.get("function", {})
+        args = func.get("arguments", {})
         for param_value in args.values():
             if isinstance(param_value, str):
                 if any(pattern.lower() in param_value.lower() for pattern in dangerous_patterns):
@@ -45,7 +46,7 @@ async def self_check_tool_calls(tool_calls, context=None, **kwargs):
     """Test implementation of tool call validation."""
     tool_calls = tool_calls or (context.get("tool_calls", []) if context else [])
 
-    return all(isinstance(call, dict) and "name" in call and "id" in call for call in tool_calls)
+    return all(isinstance(call, dict) and "function" in call and "id" in call for call in tool_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/test_topic_safety_cache.py
+++ b/tests/test_topic_safety_cache.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nemoguardrails.context import llm_call_info_var, llm_stats_var
+from nemoguardrails.integrations.langchain.llm_adapter import LangChainLLMAdapter
 from nemoguardrails.library.topic_safety.actions import topic_safety_check_input
 from nemoguardrails.llm.cache.lfu import LFUCache
 from nemoguardrails.llm.cache.utils import create_normalized_cache_key
@@ -37,7 +38,7 @@ def mock_task_manager():
 
 @pytest.fixture
 def fake_llm_topic():
-    llm = FakeLLM(responses=["on-topic"])
+    llm = LangChainLLMAdapter(FakeLLM(responses=["on-topic"]))
     return {"test_model": llm}
 
 

--- a/tests/test_topic_safety_internalevent.py
+++ b/tests/test_topic_safety_internalevent.py
@@ -21,6 +21,7 @@ import pytest
 
 from nemoguardrails.colang.v2_x.runtime.flows import InternalEvent
 from nemoguardrails.library.topic_safety.actions import topic_safety_check_input
+from nemoguardrails.types import LLMResponse
 
 
 @pytest.mark.asyncio
@@ -55,7 +56,7 @@ async def test_topic_safety_check_input_with_internal_events():
     llm_task_manager = MockTaskManager()
 
     with patch("nemoguardrails.library.topic_safety.actions.llm_call", new_callable=AsyncMock) as mock_llm_call:
-        mock_llm_call.return_value = "on-topic"
+        mock_llm_call.return_value = LLMResponse(content="on-topic")
 
         # should not raise TypeError: 'InternalEvent' object is not subscriptable
         result = await topic_safety_check_input(


### PR DESCRIPTION
Part of the LangChain decoupling stack:
1. stack-1: canonical types (#1745)
2. stack-2: adapter and framework registry (#1759)
3. **stack-3: pipeline rewrite + caller migration** (this PR)
4. stack-4: rename generate/stream to generate_async/stream_async (#1769)
5. stack-5: remove LangChain imports from core modules (#1770)
6. stack-6: move LangChain implementations into integrations/langchain/ (#1772)
7. stack-7: framework-owned provider registry (#1773)
8. stack-8: framework-agnostic test infrastructure (TODO)

## Summary

Atomic switch from LangChain to the LLMModel protocol. These changes are tightly coupled (you cannot change what the initializer returns without also changing how utils.py calls it unless bridge stacks are introduced which is a mess, and we cannot change the return type without updating all callers), so they land as one PR.

## How to review

This PR is split into 5 scoped commits for easier review. Please review commit-by-commit rather than the full diff:

1. **`rewrite initializer and llmrails for LLMModel protocol`** 
`init_llm_model()` delegates to framework registry, `LLMRails` types `self.llm` as `LLMModel` with legacy wrapping
2. **`rewrite llm_call to use LLMModel.generate/stream`**
   the core pipeline change, removes all LangChain extraction logic
3. **`update integration boundary for canonical tool calls`**
   `tool_calls_to_langchain_format()` at output boundary
4. **`migrate all callers to LLMResponse.content`** 
   mechanical one-line changes across 35 call sites
5. **`restore endpoint URL in LLMCallException via provider_url`** -
   uses `LLMModel.provider_url` instead of inspecting LLM attributes

Individual commits do not pass tests on their own since the changes are interdependent. The PR as a whole passes the full test suite.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced framework abstraction layer enabling support for multiple LLM providers beyond LangChain, with new public APIs: `get_default_framework()`, `register_framework()`, and `set_default_framework()`.

* **Refactor**
  * Replaced LangChain-specific LLM types with unified `LLMModel` interface throughout the codebase. Added `LangChainLLMAdapter` for backward compatibility with existing LangChain implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->