### PR TITLE
feat(iorails): IORails support for streaming output rails

### DIFF
--- a/examples/configs/gs_content_safety/config/config.yml
+++ b/examples/configs/gs_content_safety/config/config.yml
@@ -1,10 +1,10 @@
 models:
   - type: main
-    engine: nim
+    engine: nvidia_ai_endpoints
     model: meta/llama-3.3-70b-instruct
 
   - type: content_safety
-    engine: nim
+    engine: nvidia_ai_endpoints
     model: nvidia/llama-3.1-nemoguard-8b-content-safety
 
 rails:
@@ -16,5 +16,5 @@ rails:
       - content safety check output $model=content_safety
     streaming:
       enabled: True
-      chunk_size: 5
-      context_size: 1
+      chunk_size: 200
+      context_size: 50

--- a/examples/configs/gs_content_safety/config/config.yml
+++ b/examples/configs/gs_content_safety/config/config.yml
@@ -1,10 +1,10 @@
 models:
   - type: main
-    engine: nvidia_ai_endpoints
+    engine: nim
     model: meta/llama-3.3-70b-instruct
 
   - type: content_safety
-    engine: nvidia_ai_endpoints
+    engine: nim
     model: nvidia/llama-3.1-nemoguard-8b-content-safety
 
 rails:
@@ -16,5 +16,5 @@ rails:
       - content safety check output $model=content_safety
     streaming:
       enabled: True
-      chunk_size: 200
-      context_size: 50
+      chunk_size: 5
+      context_size: 1

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -51,6 +51,9 @@ REFUSAL_MESSAGE = "I'm sorry, I can't respond to that."
 # Default concurrency budget for streaming requests (separate from the AsyncWorkQueue for generate_async)
 STREAM_MAX_CONCURRENCY = 256
 
+# Error type used by _generation_task when pushing error JSON into the stream
+_GENERATION_ERROR_TYPE = "generation_error"
+
 
 class IORails:
     """Workflow engine for accelerated Input/Output rails inference."""
@@ -254,7 +257,7 @@ class IORails:
                     exc_info=True,
                 )
                 error_payload = json.dumps(
-                    {"error": {"message": str(e), "type": "generation_error", "code": "generation_failed"}}
+                    {"error": {"message": str(e), "type": _GENERATION_ERROR_TYPE, "code": "generation_failed"}}
                 )
                 await streaming_handler.push_chunk(error_payload)
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
@@ -343,6 +346,17 @@ class IORails:
         async for chunk_batch in buffer_strategy(streaming_handler):
             user_output_chunks = chunk_batch.user_output_chunks
             bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
+
+            # If the batch contains a generation error from _generation_task,
+            # yield it directly and stop — don't feed error JSON through output rails.
+            for chunk in user_output_chunks:
+                try:
+                    parsed = json.loads(chunk)
+                    if isinstance(parsed, dict) and parsed.get("error", {}).get("type") == _GENERATION_ERROR_TYPE:
+                        yield chunk
+                        return
+                except (json.JSONDecodeError, TypeError):
+                    pass
 
             if stream_first:
                 for chunk in user_output_chunks:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -21,9 +21,13 @@ outside this supported set, the standard LLMRails engine should be used instead.
 """
 
 import asyncio
+import json
 import logging
 import time
+from collections.abc import AsyncIterator
+from typing import Optional, Union
 
+from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
@@ -34,12 +38,17 @@ from nemoguardrails.guardrails.guardrails_types import (
 )
 from nemoguardrails.guardrails.model_manager import ModelManager
 from nemoguardrails.guardrails.rails_manager import RailsManager
+from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
+from nemoguardrails.streaming import END_OF_STREAM, StreamingHandler
 
 log = logging.getLogger(__name__)
 
 REFUSAL_MESSAGE = "I'm sorry, I can't respond to that."
+
+# Default concurrency budget for streaming requests (separate from the AsyncWorkQueue for generate_async)
+STREAM_MAX_CONCURRENCY = 256
 
 
 class IORails:
@@ -54,6 +63,9 @@ class IORails:
 
         # Rails Manager is responsible for running rails by making calls to Model Manager
         self.rails_manager = RailsManager(config, self.model_manager)
+
+        # Semaphore for streaming concurrency control / load shedding
+        self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
 
     async def start(self) -> None:
         """Start the IORails engine. Call this during service startup."""
@@ -140,3 +152,177 @@ class IORails:
             elapsed_ms = (time.monotonic() - t0) * 1000
             log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
             reset_request_id(token)
+
+    def _validate_streaming_with_output_rails(self) -> None:
+        """Raise if output rails exist but streaming is not enabled for them."""
+        if len(self.config.rails.output.flows) > 0 and (
+            not self.config.rails.output.streaming or not self.config.rails.output.streaming.enabled
+        ):
+            raise StreamingNotSupportedError(
+                "stream_async() cannot be used when output rails are configured but "
+                "rails.output.streaming.enabled is False. Either set "
+                "rails.output.streaming.enabled to True in your configuration, or use "
+                "generate_async() instead of stream_async()."
+            )
+
+    def stream_async(
+        self,
+        messages: LLMMessages,
+        options: Optional[Union[dict, GenerationOptions]] = None,
+        include_metadata: Optional[bool] = False,
+    ) -> AsyncIterator[Union[str, dict]]:
+        """Stream LLM response tokens with input/output rails applied.
+
+        Returns an async iterator that yields string chunks (or dicts when
+        ``include_metadata=True``).  Input rails run before any tokens are
+        streamed.  If output rails are configured and streaming is enabled,
+        tokens are buffered and checked using the same ``RollingBuffer`` /
+        ``stream_first`` semantics as LLMRails.
+
+        Args:
+            messages: Conversation messages in OpenAI format.
+            options: Optional GenerationOptions (llm_params are forwarded to
+                the main LLM call).
+            include_metadata: When True, chunks are dicts with ``text`` and
+                ``metadata`` keys instead of plain strings.
+
+        Returns:
+            An async iterator of string chunks (or dicts).
+
+        Raises:
+            StreamingNotSupportedError: If output rails are present but
+                ``rails.output.streaming.enabled`` is False.
+            asyncio.QueueFull: If the streaming concurrency limit is
+                reached (load shedding).
+        """
+        self._validate_streaming_with_output_rails()
+
+        # Extract llm_params from GenerationOptions if provided
+        llm_kwargs: dict = {}
+        if options and isinstance(options, GenerationOptions):
+            llm_kwargs = options.llm_params if options.llm_params else {}
+
+        streaming_handler = StreamingHandler(include_metadata=include_metadata)
+
+        async def _generation_task():
+            """Background task: input rails → stream LLM chunks → push to handler.
+
+            Inherits the request ID from the caller context via create_task().
+            """
+            req_id = get_request_id()
+            t0 = time.monotonic()
+            try:
+                log.info("[%s] stream_async generation task started", req_id)
+                log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
+
+                # Step 1: Input rails (non-streaming)
+                log.info("[%s] Running input rails", req_id)
+                input_result = await self.rails_manager.is_input_safe(messages)
+                if not input_result.is_safe:
+                    log.info("[%s] Input blocked: %s", req_id, input_result.reason)
+                    await streaming_handler.push_chunk(REFUSAL_MESSAGE)
+                    await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
+                    return
+
+                # Step 2: Stream main LLM
+                log.info("[%s] Streaming main LLM", req_id)
+                async for chunk in self.model_manager.stream_async("main", messages, **llm_kwargs):
+                    await streaming_handler.push_chunk(chunk)
+
+                await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
+            except Exception as e:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.error(
+                    "[%s] stream_async generation task failed time=%.1fms",
+                    req_id,
+                    elapsed_ms,
+                    exc_info=True,
+                )
+                error_payload = json.dumps(
+                    {"error": {"message": str(e), "type": "generation_error", "code": "generation_failed"}}
+                )
+                await streaming_handler.push_chunk(error_payload)
+                await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
+            finally:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.info("[%s] stream_async time=%.1fms", req_id, elapsed_ms)
+
+        async def _wrapped_iterator():
+            """Wrap the base iterator with semaphore-based concurrency control."""
+            # Try to acquire a streaming slot; raise immediately if saturated
+            if self._stream_semaphore._value <= 0:  # noqa: SLF001
+                raise asyncio.QueueFull("Streaming concurrency limit reached")
+
+            await self._stream_semaphore.acquire()
+            # Set request ID here so both the generation task (via create_task
+            # context copy) and output rails (running in this coroutine) share it.
+            token = set_new_request_id()
+            task = asyncio.create_task(_generation_task())
+            try:
+                # Determine base iterator: with or without output rails
+                output_streaming = self.config.rails.output.streaming
+                if output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0:
+                    base_iterator = self._run_output_rails_in_streaming(
+                        streaming_handler=streaming_handler,
+                        messages=messages,
+                    )
+                else:
+                    base_iterator = streaming_handler
+
+                async for chunk in base_iterator:
+                    if chunk is not None:
+                        yield chunk
+            finally:
+                self._stream_semaphore.release()
+                await task
+                reset_request_id(token)
+
+        return _wrapped_iterator()
+
+    async def _run_output_rails_in_streaming(
+        self,
+        streaming_handler: AsyncIterator[Union[str, dict]],
+        messages: LLMMessages,
+    ) -> AsyncIterator[Union[str, dict]]:
+        """Buffer streamed chunks and run output rails on each batch.
+
+        Uses the same ``RollingBuffer`` and ``stream_first`` semantics as
+        LLMRails:
+        - ``stream_first=True``: yield chunks immediately, then run output
+          rails.  If unsafe, inject an error and stop.
+        - ``stream_first=False``: run output rails first, only yield chunks
+          if safe.
+        """
+
+        # Unpack streaming config and get the buffer strategy
+        output_streaming_config = self.config.rails.output.streaming
+        stream_first = output_streaming_config.stream_first
+        buffer_strategy = get_buffer_strategy(output_streaming_config)
+
+        async for chunk_batch in buffer_strategy(streaming_handler):
+            user_output_chunks = chunk_batch.user_output_chunks
+            bot_response_chunk = buffer_strategy.format_chunks(chunk_batch.processing_context)
+
+            if stream_first:
+                for chunk in user_output_chunks:
+                    yield chunk
+
+            # Run output rails on the accumulated context
+            req_id = get_request_id()
+            log.info("[%s] Running output rails", req_id)
+            output_result = await self.rails_manager.is_output_safe(messages, bot_response_chunk)
+            if not output_result.is_safe:
+                log.info("[%s] Output blocked: %s", req_id, output_result.reason)
+                error_data = {
+                    "error": {
+                        "message": f"Blocked by output rails: {output_result.reason}",
+                        "type": "guardrails_violation",
+                        "code": "content_blocked",
+                    }
+                }
+                yield json.dumps(error_data)
+                return
+
+            if not stream_first:
+                for chunk in user_output_chunks:
+                    yield chunk

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -68,6 +68,12 @@ class IORails:
         # Semaphore for streaming concurrency control / load shedding
         self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
 
+    @property
+    def _has_streaming_output_rails(self) -> bool:
+        """True when output rails are configured and streaming is enabled for them."""
+        streaming = self.config.rails.output.streaming
+        return streaming is not None and streaming.enabled and len(self.config.rails.output.flows) > 0
+
     async def start(self) -> None:
         """Start the IORails engine. Call this during service startup."""
         if self._running:
@@ -128,13 +134,13 @@ class IORails:
                 return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
             # Step 2: Generate response from main LLM
-            # If we got an `options=GenerationOptions`, then unpack GenerationOptions.llm_params and add
-            # that to the main LLM call
             log.info("[%s] Calling main LLM", req_id)
             llm_kwargs = {}
-            if kwargs.get("options") and isinstance(kwargs["options"], GenerationOptions):
-                generation_options = kwargs["options"]
-                llm_kwargs = generation_options.llm_params if generation_options.llm_params else {}
+            options = kwargs.get("options")
+            if options and isinstance(options, dict):
+                options = GenerationOptions(**options)
+            if isinstance(options, GenerationOptions) and options.llm_params:
+                llm_kwargs = options.llm_params
 
             response_text = await self.model_manager.generate_async("main", messages, **llm_kwargs)
             log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
@@ -158,9 +164,7 @@ class IORails:
 
     def _validate_streaming_with_output_rails(self) -> None:
         """Raise if output rails exist but streaming is not enabled for them."""
-        if len(self.config.rails.output.flows) > 0 and (
-            not self.config.rails.output.streaming or not self.config.rails.output.streaming.enabled
-        ):
+        if len(self.config.rails.output.flows) > 0 and not self._has_streaming_output_rails:
             raise StreamingNotSupportedError(
                 "stream_async() cannot be used when output rails are configured but "
                 "rails.output.streaming.enabled is False. Either set "
@@ -202,9 +206,7 @@ class IORails:
         """
         self._validate_streaming_with_output_rails()
 
-        output_streaming = self.config.rails.output.streaming
-        has_output_rails = output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0
-        if include_metadata and has_output_rails:
+        if include_metadata and self._has_streaming_output_rails:
             raise ValueError(
                 "include_metadata=True is not supported when output rails streaming is enabled. "
                 "BufferStrategy requires plain string chunks. Use include_metadata=False or "
@@ -213,8 +215,10 @@ class IORails:
 
         # Extract llm_params from GenerationOptions if provided
         llm_kwargs: dict = {}
-        if options and isinstance(options, GenerationOptions):
-            llm_kwargs = options.llm_params if options.llm_params else {}
+        if options and isinstance(options, dict):
+            options = GenerationOptions(**options)
+        if isinstance(options, GenerationOptions) and options.llm_params:
+            llm_kwargs = options.llm_params
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
 
@@ -281,8 +285,7 @@ class IORails:
                 task = asyncio.create_task(_generation_task())
                 try:
                     # Determine base iterator: with or without output rails
-                    output_streaming = self.config.rails.output.streaming
-                    if output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0:
+                    if self._has_streaming_output_rails:
                         base_iterator = self._run_output_rails_in_streaming(
                             streaming_handler=streaming_handler,
                             messages=messages,

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -25,6 +25,7 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from typing import Optional, Union
 
 from nemoguardrails.exceptions import StreamingNotSupportedError
@@ -192,10 +193,21 @@ class IORails:
         Raises:
             StreamingNotSupportedError: If output rails are present but
                 ``rails.output.streaming.enabled`` is False.
+            ValueError: If ``include_metadata=True`` with output rails
+                streaming enabled (BufferStrategy requires plain string chunks).
             asyncio.QueueFull: If the streaming concurrency limit is
                 reached (load shedding).
         """
         self._validate_streaming_with_output_rails()
+
+        output_streaming = self.config.rails.output.streaming
+        has_output_rails = output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0
+        if include_metadata and has_output_rails:
+            raise ValueError(
+                "include_metadata=True is not supported when output rails streaming is enabled. "
+                "BufferStrategy requires plain string chunks. Use include_metadata=False or "
+                "disable output rails streaming."
+            )
 
         # Extract llm_params from GenerationOptions if provided
         llm_kwargs: dict = {}
@@ -278,9 +290,17 @@ class IORails:
                             yield chunk
                 finally:
                     try:
-                        await task
+                        if not task.done():
+                            task.cancel()
+                        with suppress(asyncio.CancelledError):
+                            await task
                     finally:
-                        reset_request_id(token)
+                        try:
+                            reset_request_id(token)
+                        except ValueError:
+                            # GeneratorExit triggers cleanup in a different context
+                            # where the token is no longer valid — safe to ignore.
+                            pass
             finally:
                 self._stream_semaphore.release()
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -111,6 +111,8 @@ class IORails:
 
     async def generate_async(self, messages: LLMMessages, **kwargs) -> LLMMessage:
         """Run input rails, generation, and output rails. Return response if safe."""
+        await self.start()
+
         token = set_new_request_id()
         req_id = get_request_id()
         t0 = time.monotonic()
@@ -224,9 +226,6 @@ class IORails:
             req_id = get_request_id()
             t0 = time.monotonic()
             try:
-                log.info("[%s] stream_async generation task started", req_id)
-                log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
-
                 # Step 1: Input rails (non-streaming)
                 log.info("[%s] Running input rails", req_id)
                 input_result = await self.rails_manager.is_input_safe(messages)
@@ -245,7 +244,7 @@ class IORails:
             except Exception as e:
                 elapsed_ms = (time.monotonic() - t0) * 1000
                 log.error(
-                    "[%s] stream_async generation task failed time=%.1fms",
+                    "[%s] generation task failed time=%.1fms",
                     req_id,
                     elapsed_ms,
                     exc_info=True,
@@ -257,10 +256,13 @@ class IORails:
                 await streaming_handler.push_chunk(END_OF_STREAM)  # type: ignore[arg-type]
             finally:
                 elapsed_ms = (time.monotonic() - t0) * 1000
-                log.info("[%s] stream_async time=%.1fms", req_id, elapsed_ms)
+                log.info("[%s] generation task completed time=%.1fms", req_id, elapsed_ms)
 
         async def _wrapped_iterator():
             """Wrap the base iterator with semaphore-based concurrency control."""
+            # Ensure engines are running (idempotent if already started).
+            await self.start()
+
             # Non-blocking acquire; raises immediately if all slots are taken.
             # locked() returns True when the semaphore value is 0.  Because there
             # is no await between the check and acquire(), no other coroutine can
@@ -269,10 +271,13 @@ class IORails:
                 raise asyncio.QueueFull("Streaming concurrency limit reached")
             await self._stream_semaphore.acquire()
 
+            token = set_new_request_id()
+            req_id = get_request_id()
+            t0 = time.monotonic()
             try:
-                # Set request ID here so both the generation task (via create_task
-                # context copy) and output rails (running in this coroutine) share it.
-                token = set_new_request_id()
+                log.info("[%s] stream_async called", req_id)
+                log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
+
                 task = asyncio.create_task(_generation_task())
                 try:
                     # Determine base iterator: with or without output rails
@@ -301,7 +306,13 @@ class IORails:
                             # GeneratorExit triggers cleanup in a different context
                             # where the token is no longer valid — safe to ignore.
                             pass
+            except Exception:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+                raise
             finally:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
                 self._stream_semaphore.release()
 
         return _wrapped_iterator()

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -249,33 +249,40 @@ class IORails:
 
         async def _wrapped_iterator():
             """Wrap the base iterator with semaphore-based concurrency control."""
-            # Try to acquire a streaming slot; raise immediately if saturated
-            if self._stream_semaphore._value <= 0:  # noqa: SLF001
+            # Non-blocking acquire; raises immediately if all slots are taken.
+            # locked() returns True when the semaphore value is 0.  Because there
+            # is no await between the check and acquire(), no other coroutine can
+            # interleave in asyncio's cooperative model, so this is race-free.
+            if self._stream_semaphore.locked():
                 raise asyncio.QueueFull("Streaming concurrency limit reached")
-
             await self._stream_semaphore.acquire()
-            # Set request ID here so both the generation task (via create_task
-            # context copy) and output rails (running in this coroutine) share it.
-            token = set_new_request_id()
-            task = asyncio.create_task(_generation_task())
-            try:
-                # Determine base iterator: with or without output rails
-                output_streaming = self.config.rails.output.streaming
-                if output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0:
-                    base_iterator = self._run_output_rails_in_streaming(
-                        streaming_handler=streaming_handler,
-                        messages=messages,
-                    )
-                else:
-                    base_iterator = streaming_handler
 
-                async for chunk in base_iterator:
-                    if chunk is not None:
-                        yield chunk
+            try:
+                # Set request ID here so both the generation task (via create_task
+                # context copy) and output rails (running in this coroutine) share it.
+                token = set_new_request_id()
+                task = asyncio.create_task(_generation_task())
+                try:
+                    # Determine base iterator: with or without output rails
+                    output_streaming = self.config.rails.output.streaming
+                    if output_streaming and output_streaming.enabled and len(self.config.rails.output.flows) > 0:
+                        base_iterator = self._run_output_rails_in_streaming(
+                            streaming_handler=streaming_handler,
+                            messages=messages,
+                        )
+                    else:
+                        base_iterator = streaming_handler
+
+                    async for chunk in base_iterator:
+                        if chunk is not None:
+                            yield chunk
+                finally:
+                    try:
+                        await task
+                    finally:
+                        reset_request_id(token)
             finally:
                 self._stream_semaphore.release()
-                await task
-                reset_request_id(token)
 
         return _wrapped_iterator()
 

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -20,10 +20,12 @@ OpenAI-compatible /v1/chat/completions endpoint via aiohttp.
 Retries are handled by aiohttp-retry (ExponentialRetry).
 """
 
+import json
 import logging
 import os
 import time
-from typing import Any, Optional, cast
+from collections.abc import AsyncIterator
+from typing import Any, NamedTuple, Optional, cast
 
 import aiohttp
 from aiohttp_retry import ExponentialRetry, RetryClient
@@ -47,6 +49,15 @@ _ENGINE_BASE_URLS = {
 }
 
 _CHAT_COMPLETIONS_ENDPOINT = "/v1/chat/completions"
+
+
+class _RequestParams(NamedTuple):
+    """Pre-built parameters for an HTTP request to the completions endpoint."""
+
+    client: RetryClient
+    url: str
+    headers: dict[str, str]
+    body: dict[str, Any]
 
 
 class ModelEngineError(Exception):
@@ -149,6 +160,55 @@ class ModelEngine:
         # If no key is available, assume it's a local model that doesn't need one
         return None
 
+    def _ensure_running(self) -> None:
+        """Raise if the engine has not been started."""
+        if not self._running:
+            raise ModelEngineError(
+                f"ModelEngine for '{self.model_name}' has not been started. Call start() first.",
+                model_name=self.model_name,
+            )
+
+    def _prepare_request(self, messages: LLMMessages, **kwargs: Any) -> _RequestParams:
+        """Build the client, URL, headers, and body common to every request."""
+        client = cast(RetryClient, self._client)
+        url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_ENDPOINT
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        body: dict[str, Any] = {"model": self.model_name, "messages": messages, **kwargs}
+        return _RequestParams(client=client, url=url, headers=headers, body=body)
+
+    async def _raise_for_status(self, response: aiohttp.ClientResponse, req_id: str, t0: float) -> None:
+        """Raise ``ModelEngineError`` if the HTTP status indicates an error."""
+        if response.status >= 400:
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            error_body = await safe_read_body(response)
+            log.warning(
+                "[%s] HTTP %s from model '%s' time=%.1fms",
+                req_id,
+                response.status,
+                self.model_name,
+                elapsed_ms,
+            )
+            raise ModelEngineError(
+                f"HTTP {response.status} from model '{self.model_name}': {error_body}",
+                model_name=self.model_name,
+                status=response.status,
+            )
+
+    def _wrap_exception(self, exc: Exception, req_id: str, t0: float, label: str = "Request") -> ModelEngineError:
+        """Wrap an unexpected exception in a ``ModelEngineError``."""
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        log.warning("[%s] %s to model '%s' failed time=%.1fms", req_id, label, self.model_name, elapsed_ms)
+        return ModelEngineError(
+            f"{label} to model '{self.model_name}' failed: {exc}",
+            model_name=self.model_name,
+        )
+
+    # -- Public request methods ------------------------------------------
+
     async def call(
         self,
         messages: LLMMessages,
@@ -169,48 +229,19 @@ class ModelEngine:
         Raises:
             ModelEngineError: If the request fails after all retries.
         """
-
-        if not self._running:
-            raise ModelEngineError(
-                f"ModelEngine for '{self.model_name}' has not been started. Call start() first.",
-                model_name=self.model_name,
-            )
-
-        # Cast as RetryClient so type-checking knows it isn't None
-        client = cast(RetryClient, self._client)
-
-        url = self.base_url.rstrip("/") + _CHAT_COMPLETIONS_ENDPOINT
-
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-
-        body: dict[str, Any] = {
-            "model": self.model_name,
-            "messages": messages,
-            **kwargs,
-        }
+        self._ensure_running()
+        req = self._prepare_request(messages, **kwargs)
 
         req_id = get_request_id()
-        log.info("[%s] HTTP POST %s model='%s'", req_id, url, self.model_name)
-        log.debug("[%s] HTTP request body: %s", req_id, truncate(body))
+        log.info("[%s] HTTP POST %s model='%s'", req_id, req.url, self.model_name)
+        log.debug("[%s] HTTP request body: %s", req_id, truncate(req.body))
 
         t0 = time.monotonic()
         try:
-            async with client.post(url, json=body, headers=headers) as response:
+            async with req.client.post(req.url, json=req.body, headers=req.headers) as response:
+                await self._raise_for_status(response, req_id, t0)
+
                 elapsed_ms = (time.monotonic() - t0) * 1000
-
-                if response.status >= 400:
-                    error_body = await safe_read_body(response)
-                    log.warning(
-                        "[%s] HTTP %s from model '%s' time=%.1fms", req_id, response.status, self.model_name, elapsed_ms
-                    )
-                    raise ModelEngineError(
-                        f"HTTP {response.status} from model '{self.model_name}': {error_body}",
-                        model_name=self.model_name,
-                        status=response.status,
-                    )
-
                 result = await response.json()
                 log.debug(
                     "[%s] HTTP response status=%s time=%.1fms body: %s",
@@ -224,12 +255,78 @@ class ModelEngine:
         except ModelEngineError:
             raise
         except Exception as exc:
-            elapsed_ms = (time.monotonic() - t0) * 1000
-            log.warning("[%s] Request to model '%s' failed time=%.1fms", req_id, self.model_name, elapsed_ms)
-            raise ModelEngineError(
-                f"Request to model '{self.model_name}' failed: {exc}",
-                model_name=self.model_name,
-            ) from exc
+            raise self._wrap_exception(exc, req_id, t0) from exc
+
+    async def stream_call(
+        self,
+        messages: LLMMessages,
+        **kwargs: Any,
+    ) -> AsyncIterator[str]:
+        """Make a streaming POST request to the /v1/chat/completions endpoint.
+
+        Sends ``stream=True`` and yields content-delta strings as they arrive
+        via SSE.  Retries are handled by the RetryClient (same as ``call()``).
+
+        Args:
+            messages: List of message dicts in OpenAI format.
+            **kwargs: Additional parameters for the request body (temperature, max_tokens, etc.)
+
+        Yields:
+            Content-delta strings from each streamed chunk.
+
+        Raises:
+            ModelEngineError: If the request fails after all retries.
+        """
+        self._ensure_running()
+        req = self._prepare_request(messages, stream=True, **kwargs)
+
+        # For streaming, disable the total timeout (response body streams
+        # for the full generation duration) and use sock_read to detect stalls
+        # between individual SSE chunks.
+        stream_timeout = aiohttp.ClientTimeout(
+            total=None,
+            connect=self._timeout.connect,
+            sock_read=self._timeout.total,
+        )
+
+        req_id = get_request_id()
+        log.info("[%s] HTTP POST (stream) %s model='%s'", req_id, req.url, self.model_name)
+        log.debug("[%s] HTTP request body: %s", req_id, truncate(req.body))
+
+        t0 = time.monotonic()
+        try:
+            async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
+                await self._raise_for_status(response, req_id, t0)
+
+                async for raw_line in response.content:
+                    line = raw_line.decode("utf-8").strip()
+                    if not line:
+                        continue
+                    if not line.startswith("data: "):
+                        continue
+
+                    payload = line[len("data: ") :]
+                    if payload == "[DONE]":
+                        break
+
+                    try:
+                        chunk = json.loads(payload)
+                    except json.JSONDecodeError:
+                        log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
+                        continue
+
+                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    content = delta.get("content")
+                    if content:
+                        yield content
+
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.debug("[%s] Stream completed time=%.1fms", req_id, elapsed_ms)
+
+        except ModelEngineError:
+            raise
+        except Exception as exc:
+            raise self._wrap_exception(exc, req_id, t0, label="Stream request") from exc
 
     async def __aenter__(self):
         """Context manager (used for testing rather than long-lived instance)"""

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -315,7 +315,10 @@ class ModelEngine:
                         log.warning("[%s] Unparseable SSE chunk: %s", req_id, payload[:200])
                         continue
 
-                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    choices = chunk.get("choices") or []
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta") or {}
                     content = delta.get("content")
                     if content:
                         yield content

--- a/nemoguardrails/guardrails/model_engine.py
+++ b/nemoguardrails/guardrails/model_engine.py
@@ -298,7 +298,15 @@ class ModelEngine:
             async with req.client.post(req.url, json=req.body, headers=req.headers, timeout=stream_timeout) as response:
                 await self._raise_for_status(response, req_id, t0)
 
-                async for raw_line in response.content:
+                # Use readline() instead of iterating response.content directly.
+                # response.content uses readany() which returns arbitrary byte
+                # chunks — multiple SSE events in one TCP segment would be merged
+                # into one unparseable blob.  readline() splits on \n correctly.
+                while True:
+                    raw_line = await response.content.readline()
+                    if not raw_line:
+                        break
+
                     line = raw_line.decode("utf-8").strip()
                     if not line:
                         continue

--- a/nemoguardrails/guardrails/model_manager.py
+++ b/nemoguardrails/guardrails/model_manager.py
@@ -20,6 +20,7 @@ Each ModelEngine owns its own RetryClient with per-model settings.
 """
 
 import logging
+from collections.abc import AsyncIterator
 from typing import Any
 
 from nemoguardrails.guardrails.api_engine import APIEngine
@@ -158,6 +159,15 @@ class ModelManager:
 
         log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))
         return result
+
+    async def stream_async(self, model_type: str, messages: list[dict], **kwargs: Any) -> AsyncIterator[str]:
+        """Stream chat completion chunks from the named model engine."""
+        req_id = get_request_id()
+        log.debug("[%s] Model engine '%s' stream messages: %s", req_id, model_type, truncate(messages))
+
+        engine = self._get_model_engine(model_type)
+        async for chunk in engine.stream_call(messages, **kwargs):
+            yield chunk
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         req_id = get_request_id()

--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -151,6 +151,29 @@ class TestGenerateAsync:
         iorails.model_manager.generate_async.assert_called_once_with("main", messages)
         iorails.rails_manager.is_output_safe.assert_called_once_with(messages, llm_response)
 
+    @pytest.mark.asyncio
+    async def test_dict_options_forwarded(self, iorails):
+        """Dict options are converted to GenerationOptions and forwarded."""
+        messages = [{"role": "user", "content": "hi"}]
+        llm_params = {"temperature": 0.01, "max_completion_tokens": 1000}
+
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(return_value="ok")
+        iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+        await iorails.generate_async(messages, options={"llm_params": llm_params})
+
+        iorails.model_manager.generate_async.assert_called_once_with("main", messages, **llm_params)
+
+    @pytest.mark.asyncio
+    async def test_generate_async_propagates_exception(self, iorails):
+        """Exceptions from the LLM call propagate to the caller."""
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.model_manager.generate_async = AsyncMock(side_effect=RuntimeError("LLM internal error"))
+
+        with pytest.raises(RuntimeError, match="LLM internal error"):
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
+
 
 class TestIORailsLifecycle:
     """Test IORails start/stop lifecycle management."""

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -23,7 +23,7 @@ import pytest
 
 from nemoguardrails.exceptions import StreamingNotSupportedError
 from nemoguardrails.guardrails.guardrails_types import RailResult
-from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, STREAM_MAX_CONCURRENCY, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from nemoguardrails.rails.llm.options import GenerationOptions
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
@@ -126,6 +126,23 @@ class TestStreamAsyncValidation:
     async def test_no_error_when_streaming_enabled(self, iorails_stream_first):
         _wire_mocks(iorails_stream_first)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert len(chunks) > 0
+
+    def test_raises_when_include_metadata_with_output_rails_streaming(self, iorails_stream_first):
+        """include_metadata=True is rejected when output rails streaming is enabled."""
+        with pytest.raises(ValueError, match="include_metadata=True is not supported"):
+            iorails_stream_first.stream_async(
+                messages=[{"role": "user", "content": "hi"}],
+                include_metadata=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_include_metadata_allowed_without_output_rails(self, iorails_input_only):
+        """include_metadata=True is fine when there are no output rails."""
+        _wire_mocks(iorails_input_only)
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], include_metadata=True)
+        )
         assert len(chunks) > 0
 
 
@@ -287,3 +304,27 @@ class TestStreamAsyncConcurrency:
 
         await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
         assert iorails_input_only._stream_semaphore._value == 1
+
+    @pytest.mark.asyncio
+    async def test_background_task_cancelled_on_early_exit(self, iorails_input_only):
+        """When the consumer breaks early, the background generation task is cancelled."""
+        task_started = asyncio.Event()
+
+        async def slow_stream(model_type, messages, **kwargs):
+            task_started.set()
+            for i in range(1000):
+                yield f"chunk{i}"
+                await asyncio.sleep(0)  # yield control so cancellation can propagate
+
+        _wire_mocks(iorails_input_only, stream=slow_stream)
+
+        async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]):
+            if task_started.is_set():
+                break  # consumer exits early
+
+        # Give the event loop a few ticks to process cancellation and cleanup
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        # Semaphore should be released even after early exit
+        assert iorails_input_only._stream_semaphore._value == STREAM_MAX_CONCURRENCY

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -113,17 +113,20 @@ class TestStreamAsyncValidation:
     """Test that stream_async raises when output rails exist but streaming is disabled."""
 
     def test_raises_when_output_rails_without_streaming(self, iorails):
+        """Raises StreamingNotSupportedError when output rails exist but streaming is disabled."""
         with pytest.raises(StreamingNotSupportedError):
             iorails.stream_async(messages=[{"role": "user", "content": "hi"}])
 
     @pytest.mark.asyncio
     async def test_no_error_when_no_output_rails(self, iorails_input_only):
+        """Succeeds when there are no output rails at all."""
         _wire_mocks(iorails_input_only)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
         assert len(chunks) > 0
 
     @pytest.mark.asyncio
     async def test_no_error_when_streaming_enabled(self, iorails_stream_first):
+        """Succeeds when output rails have streaming enabled."""
         _wire_mocks(iorails_stream_first)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
         assert len(chunks) > 0
@@ -151,21 +154,25 @@ class TestStreamAsyncNoOutputRails:
 
     @pytest.mark.asyncio
     async def test_streams_all_chunks(self, iorails_input_only):
+        """All LLM chunks are yielded to the caller."""
         _wire_mocks(iorails_input_only)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
         assert "".join(chunks) == "Hello from the streaming LLM! Have a nice day"
 
     @pytest.mark.asyncio
     async def test_input_rails_block(self, iorails_input_only):
+        """Yields the refusal message when input rails block."""
         _wire_mocks(iorails_input_only, input_safe=False)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "bad"}]))
         assert "".join(chunks) == REFUSAL_MESSAGE
 
     @pytest.mark.asyncio
     async def test_generation_options_forwarded(self, iorails_input_only):
+        """llm_params from GenerationOptions are forwarded to the LLM call."""
         captured_kwargs = {}
 
         async def capturing_stream(model_type, messages, **kwargs):
+            """Mock stream that records kwargs."""
             captured_kwargs.update(kwargs)
             yield "ok"
 
@@ -186,6 +193,7 @@ class TestStreamAsyncOutputRailsStreamFirst:
 
     @pytest.mark.asyncio
     async def test_safe_output_streams_all(self, iorails_stream_first):
+        """All chunks are streamed when output rails pass."""
         _wire_mocks(iorails_stream_first)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
         text = "".join(c for c in chunks if not c.startswith("{"))
@@ -193,6 +201,7 @@ class TestStreamAsyncOutputRailsStreamFirst:
 
     @pytest.mark.asyncio
     async def test_unsafe_output_injects_error(self, iorails_stream_first):
+        """Error JSON is injected into the stream when output rails block."""
         _wire_mocks(iorails_stream_first, output_safe=False)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
@@ -204,9 +213,11 @@ class TestStreamAsyncOutputRailsStreamFirst:
 
     @pytest.mark.asyncio
     async def test_stream_first_yields_before_rail_check(self, iorails_stream_first):
+        """Chunks appear before the output rail check in stream_first mode."""
         yield_order = []
 
         async def tracking_rail(messages, response):
+            """Mock output rail that records call order."""
             yield_order.append("rail_check")
             return RailResult(is_safe=True)
 
@@ -230,6 +241,7 @@ class TestStreamAsyncOutputRailsGated:
 
     @pytest.mark.asyncio
     async def test_safe_output_streams_all(self, iorails_stream_check_first):
+        """All chunks are eventually yielded when output rails pass."""
         _wire_mocks(iorails_stream_check_first)
         chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
         text = "".join(c for c in chunks if not c.startswith("{"))
@@ -237,6 +249,7 @@ class TestStreamAsyncOutputRailsGated:
 
     @pytest.mark.asyncio
     async def test_unsafe_output_yields_nothing_then_error(self, iorails_stream_check_first):
+        """No content chunks appear before the error in gated mode."""
         _wire_mocks(iorails_stream_check_first, output_safe=False)
         chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
@@ -248,9 +261,11 @@ class TestStreamAsyncOutputRailsGated:
 
     @pytest.mark.asyncio
     async def test_gated_yields_after_rail_check(self, iorails_stream_check_first):
+        """Each chunk batch only appears after its rail check passes."""
         yield_order = []
 
         async def tracking_rail(messages, response):
+            """Mock output rail that records call order."""
             yield_order.append("rail_check")
             return RailResult(is_safe=True)
 
@@ -271,7 +286,10 @@ class TestStreamAsyncErrors:
 
     @pytest.mark.asyncio
     async def test_generation_error_yields_error_json(self, iorails_input_only):
+        """LLM exceptions are surfaced as error JSON chunks."""
+
         async def failing_stream(model_type, messages, **kwargs):
+            """Mock stream that raises immediately."""
             raise RuntimeError("LLM exploded")
             yield  # noqa: unreachable -- makes this an async generator
 
@@ -290,6 +308,7 @@ class TestStreamAsyncConcurrency:
 
     @pytest.mark.asyncio
     async def test_semaphore_exhaustion_raises(self, iorails_input_only):
+        """Raises QueueFull when all streaming slots are taken."""
         _wire_mocks(iorails_input_only)
         iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
 
@@ -299,6 +318,7 @@ class TestStreamAsyncConcurrency:
 
     @pytest.mark.asyncio
     async def test_semaphore_released_after_stream(self, iorails_input_only):
+        """Semaphore slot is released after the stream is fully consumed."""
         _wire_mocks(iorails_input_only)
         iorails_input_only._stream_semaphore = asyncio.Semaphore(1)
 
@@ -311,6 +331,7 @@ class TestStreamAsyncConcurrency:
         task_started = asyncio.Event()
 
         async def slow_stream(model_type, messages, **kwargs):
+            """Mock stream that yields many chunks to allow early exit testing."""
             task_started.set()
             for i in range(1000):
                 yield f"chunk{i}"

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for IORails streaming support."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from nemoguardrails.exceptions import StreamingNotSupportedError
+from nemoguardrails.guardrails.guardrails_types import RailResult
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.rails.llm.options import GenerationOptions
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+# --- Helpers / factories ------------------------------------------------
+
+
+def _make_streaming_config(*, enabled: bool = True, stream_first: bool = True) -> dict:
+    """Build a NEMOGUARDS_CONFIG variant with output-rail streaming settings."""
+    return {
+        **NEMOGUARDS_CONFIG,
+        "rails": {
+            **NEMOGUARDS_CONFIG["rails"],
+            "output": {
+                **NEMOGUARDS_CONFIG["rails"]["output"],
+                "streaming": {
+                    "enabled": enabled,
+                    "chunk_size": 5,
+                    "context_size": 2,
+                    "stream_first": stream_first,
+                },
+            },
+        },
+    }
+
+
+_INPUT_ONLY_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {
+        **NEMOGUARDS_CONFIG["rails"],
+        "output": {"flows": []},
+    },
+}
+
+
+async def _mock_stream(model_type, messages, **kwargs):
+    """Async generator simulating streaming chunks from the main LLM."""
+    for chunk in ["Hello", " from", " the", " streaming", " LLM", "!", " Have", " a", " nice", " day"]:
+        yield chunk
+
+
+async def _collect(async_iter):
+    """Collect all chunks from an async iterator into a list."""
+    return [chunk async for chunk in async_iter]
+
+
+def _wire_mocks(iorails, *, input_safe=True, output_safe=True, stream=_mock_stream):
+    """Attach standard mocks for input rails, output rails, and LLM streaming."""
+    iorails.rails_manager.is_input_safe = AsyncMock(
+        return_value=RailResult(is_safe=input_safe, reason=None if input_safe else "blocked")
+    )
+    iorails.rails_manager.is_output_safe = AsyncMock(
+        return_value=RailResult(is_safe=output_safe, reason=None if output_safe else "blocked")
+    )
+    iorails.model_manager.stream_async = stream
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails():
+    """IORails with output rails but streaming NOT enabled."""
+    return IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_stream_first():
+    """IORails with output rails and streaming enabled (stream_first=True)."""
+    return IORails(RailsConfig.from_content(config=_make_streaming_config(stream_first=True)))
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_stream_check_first():
+    """IORails with output rails and streaming enabled (stream_first=False)."""
+    return IORails(RailsConfig.from_content(config=_make_streaming_config(stream_first=False)))
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_input_only():
+    """IORails with input rails only, no output rails."""
+    return IORails(RailsConfig.from_content(config=_INPUT_ONLY_CONFIG))
+
+
+class TestStreamAsyncValidation:
+    """Test that stream_async raises when output rails exist but streaming is disabled."""
+
+    def test_raises_when_output_rails_without_streaming(self, iorails):
+        with pytest.raises(StreamingNotSupportedError):
+            iorails.stream_async(messages=[{"role": "user", "content": "hi"}])
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_no_output_rails(self, iorails_input_only):
+        _wire_mocks(iorails_input_only)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert len(chunks) > 0
+
+    @pytest.mark.asyncio
+    async def test_no_error_when_streaming_enabled(self, iorails_stream_first):
+        _wire_mocks(iorails_stream_first)
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert len(chunks) > 0
+
+
+class TestStreamAsyncNoOutputRails:
+    """Test streaming when there are no output rails -- chunks flow straight through."""
+
+    @pytest.mark.asyncio
+    async def test_streams_all_chunks(self, iorails_input_only):
+        _wire_mocks(iorails_input_only)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert "".join(chunks) == "Hello from the streaming LLM! Have a nice day"
+
+    @pytest.mark.asyncio
+    async def test_input_rails_block(self, iorails_input_only):
+        _wire_mocks(iorails_input_only, input_safe=False)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "bad"}]))
+        assert "".join(chunks) == REFUSAL_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_generation_options_forwarded(self, iorails_input_only):
+        captured_kwargs = {}
+
+        async def capturing_stream(model_type, messages, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield "ok"
+
+        _wire_mocks(iorails_input_only, stream=capturing_stream)
+        options = GenerationOptions(llm_params={"temperature": 0.42})
+        chunks = await _collect(
+            iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}], options=options)
+        )
+        assert "".join(chunks) == "ok"
+        assert captured_kwargs.get("temperature") == 0.42
+
+
+# --- Tests: Output rails with stream_first=True -------------------------
+
+
+class TestStreamAsyncOutputRailsStreamFirst:
+    """Test streaming with output rails in stream_first=True mode (optimistic)."""
+
+    @pytest.mark.asyncio
+    async def test_safe_output_streams_all(self, iorails_stream_first):
+        _wire_mocks(iorails_stream_first)
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        text = "".join(c for c in chunks if not c.startswith("{"))
+        assert "Hello from the streaming LLM" in text
+
+    @pytest.mark.asyncio
+    async def test_unsafe_output_injects_error(self, iorails_stream_first):
+        _wire_mocks(iorails_stream_first, output_safe=False)
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(error_chunks) >= 1
+        error_data = json.loads(error_chunks[0])
+        assert error_data["error"]["type"] == "guardrails_violation"
+        assert error_data["error"]["code"] == "content_blocked"
+
+    @pytest.mark.asyncio
+    async def test_stream_first_yields_before_rail_check(self, iorails_stream_first):
+        yield_order = []
+
+        async def tracking_rail(messages, response):
+            yield_order.append("rail_check")
+            return RailResult(is_safe=True)
+
+        _wire_mocks(iorails_stream_first)
+        iorails_stream_first.rails_manager.is_output_safe = tracking_rail
+
+        async for chunk in iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]):
+            if not chunk.startswith("{"):
+                yield_order.append(f"chunk:{chunk}")
+
+        first_chunk_idx = next(i for i, v in enumerate(yield_order) if v.startswith("chunk:"))
+        first_rail_idx = next(i for i, v in enumerate(yield_order) if v == "rail_check")
+        assert first_chunk_idx < first_rail_idx
+
+
+# --- Tests: Output rails with stream_first=False ------------------------
+
+
+class TestStreamAsyncOutputRailsGated:
+    """Test streaming with output rails in stream_first=False mode (gated)."""
+
+    @pytest.mark.asyncio
+    async def test_safe_output_streams_all(self, iorails_stream_check_first):
+        _wire_mocks(iorails_stream_check_first)
+        chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        text = "".join(c for c in chunks if not c.startswith("{"))
+        assert "Hello from the streaming LLM" in text
+
+    @pytest.mark.asyncio
+    async def test_unsafe_output_yields_nothing_then_error(self, iorails_stream_check_first):
+        _wire_mocks(iorails_stream_check_first, output_safe=False)
+        chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        content_chunks = [c for c in chunks if isinstance(c, str) and not c.startswith("{")]
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(content_chunks) == 0
+        assert len(error_chunks) >= 1
+        assert json.loads(error_chunks[0])["error"]["code"] == "content_blocked"
+
+    @pytest.mark.asyncio
+    async def test_gated_yields_after_rail_check(self, iorails_stream_check_first):
+        yield_order = []
+
+        async def tracking_rail(messages, response):
+            yield_order.append("rail_check")
+            return RailResult(is_safe=True)
+
+        _wire_mocks(iorails_stream_check_first)
+        iorails_stream_check_first.rails_manager.is_output_safe = tracking_rail
+
+        async for chunk in iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]):
+            if not chunk.startswith("{"):
+                yield_order.append(f"chunk:{chunk}")
+
+        assert len([v for v in yield_order if v == "rail_check"]) > 0
+        assert len([v for v in yield_order if v.startswith("chunk:")]) > 0
+        assert yield_order[0] == "rail_check"
+
+
+class TestStreamAsyncErrors:
+    """Test error propagation during streaming."""
+
+    @pytest.mark.asyncio
+    async def test_generation_error_yields_error_json(self, iorails_input_only):
+        async def failing_stream(model_type, messages, **kwargs):
+            raise RuntimeError("LLM exploded")
+            yield  # noqa: unreachable -- makes this an async generator
+
+        _wire_mocks(iorails_input_only, stream=failing_stream)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(error_chunks) >= 1
+        error_data = json.loads(error_chunks[0])
+        assert error_data["error"]["code"] == "generation_failed"
+        assert "LLM exploded" in error_data["error"]["message"]
+
+
+class TestStreamAsyncConcurrency:
+    """Test the streaming semaphore for concurrency control."""
+
+    @pytest.mark.asyncio
+    async def test_semaphore_exhaustion_raises(self, iorails_input_only):
+        _wire_mocks(iorails_input_only)
+        iorails_input_only._stream_semaphore = asyncio.Semaphore(0)
+
+        with pytest.raises(asyncio.QueueFull, match="Streaming concurrency limit reached"):
+            async for _ in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_semaphore_released_after_stream(self, iorails_input_only):
+        _wire_mocks(iorails_input_only)
+        iorails_input_only._stream_semaphore = asyncio.Semaphore(1)
+
+        await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        assert iorails_input_only._stream_semaphore._value == 1

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -354,9 +354,33 @@ class TestStreamAsyncErrors:
 
     @pytest.mark.asyncio
     async def test_mid_stream_failure_with_output_rails(self, iorails_stream_first):
-        """Mid-stream failure with output rails active still surfaces the error."""
+        """Mid-stream failure with output rails active still surfaces the error (stream_first)."""
         _wire_mocks(iorails_stream_first, stream=_mid_stream_failure)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="connection lost")
+
+    @pytest.mark.asyncio
+    async def test_generation_error_bypasses_output_rails_gated(self, iorails_stream_check_first):
+        """In stream_first=False, generation errors bypass output rails instead of being checked."""
+        _wire_mocks(iorails_stream_check_first, stream=_failing_stream)
+        # Output rail would block if the error JSON were fed through it
+        iorails_stream_check_first.rails_manager.is_output_safe = AsyncMock(
+            return_value=RailResult(is_safe=False, reason="blocked")
+        )
+
+        chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        # Should see generation_failed, NOT content_blocked
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="LLM exploded")
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_error_bypasses_output_rails_gated(self, iorails_stream_check_first):
+        """In stream_first=False, mid-stream errors bypass output rails."""
+        _wire_mocks(iorails_stream_check_first, stream=_mid_stream_failure)
+
+        chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        # The error chunk should come through as generation_failed
         _assert_error_chunk(chunks, code="generation_failed", message_contains="connection lost")
 
 

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -184,6 +184,26 @@ class TestStreamAsyncNoOutputRails:
         assert "".join(chunks) == "ok"
         assert captured_kwargs.get("temperature") == 0.42
 
+    @pytest.mark.asyncio
+    async def test_dict_options_forwarded(self, iorails_input_only):
+        """Dict options are converted to GenerationOptions and forwarded."""
+        captured_kwargs = {}
+
+        async def capturing_stream(model_type, messages, **kwargs):
+            """Mock stream that records kwargs."""
+            captured_kwargs.update(kwargs)
+            yield "ok"
+
+        _wire_mocks(iorails_input_only, stream=capturing_stream)
+        chunks = await _collect(
+            iorails_input_only.stream_async(
+                messages=[{"role": "user", "content": "hi"}],
+                options={"llm_params": {"temperature": 0.42}},
+            )
+        )
+        assert "".join(chunks) == "ok"
+        assert captured_kwargs.get("temperature") == 0.42
+
 
 # --- Tests: Output rails with stream_first=True -------------------------
 
@@ -301,6 +321,73 @@ class TestStreamAsyncErrors:
         error_data = json.loads(error_chunks[0])
         assert error_data["error"]["code"] == "generation_failed"
         assert "LLM exploded" in error_data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_generation_error_with_output_rails(self, iorails_stream_first):
+        """LLM exceptions propagate as error JSON even with output rails active."""
+
+        async def failing_stream(model_type, messages, **kwargs):
+            """Mock stream that raises immediately."""
+            raise RuntimeError("LLM exploded")
+            yield  # noqa: unreachable -- makes this an async generator
+
+        _wire_mocks(iorails_stream_first, stream=failing_stream)
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(error_chunks) >= 1
+        error_data = json.loads(error_chunks[0])
+        assert error_data["error"]["code"] == "generation_failed"
+        assert "LLM exploded" in error_data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_output_rail_exception_propagates(self, iorails_stream_first):
+        """Exception in is_output_safe propagates out of the stream."""
+        _wire_mocks(iorails_stream_first)
+        iorails_stream_first.rails_manager.is_output_safe = AsyncMock(side_effect=RuntimeError("rail crashed"))
+
+        with pytest.raises(RuntimeError, match="rail crashed"):
+            await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_failure_yields_partial_then_error(self, iorails_input_only):
+        """A failure after some successful chunks yields partial output then error JSON."""
+
+        async def mid_stream_failure(model_type, messages, **kwargs):
+            """Mock stream that yields some chunks then raises."""
+            yield "Hello"
+            yield " world"
+            raise RuntimeError("connection lost")
+
+        _wire_mocks(iorails_input_only, stream=mid_stream_failure)
+        chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        content_chunks = [c for c in chunks if not c.startswith("{")]
+        error_chunks = [c for c in chunks if c.startswith("{")]
+
+        assert "".join(content_chunks) == "Hello world"
+        assert len(error_chunks) == 1
+        error_data = json.loads(error_chunks[0])
+        assert error_data["error"]["code"] == "generation_failed"
+        assert "connection lost" in error_data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_failure_with_output_rails(self, iorails_stream_first):
+        """Mid-stream failure with output rails active still surfaces the error."""
+
+        async def mid_stream_failure(model_type, messages, **kwargs):
+            """Mock stream that yields some chunks then raises."""
+            yield "Hello"
+            yield " world"
+            raise RuntimeError("connection lost")
+
+        _wire_mocks(iorails_stream_first, stream=mid_stream_failure)
+        chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
+
+        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+        assert len(error_chunks) >= 1
+        error_data = json.loads(error_chunks[0])
+        assert "connection lost" in error_data["error"]["message"]
 
 
 class TestStreamAsyncConcurrency:

--- a/tests/guardrails/test_iorails_streaming.py
+++ b/tests/guardrails/test_iorails_streaming.py
@@ -70,6 +70,28 @@ async def _collect(async_iter):
     return [chunk async for chunk in async_iter]
 
 
+async def _failing_stream(model_type, messages, **kwargs):
+    """Mock stream that raises immediately."""
+    raise RuntimeError("LLM exploded")
+    yield  # noqa: unreachable -- makes this an async generator
+
+
+async def _mid_stream_failure(model_type, messages, **kwargs):
+    """Mock stream that yields some chunks then raises."""
+    yield "Hello"
+    yield " world"
+    raise RuntimeError("connection lost")
+
+
+def _assert_error_chunk(chunks, *, code, message_contains):
+    """Assert that chunks contain exactly one error JSON with the given code and message substring."""
+    error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
+    assert len(error_chunks) >= 1, f"Expected error chunk, got none in {chunks}"
+    error_data = json.loads(error_chunks[0])
+    assert error_data["error"]["code"] == code
+    assert message_contains in error_data["error"]["message"]
+
+
 def _wire_mocks(iorails, *, input_safe=True, output_safe=True, stream=_mock_stream):
     """Attach standard mocks for input rails, output rails, and LLM streaming."""
     iorails.rails_manager.is_input_safe = AsyncMock(
@@ -224,12 +246,7 @@ class TestStreamAsyncOutputRailsStreamFirst:
         """Error JSON is injected into the stream when output rails block."""
         _wire_mocks(iorails_stream_first, output_safe=False)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
-
-        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
-        assert len(error_chunks) >= 1
-        error_data = json.loads(error_chunks[0])
-        assert error_data["error"]["type"] == "guardrails_violation"
-        assert error_data["error"]["code"] == "content_blocked"
+        _assert_error_chunk(chunks, code="content_blocked", message_contains="Blocked by output rails")
 
     @pytest.mark.asyncio
     async def test_stream_first_yields_before_rail_check(self, iorails_stream_first):
@@ -274,10 +291,8 @@ class TestStreamAsyncOutputRailsGated:
         chunks = await _collect(iorails_stream_check_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         content_chunks = [c for c in chunks if isinstance(c, str) and not c.startswith("{")]
-        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
         assert len(content_chunks) == 0
-        assert len(error_chunks) >= 1
-        assert json.loads(error_chunks[0])["error"]["code"] == "content_blocked"
+        _assert_error_chunk(chunks, code="content_blocked", message_contains="Blocked by output rails")
 
     @pytest.mark.asyncio
     async def test_gated_yields_after_rail_check(self, iorails_stream_check_first):
@@ -307,38 +322,16 @@ class TestStreamAsyncErrors:
     @pytest.mark.asyncio
     async def test_generation_error_yields_error_json(self, iorails_input_only):
         """LLM exceptions are surfaced as error JSON chunks."""
-
-        async def failing_stream(model_type, messages, **kwargs):
-            """Mock stream that raises immediately."""
-            raise RuntimeError("LLM exploded")
-            yield  # noqa: unreachable -- makes this an async generator
-
-        _wire_mocks(iorails_input_only, stream=failing_stream)
+        _wire_mocks(iorails_input_only, stream=_failing_stream)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
-
-        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
-        assert len(error_chunks) >= 1
-        error_data = json.loads(error_chunks[0])
-        assert error_data["error"]["code"] == "generation_failed"
-        assert "LLM exploded" in error_data["error"]["message"]
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="LLM exploded")
 
     @pytest.mark.asyncio
     async def test_generation_error_with_output_rails(self, iorails_stream_first):
         """LLM exceptions propagate as error JSON even with output rails active."""
-
-        async def failing_stream(model_type, messages, **kwargs):
-            """Mock stream that raises immediately."""
-            raise RuntimeError("LLM exploded")
-            yield  # noqa: unreachable -- makes this an async generator
-
-        _wire_mocks(iorails_stream_first, stream=failing_stream)
+        _wire_mocks(iorails_stream_first, stream=_failing_stream)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
-
-        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
-        assert len(error_chunks) >= 1
-        error_data = json.loads(error_chunks[0])
-        assert error_data["error"]["code"] == "generation_failed"
-        assert "LLM exploded" in error_data["error"]["message"]
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="LLM exploded")
 
     @pytest.mark.asyncio
     async def test_output_rail_exception_propagates(self, iorails_stream_first):
@@ -352,42 +345,19 @@ class TestStreamAsyncErrors:
     @pytest.mark.asyncio
     async def test_mid_stream_failure_yields_partial_then_error(self, iorails_input_only):
         """A failure after some successful chunks yields partial output then error JSON."""
-
-        async def mid_stream_failure(model_type, messages, **kwargs):
-            """Mock stream that yields some chunks then raises."""
-            yield "Hello"
-            yield " world"
-            raise RuntimeError("connection lost")
-
-        _wire_mocks(iorails_input_only, stream=mid_stream_failure)
+        _wire_mocks(iorails_input_only, stream=_mid_stream_failure)
         chunks = await _collect(iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}]))
 
         content_chunks = [c for c in chunks if not c.startswith("{")]
-        error_chunks = [c for c in chunks if c.startswith("{")]
-
         assert "".join(content_chunks) == "Hello world"
-        assert len(error_chunks) == 1
-        error_data = json.loads(error_chunks[0])
-        assert error_data["error"]["code"] == "generation_failed"
-        assert "connection lost" in error_data["error"]["message"]
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="connection lost")
 
     @pytest.mark.asyncio
     async def test_mid_stream_failure_with_output_rails(self, iorails_stream_first):
         """Mid-stream failure with output rails active still surfaces the error."""
-
-        async def mid_stream_failure(model_type, messages, **kwargs):
-            """Mock stream that yields some chunks then raises."""
-            yield "Hello"
-            yield " world"
-            raise RuntimeError("connection lost")
-
-        _wire_mocks(iorails_stream_first, stream=mid_stream_failure)
+        _wire_mocks(iorails_stream_first, stream=_mid_stream_failure)
         chunks = await _collect(iorails_stream_first.stream_async(messages=[{"role": "user", "content": "hi"}]))
-
-        error_chunks = [c for c in chunks if isinstance(c, str) and c.startswith("{")]
-        assert len(error_chunks) >= 1
-        error_data = json.loads(error_chunks[0])
-        assert "connection lost" in error_data["error"]["message"]
+        _assert_error_chunk(chunks, code="generation_failed", message_contains="connection lost")
 
 
 class TestStreamAsyncConcurrency:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -562,6 +562,71 @@ class TestModelEngineStreamCall:
 
         assert chunks == ["Hello"]
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_skips_empty_and_non_data_lines(self):
+        """Empty lines and non-'data:' lines (e.g. comments, event types) are skipped."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b"\n",  # empty line
+            b": keepalive\n",  # SSE comment
+            b"event: ping\n",  # non-data event line
+            b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["ok"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_skips_unparseable_json(self):
+        """Malformed JSON in an SSE data line is logged and skipped."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b"data: {not valid json}\n\n",
+            b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["ok"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_unexpected_exception_wraps_in_model_engine_error(self):
+        """Non-HTTP exceptions during streaming are wrapped in ModelEngineError."""
+        engine = ModelEngine(_make_model())
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(side_effect=RuntimeError("connection dropped"))
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError, match="connection dropped"):
+            async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+                pass
+
 
 class TestModelEngineConstants:
     """Test values of model-engine-specific constants."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -412,6 +412,7 @@ class TestModelEngineStreamCall:
         """Create a mock aiohttp response that yields raw_lines from response.content."""
 
         async def _content_iter():
+            """Async generator yielding raw SSE byte lines."""
             for line in raw_lines:
                 yield line
 

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -627,6 +627,30 @@ class TestModelEngineStreamCall:
             async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
                 pass
 
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_skips_empty_choices(self):
+        """SSE events with choices: [] (e.g. include_usage) are skipped without IndexError."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = [
+            b'data: {"choices": []}\n\n',
+            b'data: {"choices": [{"delta": {"content": "ok"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["ok"]
+
 
 class TestModelEngineConstants:
     """Test values of model-engine-specific constants."""

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -15,8 +15,10 @@
 
 """Unit tests for model_engine module."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from nemoguardrails.guardrails._http import (
@@ -390,6 +392,175 @@ class TestModelEngineCall:
 
         with pytest.raises(ModelEngineError, match="has not been started"):
             await engine.call([{"role": "user", "content": "Hi"}])
+
+
+class TestModelEngineStreamCall:
+    """Test ModelEngine.stream_call() SSE streaming."""
+
+    @staticmethod
+    def _make_sse_content(chunks):
+        """Build raw SSE byte lines from a list of content strings."""
+        lines = []
+        for text in chunks:
+            payload = json.dumps({"choices": [{"delta": {"content": text}}]})
+            lines.append(f"data: {payload}\n\n".encode())
+        lines.append(b"data: [DONE]\n\n")
+        return lines
+
+    @staticmethod
+    def _mock_streaming_response(raw_lines, status=200):
+        """Create a mock aiohttp response that yields raw_lines from response.content."""
+
+        async def _content_iter():
+            for line in raw_lines:
+                yield line
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = status
+        mock_response.content = _content_iter()
+        return mock_response
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_yields_content_chunks(self):
+        """stream_call() yields content deltas from SSE lines."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["Hello", " world", "!"])
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello", " world", "!"]
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_sends_stream_true(self):
+        """stream_call() includes stream=True in the request body."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["ok"])
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            pass
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["stream"] is True
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_forwards_kwargs(self):
+        """Extra kwargs (temperature, etc.) are included in the request body."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["ok"])
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}], temperature=0.5):
+            pass
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["temperature"] == 0.5
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_http_error(self):
+        """stream_call() raises ModelEngineError on HTTP 4xx/5xx."""
+        engine = ModelEngine(_make_model())
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="internal error")
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        with pytest.raises(ModelEngineError) as exc_info:
+            async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+                pass
+
+        assert exc_info.value.status == 500
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_raises_if_not_started(self):
+        """stream_call() raises ModelEngineError if start() hasn't been called."""
+        engine = ModelEngine(_make_model())
+
+        with pytest.raises(ModelEngineError, match="has not been started"):
+            async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+                pass
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_uses_streaming_timeout(self):
+        """stream_call() overrides total timeout to None and sets sock_read."""
+        engine = ModelEngine(_make_model())
+
+        raw_lines = self._make_sse_content(["ok"])
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        async for _ in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            pass
+
+        call_kwargs = mock_client.post.call_args[1]
+        timeout = call_kwargs["timeout"]
+        assert isinstance(timeout, aiohttp.ClientTimeout)
+        assert timeout.total is None
+        assert timeout.connect == engine._timeout.connect
+        assert timeout.sock_read == engine._timeout.total
+
+    @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+    @pytest.mark.asyncio
+    async def test_stream_call_skips_empty_content(self):
+        """Chunks where delta has no 'content' key are skipped."""
+        engine = ModelEngine(_make_model())
+
+        # Include a chunk with role-only delta (no content) — typical for first SSE event
+        raw_lines = [
+            b'data: {"choices": [{"delta": {"role": "assistant"}}]}\n\n',
+            b'data: {"choices": [{"delta": {"content": "Hello"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        mock_response = self._mock_streaming_response(raw_lines)
+
+        mock_client = AsyncMock()
+        mock_client.post = MagicMock(return_value=mock_response)
+        engine._client = mock_client
+        engine._running = True
+
+        chunks = []
+        async for chunk in engine.stream_call([{"role": "user", "content": "Hi"}]):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello"]
 
 
 class TestModelEngineConstants:

--- a/tests/guardrails/test_model_engine.py
+++ b/tests/guardrails/test_model_engine.py
@@ -409,17 +409,30 @@ class TestModelEngineStreamCall:
 
     @staticmethod
     def _mock_streaming_response(raw_lines, status=200):
-        """Create a mock aiohttp response that yields raw_lines from response.content."""
+        """Create a mock aiohttp response with a readline()-based content mock.
 
-        async def _content_iter():
-            """Async generator yielding raw SSE byte lines."""
-            for line in raw_lines:
-                yield line
+        Splits each raw_line on ``\\n`` boundaries so that readline() returns
+        one line at a time, matching real aiohttp StreamReader behaviour.
+        """
+        # Flatten raw_lines into individual \n-terminated lines
+        all_lines = []
+        for raw in raw_lines:
+            for part in raw.split(b"\n"):
+                if part:
+                    all_lines.append(part + b"\n")
+
+        line_iter = iter(all_lines)
+
+        async def _readline():
+            return next(line_iter, b"")
+
+        mock_content = MagicMock()
+        mock_content.readline = _readline
 
         mock_response = AsyncMock()
         mock_response.__aenter__ = AsyncMock(return_value=mock_response)
         mock_response.status = status
-        mock_response.content = _content_iter()
+        mock_response.content = mock_content
         return mock_response
 
     @patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})

--- a/tests/guardrails/test_model_manager.py
+++ b/tests/guardrails/test_model_manager.py
@@ -465,6 +465,7 @@ class TestModelManagerStreamAsync:
         messages = [{"role": "user", "content": "Hi"}]
 
         async def mock_stream_call(msgs, **kwargs):
+            """Mock stream yielding two chunks."""
             for chunk in ["Hello", " world"]:
                 yield chunk
 
@@ -484,6 +485,7 @@ class TestModelManagerStreamAsync:
         captured_kwargs = {}
 
         async def mock_stream_call(msgs, **kwargs):
+            """Mock stream that records kwargs."""
             captured_kwargs.update(kwargs)
             yield "ok"
 

--- a/tests/guardrails/test_model_manager.py
+++ b/tests/guardrails/test_model_manager.py
@@ -454,3 +454,50 @@ class TestModelManagerApiEngineStopErrors:
 
         with pytest.raises(RuntimeError, match="Engine jailbreak_detection"):
             await manager.stop()
+
+
+class TestModelManagerStreamAsync:
+    """Test stream_async routes to the correct engine and yields chunks."""
+
+    @pytest.mark.asyncio
+    async def test_streams_chunks_from_correct_engine(self, manager):
+        """Calls the named engine's stream_call and yields all chunks."""
+        messages = [{"role": "user", "content": "Hi"}]
+
+        async def mock_stream_call(msgs, **kwargs):
+            for chunk in ["Hello", " world"]:
+                yield chunk
+
+        engine = manager._get_model_engine("main")
+        engine.stream_call = mock_stream_call
+
+        chunks = []
+        async for chunk in manager.stream_async("main", messages):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_forwards_kwargs_to_engine(self, manager):
+        """Extra kwargs are forwarded to engine.stream_call()."""
+        messages = [{"role": "user", "content": "Hi"}]
+        captured_kwargs = {}
+
+        async def mock_stream_call(msgs, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield "ok"
+
+        engine = manager._get_model_engine("main")
+        engine.stream_call = mock_stream_call
+
+        async for _ in manager.stream_async("main", messages, temperature=0.7):
+            pass
+
+        assert captured_kwargs["temperature"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_raises_key_error_for_unknown_model_type(self, manager):
+        """Raises KeyError when the model type doesn't exist."""
+        with pytest.raises(KeyError):
+            async for _ in manager.stream_async("nonexistent", [{"role": "user", "content": "Hi"}]):
+                pass


### PR DESCRIPTION
## Description

Adds output-rail streaming to IORails. Integrations into the API service, chat, etc via Guardrails top-level in follow-on PR #1766 .  Key points:
  - Two concurrent paths: _generation_task pushes chunks into the StreamingHandler queue; _wrapped_iterator (or _run_output_rails_in_streaming) consumes
  from it
  - StreamingHandler is the bridge — it's an AsyncIterator backed by an asyncio.Queue
  - RollingBuffer sits between the StreamingHandler and the caller, batching tokens and providing overlap context for output rail checks
  - Output rails use the same ModelEngine.call() (non-streaming) as input rails — only the main LLM uses stream_call()



High-level overview of the change below:

```
*  IORails.stream_async(messages)
  │
  ├─ _validate_streaming_with_output_rails()
  │
  └─ _wrapped_iterator()                          [async generator returned to caller]
     │
     ├─ Semaphore.acquire()                       [concurrency gate]
     ├─ set_new_request_id()
     │
     ├─ asyncio.create_task(_generation_task)      [background task ─────────────────┐
     │                                                                               │
     │   _generation_task()                                                          │
     │   │                                                                           │
     │   ├─ RailsManager.is_input_safe(messages)   [input rails, non-streaming]      │
     │   │   └─ ModelManager.generate_async("content_safety", ...)                   │
     │   │       └─ ModelEngine.call()              [HTTP POST, full response]       │
     │   │                                                                           │
     │   ├─ ModelManager.stream_async("main", messages)                              │
     │   │   └─ ModelEngine.stream_call()           [HTTP POST stream=True, SSE]     │
     │   │       └─ yields content delta strings ──┐                                 │
     │   │                                         │                                 │
     │   │   for each chunk:                       │                                 │
     │   │       StreamingHandler.push_chunk(chunk) ◄┘                               │
     │   │           └─ queue.put(chunk)                                             │
     │   │                                                                           │
     │   └─ StreamingHandler.push_chunk(END_OF_STREAM)                               │
     │                                              │                                │
     │                                              ▼                                │
     │                                     StreamingHandler                          │
     │                                     [AsyncIterator]                           │
     │                                     queue: chunk→chunk→...→EOS                │
     │                                              │                                │
     │  ┌───────────────────────────────────────────┘                                │
     │  │                                                                            │
     │  ▼  [if output rails streaming enabled]                                       │
     │                                                                               │
     ├─ _run_output_rails_in_streaming(streaming_handler, messages)                  │
     │  │                                                                            │
     │  ├─ get_buffer_strategy(config)                                               │
     │  │   └─ RollingBuffer(context_size, chunk_size)                               │
     │  │                                                                            │
     │  └─ async for chunk_batch in buffer_strategy(streaming_handler):              │
     │     │                                                                         │
     │     │  RollingBuffer.process_stream()                                         │
     │     │  ├─ accumulates chunks until len(buffer) >= chunk_size                  │
     │     │  └─ yields ChunkBatch:                                                  │
     │     │       .processing_context  = [context_size overlap + chunk_size tokens] │
     │     │       .user_output_chunks  = [new tokens only]                          │
     │     │                                                                         │
     │     ├─ [stream_first=True]  yield user_output_chunks to caller                │
     │     │                                                                         │
     │     ├─ RailsManager.is_output_safe(messages, processing_context_text)         │
     │     │   └─ ModelManager.generate_async("content_safety", ...)                 │
     │     │       └─ ModelEngine.call()                                             │
     │     │                                                                         │
     │     ├─ [unsafe] → yield error JSON, return                                    │
     │     │                                                                         │
     │     └─ [stream_first=False] yield user_output_chunks to caller                │
     │                                                                               │
     │  [if NO output rails]                                                         │
     ├─ async for chunk in streaming_handler: yield chunk                            │
     │                                                                               │
     └─ finally:                                                                     │
        ├─ Semaphore.release()                                                       │
        ├─ await task  ◄─────────────────────────────────────────────────────────────┘
        └─ reset_request_id(token)



```

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-tests

```
$ poetry run pytest -q
.......................ssss.........................................................................................s............................... [  4%]
.................................................................................................................................................... [  9%]
.................................................................................................................................................... [ 13%]
.................................................................................................................................................... [ 18%]
.................................................................................................................................................... [ 22%]
.......................s......ss...................sssssss.......................................................................................... [ 27%]
...................................................................s.......s.........................................ss...........................s. [ 31%]
..............s.......sssss...............................................................s......................................................... [ 36%]
.............................................................ss........ss...ss............................................s......................... [ 40%]
............................s............s.......................................................................................................... [ 45%]
.................................................................................................................................................... [ 50%]
...................................................................sssss......ssssssssssssssssss.........sssss...................................... [ 54%]
..............................................s...........ss...................................sssssssss.ssssssssss................................s [ 59%]
...................................................s....s........................................................ssssssss..............sss...ss...ss [ 63%]
.....ssssssssssssss................................................................................................................................. [ 68%]
.....s..............................................................................................................s....................ssssssss... [ 72%]
......ss......................................................................................................................................ssssss [ 77%]
s...........................................................................s....................................................................... [ 81%]
..................................ss................................................................................................................ [ 86%]
.................................................................................................................................................... [ 90%]
...................................s................................................................................................................ [ 95%]
.................................................................................................................................................... [100%]
3115 passed, 141 skipped in 137.15s (0:02:17)
```

### Local integration test

<img width="1207" height="1511" alt="image" src="https://github.com/user-attachments/assets/3cde96f3-dc4f-470c-8bc2-5e1a4df54ee7" />

[20260406_iorails_streaming_integ_tests.ipynb](https://github.com/user-attachments/files/26517882/20260406_iorails_streaming_integ_tests.ipynb)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.
