### PR TITLE
fix(types): require id field on tool calls in ChatMessage.from_dict

### DIFF
--- a/nemoguardrails/types.py
+++ b/nemoguardrails/types.py
@@ -164,9 +164,13 @@ class ChatMessage:
                         )
                     args_dict = raw_args
 
+                tc_id = tc.get("id")
+                if not tc_id:
+                    raise ValueError("Tool call missing required 'id' field.")
+
                 tool_calls.append(
                     ToolCall(
-                        id=tc.get("id", ""),
+                        id=tc_id,
                         type=tc.get("type", "function"),
                         function=ToolCallFunction(
                             name=func_data.get("name", ""),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -258,6 +258,22 @@ class TestChatMessage:
         assert msg.tool_calls[0].function.arguments == {"q": "x"}
         assert msg.tool_calls[0].id == "tc_1"
 
+    def test_from_dict_raises_on_tool_call_missing_id(self):
+        d = {
+            "role": "assistant",
+            "tool_calls": [{"function": {"name": "search", "arguments": {"q": "x"}}}],
+        }
+        with pytest.raises(ValueError, match="missing required 'id'"):
+            ChatMessage.from_dict(d)
+
+    def test_from_dict_raises_on_tool_call_empty_id(self):
+        d = {
+            "role": "assistant",
+            "tool_calls": [{"id": "", "function": {"name": "search", "arguments": {"q": "x"}}}],
+        }
+        with pytest.raises(ValueError, match="missing required 'id'"):
+            ChatMessage.from_dict(d)
+
     def test_from_dict_captures_provider_metadata(self):
         d = {"role": "user", "content": "hi", "provider_metadata": {"custom_field": "value", "model": "gpt-4"}}
         msg = ChatMessage.from_dict(d)


### PR DESCRIPTION
## Description

Resolves the comment https://github.com/NVIDIA-NeMo/Guardrails/pull/1745#discussion_r3015225012 in  #1745. Raise ValueError when tool call dict is missing 'id' or has empty string. Tool call IDs are required for multiturn tool use. The adapter layer synthesizes UUIDs for provider responses that omit IDs, but from_dict receives upstream data that should already have them.

