### PR TITLE
refactor(llm): remove LangChain imports from core modules

### DIFF
--- a/nemoguardrails/actions/action_dispatcher.py
+++ b/nemoguardrails/actions/action_dispatcher.py
@@ -23,8 +23,6 @@ from importlib.machinery import ModuleSpec
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
-from langchain_core.runnables import Runnable
-
 from nemoguardrails import utils
 from nemoguardrails.exceptions import LLMCallException
 
@@ -218,11 +216,10 @@ class ActionDispatcher:
                         else:
                             log.warning(f"Synchronous action `{action_name}` has been called.")
 
-                    elif isinstance(fn, Runnable):
-                        # If it's a Runnable, we invoke it as well
-                        runnable = fn
-
-                        result = await runnable.ainvoke(input=params)
+                    elif hasattr(fn, "ainvoke") and callable(fn.ainvoke):  # type: ignore[union-attr]
+                        # Duck-type check for LangChain Runnables (or any object
+                        # with ainvoke) to avoid importing langchain in core.
+                        result = await fn.ainvoke(input=params)  # type: ignore[union-attr]
                     else:
                         # TODO: there should be a common base class here
                         fn_run_func = getattr(fn, "run", None)

--- a/nemoguardrails/eval/cli.py
+++ b/nemoguardrails/eval/cli.py
@@ -170,12 +170,12 @@ def check_compliance(
     if disable_llm_cache:
         console.print("[orange]Caching is disabled.[/]")
     else:
-        console.print("[green]Caching is enabled.[/]")
         try:
             from langchain_community.cache import SQLiteCache
             from langchain_core.globals import set_llm_cache
 
             set_llm_cache(SQLiteCache(database_path=".langchain.db"))
+            console.print("[green]Caching is enabled.[/]")
         except ImportError:
             console.print("[yellow]langchain not installed, LLM caching unavailable.[/]")
 

--- a/nemoguardrails/eval/cli.py
+++ b/nemoguardrails/eval/cli.py
@@ -19,8 +19,6 @@ import sys
 from typing import List
 
 import typer
-from langchain_community.cache import SQLiteCache
-from langchain_core.globals import set_llm_cache
 
 from nemoguardrails.eval.check import LLMJudgeComplianceChecker
 from nemoguardrails.eval.eval import run_eval
@@ -173,7 +171,13 @@ def check_compliance(
         console.print("[orange]Caching is disabled.[/]")
     else:
         console.print("[green]Caching is enabled.[/]")
-        set_llm_cache(SQLiteCache(database_path=".langchain.db"))
+        try:
+            from langchain_community.cache import SQLiteCache
+            from langchain_core.globals import set_llm_cache
+
+            set_llm_cache(SQLiteCache(database_path=".langchain.db"))
+        except ImportError:
+            console.print("[yellow]langchain not installed, LLM caching unavailable.[/]")
 
     console.print(f"Using eval configuration from {eval_config_path}.")
     console.print(f"Using output paths: {output_path}.")

--- a/nemoguardrails/evaluate/evaluate_factcheck.py
+++ b/nemoguardrails/evaluate/evaluate_factcheck.py
@@ -20,7 +20,6 @@ import time
 
 import tqdm
 import typer
-from langchain_core.prompts import PromptTemplate
 
 from nemoguardrails import LLMRails
 from nemoguardrails.actions.llm.utils import llm_call
@@ -28,6 +27,7 @@ from nemoguardrails.evaluate.utils import load_dataset
 from nemoguardrails.llm.prompts import Task
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
+from nemoguardrails.utils import get_or_create_event_loop
 
 
 class FactCheckEvaluation:
@@ -89,13 +89,7 @@ class FactCheckEvaluation:
         that it will not be grounded in the evidence passage. change details in the answer to make the answer
         wrong but yet believable.\nevidence: {evidence}\nanswer: {answer}\nincorrect answer:"""
 
-        create_negatives_prompt = PromptTemplate(
-            template=create_negatives_template,
-            input_variables=["evidence", "answer"],
-        )
-
-        # Bind config parameters to the LLM for generating negative samples
-        llm_with_config = self.llm.bind(temperature=0.8, max_tokens=300)
+        loop = get_or_create_event_loop()
 
         print("Creating negative samples...")
         for data in tqdm.tqdm(dataset):
@@ -103,13 +97,11 @@ class FactCheckEvaluation:
             evidence = data["evidence"]
             answer = data["answer"]
 
-            # Format the prompt and invoke the LLM directly
-            formatted_prompt = create_negatives_prompt.format(evidence=evidence, answer=answer)
-            negative_answer = llm_with_config.invoke(formatted_prompt)
-            if isinstance(negative_answer, str):
-                data["incorrect_answer"] = negative_answer.strip()
-            else:
-                data["incorrect_answer"] = negative_answer.content.strip()
+            formatted_prompt = create_negatives_template.format(evidence=evidence, answer=answer)
+            response = loop.run_until_complete(
+                self.llm.generate_async(formatted_prompt, temperature=0.8, max_tokens=300)
+            )
+            data["incorrect_answer"] = response.content.strip()
 
         return dataset
 

--- a/nemoguardrails/evaluate/evaluate_factcheck.py
+++ b/nemoguardrails/evaluate/evaluate_factcheck.py
@@ -27,7 +27,6 @@ from nemoguardrails.evaluate.utils import load_dataset
 from nemoguardrails.llm.prompts import Task
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import RailsConfig
-from nemoguardrails.utils import get_or_create_event_loop
 
 
 class FactCheckEvaluation:
@@ -71,7 +70,7 @@ class FactCheckEvaluation:
         if not os.path.exists(self.output_dir):
             os.makedirs(self.output_dir)
 
-    def create_negative_samples(self, dataset):
+    async def create_negative_samples(self, dataset):
         """
         Create synthetic negative samples for fact checking. The negative samples are created by an LLM that acts
         as an adversary and modifies the answer to make it incorrect.
@@ -89,8 +88,6 @@ class FactCheckEvaluation:
         that it will not be grounded in the evidence passage. change details in the answer to make the answer
         wrong but yet believable.\nevidence: {evidence}\nanswer: {answer}\nincorrect answer:"""
 
-        loop = get_or_create_event_loop()
-
         print("Creating negative samples...")
         for data in tqdm.tqdm(dataset):
             assert "evidence" in data and "question" in data and "answer" in data
@@ -98,9 +95,7 @@ class FactCheckEvaluation:
             answer = data["answer"]
 
             formatted_prompt = create_negatives_template.format(evidence=evidence, answer=answer)
-            response = loop.run_until_complete(
-                self.llm.generate_async(formatted_prompt, temperature=0.8, max_tokens=300)
-            )
+            response = await self.llm.generate_async(formatted_prompt, temperature=0.8, max_tokens=300)
             data["incorrect_answer"] = response.content.strip()
 
         return dataset
@@ -164,7 +159,7 @@ class FactCheckEvaluation:
         Run the fact checking evaluation and print the results.
         """
         if self.create_negatives:
-            self.dataset = self.create_negative_samples(self.dataset)
+            self.dataset = asyncio.run(self.create_negative_samples(self.dataset))
 
         print("Checking facts - positive entailment")
         positive_fact_check_predictions, pos_num_correct, pos_time = self.check_facts(split="positive")

--- a/nemoguardrails/library/hallucination/actions.py
+++ b/nemoguardrails/library/hallucination/actions.py
@@ -17,8 +17,6 @@ import asyncio
 import logging
 from typing import Optional
 
-from langchain_core.prompts import PromptTemplate
-
 from nemoguardrails import RailsConfig
 from nemoguardrails.actions import action
 from nemoguardrails.actions.llm.utils import (
@@ -56,8 +54,7 @@ async def self_check_hallucination(
     if bot_response and last_bot_prompt_string:
         num_responses = HALLUCINATION_NUM_EXTRA_RESPONSES
 
-        last_bot_prompt = PromptTemplate(template="{text}", input_variables=["text"])
-        formatted_prompt = last_bot_prompt.format(text=last_bot_prompt_string)
+        formatted_prompt = last_bot_prompt_string
 
         async def _generate_extra_response(index: int) -> Optional[str]:
             llm_call_info_var.set(LLMCallInfo(task=Task.SELF_CHECK_HALLUCINATION.value))


### PR DESCRIPTION
Part of the LangChain decoupling stack:
1. stack-1: canonical types (#1745)
2. stack-2: adapter and framework registry (#1759)
3. stack-3: pipeline rewrite + caller migration (#1760)
4. stack-4: rename generate/stream to generate_async/stream_async (#1769)
5. **stack-5: remove LangChain imports from core modules** (this PR)
6. stack-6: move LangChain implementations into integrations/langchain/ (#1772)
7. stack-7: framework-owned provider registry (#1773)
8. stack-8: framework-agnostic test infrastructure (TODO)

## Description

- Remove PromptTemplate from hallucination actions (was a no-op)
- Replace Runnable isinstance check with duck-type ainvoke check in action_dispatcher
- Remove PromptTemplate and llm.bind().invoke() from evaluate_factcheck, use LLMModel.generate_async via event loop
- Make eval CLI LangChain cache a lazy optional import




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LLM caching no longer causes startup failure if LangChain dependencies are unavailable; users receive a warning instead.

* **Refactor**
  * Reduced direct dependency on specific LangChain APIs for improved flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->