### PR TITLE
fix(ci): pin baseline x86-64 compiler target to prevent SIGILL on cached venvs

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -85,6 +85,12 @@ jobs:
       - name: Check Poetry .lock
         run: poetry check --lock
 
+      - name: Set baseline x86-64 compiler flags
+        if: runner.os == 'Linux'
+        run: |
+          echo "CFLAGS=-march=x86-64" >> $GITHUB_ENV
+          echo "CXXFLAGS=-march=x86-64" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           if [ "${{ inputs.upgrade-deps}}" = "true" ]; then

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ on:
 env:
   POETRY_VERSION: 1.8.2
   PYTHON_VERSION: "3.11"
+  CFLAGS: "-march=x86-64"
+  CXXFLAGS: "-march=x86-64"
 
 jobs:
   lint:
@@ -28,6 +30,10 @@ jobs:
         id: full-python-version
         run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
 
+      - name: Get runner architecture
+        id: runner-arch
+        run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
+
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | POETRY_VERSION=${{ env.POETRY_VERSION }} python -
@@ -41,7 +47,7 @@ jobs:
         id: cache
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.runner-arch.outputs.arch }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
## Description
CI tests intermittently crash with `Fatal Python error: Illegal instruction` (SIGILL, exit code 132) on Ubuntu runners.

GitHub Actions `ubuntu-latest` runners have heterogeneous CPU microarchitectures some support AVX-512, others only AVX2. When native C extensions (e.g. `annoy`, `numpy`) are compiled from source on a runner with newer SIMD instructions and the resulting `.venv` is cached, restoring that cache on a runner with an older CPU causes native code to hit unsupported instructions.

The cache key includes OS, arch (`x86_64`), and Python version — but not the CPU model. Since `uname -m` returns `x86_64` regardless of instruction set support, different CPUs produce identical cache keys.
## Fix

Set `CFLAGS` and `CXXFLAGS` to `-march=x86-64` on Linux runners before `poetry install`. This forces all native extensions to compile for the baseline x86-64 instruction set, making cached `.so` files safe across any x86-64 runner.

Scoped to Linux only 

closes #1659 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow cache verification logic to improve environment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->