### PR TITLE
refactor(llm): rename generate/stream to generate_async/stream_async

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -78,7 +78,7 @@ async def llm_call(
         return await _stream_llm_call(model, chat_prompt, streaming_handler, stop, llm_params)
 
     try:
-        response: LLMResponse = await model.generate(chat_prompt, stop=stop, **(llm_params or {}))
+        response: LLMResponse = await model.generate_async(chat_prompt, stop=stop, **(llm_params or {}))
     except Exception as e:
         _raise_llm_call_exception(e, model)
 
@@ -102,7 +102,7 @@ async def _stream_llm_call(
     last_chunk: Optional[LLMResponseChunk] = None
 
     try:
-        async for chunk in model.stream(prompt, stop=stop, **(llm_params or {})):
+        async for chunk in model.stream_async(prompt, stop=stop, **(llm_params or {})):
             last_chunk = chunk
             content = chunk.delta_content or ""
 

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -184,7 +184,7 @@ class LangChainLLMAdapter:
             return chatmessages_to_langchain_messages(prompt)
         return prompt
 
-    async def generate(
+    async def generate_async(
         self,
         prompt: Union[str, List[ChatMessage]],
         *,
@@ -196,7 +196,7 @@ class LangChainLLMAdapter:
         response = await llm.ainvoke(messages, stop=stop)
         return _langchain_response_to_llm_response(response)
 
-    async def stream(
+    async def stream_async(
         self,
         prompt: Union[str, List[ChatMessage]],
         *,

--- a/nemoguardrails/types.py
+++ b/nemoguardrails/types.py
@@ -228,7 +228,7 @@ class LLMModel(Protocol):
     max_tokens).
     """
 
-    async def generate(
+    async def generate_async(
         self,
         prompt: Union[str, List["ChatMessage"]],
         *,
@@ -236,7 +236,7 @@ class LLMModel(Protocol):
         **kwargs,
     ) -> "LLMResponse": ...
 
-    def stream(
+    def stream_async(
         self,
         prompt: Union[str, List["ChatMessage"]],
         *,

--- a/tests/test_actions_llm_utils.py
+++ b/tests/test_actions_llm_utils.py
@@ -387,12 +387,12 @@ class TestLlmCallDictToChatMessageConversion:
         received_prompt = None
 
         class CaptureLLM:
-            async def generate(self, prompt, *, stop=None, **kwargs):
+            async def generate_async(self, prompt, *, stop=None, **kwargs):
                 nonlocal received_prompt
                 received_prompt = prompt
                 return LLMResponse(content="ok")
 
-            async def stream(self, prompt, *, stop=None, **kwargs):
+            async def stream_async(self, prompt, *, stop=None, **kwargs):
                 yield LLMResponseChunk(delta_content="ok")
 
             @property
@@ -428,12 +428,12 @@ class TestLlmCallDictToChatMessageConversion:
         received_prompt = None
 
         class CaptureLLM:
-            async def generate(self, prompt, *, stop=None, **kwargs):
+            async def generate_async(self, prompt, *, stop=None, **kwargs):
                 nonlocal received_prompt
                 received_prompt = prompt
                 return LLMResponse(content="ok")
 
-            async def stream(self, prompt, *, stop=None, **kwargs):
+            async def stream_async(self, prompt, *, stop=None, **kwargs):
                 yield LLMResponseChunk(delta_content="ok")
 
             @property
@@ -458,12 +458,12 @@ class TestLlmCallDictToChatMessageConversion:
         received_prompt = None
 
         class CaptureLLM:
-            async def generate(self, prompt, *, stop=None, **kwargs):
+            async def generate_async(self, prompt, *, stop=None, **kwargs):
                 nonlocal received_prompt
                 received_prompt = prompt
                 return LLMResponse(content="ok")
 
-            async def stream(self, prompt, *, stop=None, **kwargs):
+            async def stream_async(self, prompt, *, stop=None, **kwargs):
                 yield LLMResponseChunk(delta_content="ok")
 
             @property

--- a/tests/test_langchain_llm_adapter.py
+++ b/tests/test_langchain_llm_adapter.py
@@ -86,7 +86,7 @@ class TestLangChainLLMAdapter:
         mock_llm.ainvoke.return_value = AIMessage(content="hello world")
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("say hello")
+        result = await adapter.generate_async("say hello")
 
         assert isinstance(result, LLMResponse)
         assert result.content == "hello world"
@@ -98,7 +98,7 @@ class TestLangChainLLMAdapter:
         mock_llm.ainvoke.return_value = AIMessage(content="hi there")
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate([ChatMessage.from_user("hello")])
+        result = await adapter.generate_async([ChatMessage.from_user("hello")])
 
         assert isinstance(result, LLMResponse)
         assert result.content == "hi there"
@@ -116,7 +116,7 @@ class TestLangChainLLMAdapter:
         )
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt")
+        result = await adapter.generate_async("prompt")
 
         assert isinstance(result, LLMResponse)
         assert result.content == "response"
@@ -134,7 +134,7 @@ class TestLangChainLLMAdapter:
         )
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt")
+        result = await adapter.generate_async("prompt")
 
         assert result.tool_calls is not None
         assert len(result.tool_calls) == 1
@@ -152,7 +152,7 @@ class TestLangChainLLMAdapter:
         mock_llm.ainvoke.return_value = response
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt")
+        result = await adapter.generate_async("prompt")
 
         assert result.usage is not None
         assert result.usage.total_tokens == 100
@@ -175,7 +175,7 @@ class TestLangChainLLMAdapter:
         adapter = LangChainLLMAdapter(mock_llm)
 
         results = []
-        async for chunk in adapter.stream("say hello"):
+        async for chunk in adapter.stream_async("say hello"):
             results.append(chunk)
 
         assert len(results) == 2
@@ -191,7 +191,7 @@ class TestLangChainLLMAdapter:
         mock_llm.bind.return_value = bound_llm
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt", temperature=0.5, max_tokens=100)
+        result = await adapter.generate_async("prompt", temperature=0.5, max_tokens=100)
 
         mock_llm.bind.assert_called_once_with(temperature=0.5, max_tokens=100)
         bound_llm.ainvoke.assert_called_once_with("prompt", stop=None)
@@ -203,7 +203,7 @@ class TestLangChainLLMAdapter:
         mock_llm.ainvoke.return_value = AIMessage(content="direct response")
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt")
+        result = await adapter.generate_async("prompt")
 
         mock_llm.bind.assert_not_called()
         assert result.content == "direct response"
@@ -217,7 +217,7 @@ class TestLangChainLLMAdapter:
         mock_llm.bind.return_value = bound_llm
         adapter = LangChainLLMAdapter(mock_llm)
 
-        result = await adapter.generate("prompt", temperature=0.5, max_tokens=100)
+        result = await adapter.generate_async("prompt", temperature=0.5, max_tokens=100)
 
         mock_llm.bind.assert_called_once_with(max_tokens=100)
         assert result.content == "reasoning response"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -415,10 +415,10 @@ class TestLLMResponseChunk:
 class TestLLMModelProtocol:
     def test_mock_satisfies_protocol(self):
         class MockLLM:
-            async def generate(self, prompt, *, stop=None, **kwargs):
+            async def generate_async(self, prompt, *, stop=None, **kwargs):
                 return LLMResponse(content="response")
 
-            async def stream(self, prompt, *, stop=None, **kwargs):
+            async def stream_async(self, prompt, *, stop=None, **kwargs):
                 yield LLMResponseChunk(delta_content="chunk")
 
             @property
@@ -437,7 +437,7 @@ class TestLLMModelProtocol:
 
     def test_incomplete_class_fails_protocol(self):
         class IncompleteLLM:
-            async def generate(self, prompt, *, stop=None, **kwargs):
+            async def generate_async(self, prompt, *, stop=None, **kwargs):
                 return LLMResponse(content="response")
 
         assert not isinstance(IncompleteLLM(), LLMModel)


### PR DESCRIPTION
Part of the LangChain decoupling stack:
1. stack-1: canonical types (#1745)
2. stack-2: adapter and framework registry (#1759)
3. stack-3: pipeline rewrite + caller migration (#1760)
4. **stack-4: rename generate/stream to generate_async/stream_async** (this PR)
5. stack-5: remove LangChain imports from core modules (#1770)
6. stack-6: move LangChain implementations into integrations/langchain/ (#1772)
7. stack-7: framework-owned provider registry (#1773)
8. stack-8: framework-agnostic test infrastructure (TODO)

## Description

Rename LLMModel protocol methods for clarity and consistency. Updates protocol, LangChainLLMAdapter, llm_call callers, and tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Asynchronous LLM model methods renamed to explicitly indicate their async nature: `generate_async()` and `stream_async()` for improved API clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->