### PR TITLE
feat(llm): add streaming tool call accumulation and LLMResponse parity

### DIFF
--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -144,10 +144,15 @@ async def _stream_llm_call(
 
         if tool_calls:
             tool_calls_var.set([tc.to_dict() for tc in tool_calls])
+        else:
+            tool_calls_var.set(None)
+
+        reasoning_content = "".join(accumulated_reasoning) if accumulated_reasoning else None
+        reasoning_trace_var.set(reasoning_content)
 
         return LLMResponse(
             content=handler.completion,
-            reasoning="".join(accumulated_reasoning) if accumulated_reasoning else None,
+            reasoning=reasoning_content,
             tool_calls=tool_calls,
             model=model_name,
             finish_reason=finish_reason,

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -29,7 +29,7 @@ from nemoguardrails.context import (
 from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.llm_tracker import track_llm_call
-from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk
+from nemoguardrails.types import ChatMessage, LLMModel, LLMResponse, LLMResponseChunk, UsageInfo
 
 if TYPE_CHECKING:
     from nemoguardrails.streaming import StreamingHandler
@@ -99,12 +99,29 @@ async def _stream_llm_call(
 ) -> LLMResponse:
     handler.stop = stop or []
     accumulated_metadata: Dict[str, Any] = {}
-    last_chunk: Optional[LLMResponseChunk] = None
+    accumulated_reasoning: List[str] = []
+    tool_calls = None
+    model_name: Optional[str] = None
+    finish_reason: Optional[str] = None
+    request_id: Optional[str] = None
+    usage: Optional[UsageInfo] = None
 
     try:
         async for chunk in model.stream_async(prompt, stop=stop, **(llm_params or {})):
-            last_chunk = chunk
             content = chunk.delta_content or ""
+
+            if chunk.delta_reasoning:
+                accumulated_reasoning.append(chunk.delta_reasoning)
+            if chunk.delta_tool_calls:
+                tool_calls = chunk.delta_tool_calls
+            if chunk.model:
+                model_name = chunk.model
+            if chunk.finish_reason:
+                finish_reason = chunk.finish_reason
+            if chunk.request_id:
+                request_id = chunk.request_id
+            if chunk.usage:
+                usage = chunk.usage
 
             chunk_metadata = _extract_chunk_metadata(chunk)
             if chunk_metadata:
@@ -121,12 +138,21 @@ async def _stream_llm_call(
         if llm_call_info:
             llm_call_info.completion = handler.completion
 
-        if last_chunk is not None:
-            _update_token_stats_from_chunk(last_chunk)
+        if usage:
+            fake_chunk = LLMResponseChunk(usage=usage)
+            _update_token_stats_from_chunk(fake_chunk)
+
+        if tool_calls:
+            tool_calls_var.set([tc.to_dict() for tc in tool_calls])
 
         return LLMResponse(
             content=handler.completion,
-            usage=last_chunk.usage if last_chunk else None,
+            reasoning="".join(accumulated_reasoning) if accumulated_reasoning else None,
+            tool_calls=tool_calls,
+            model=model_name,
+            finish_reason=finish_reason,
+            request_id=request_id,
+            usage=usage,
             provider_metadata=accumulated_metadata if accumulated_metadata else None,
         )
 
@@ -135,6 +161,11 @@ async def _stream_llm_call(
 
 
 def _extract_chunk_metadata(chunk: LLMResponseChunk) -> Optional[Dict[str, Any]]:
+    # This feeds handler.push_chunk() for the StreamingHandler consumer path
+    # (API responses, output rails). Separate from the field accumulation in
+    # _stream_llm_call which builds the returned LLMResponse for the pipeline.
+    # TODO(Pouyanpi): consider pushing tool_calls and reasoning through the handler too,
+    # so output rails and streaming consumers can see them in real-time.
     metadata: Dict[str, Any] = {}
     if chunk.provider_metadata:
         metadata["provider_metadata"] = chunk.provider_metadata

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -98,7 +98,8 @@ async def _stream_llm_call(
     llm_params: Optional[dict] = None,
 ) -> LLMResponse:
     handler.stop = stop or []
-    accumulated_metadata: Dict[str, Any] = {}
+    streaming_handler_metadata: Dict[str, Any] = {}
+    accumulated_provider_metadata: Dict[str, Any] = {}
     accumulated_reasoning: List[str] = []
     tool_calls = None
     model_name: Optional[str] = None
@@ -122,14 +123,16 @@ async def _stream_llm_call(
                 request_id = chunk.request_id
             if chunk.usage:
                 usage = chunk.usage
+            if chunk.provider_metadata:
+                accumulated_provider_metadata.update(chunk.provider_metadata)
 
             chunk_metadata = _extract_chunk_metadata(chunk)
             if chunk_metadata:
-                accumulated_metadata.update(chunk_metadata)
+                streaming_handler_metadata.update(chunk_metadata)
 
             await handler.push_chunk(content, chunk_metadata)
 
-        llm_response_metadata_var.set(accumulated_metadata or None)
+        llm_response_metadata_var.set(accumulated_provider_metadata or None)
 
         await handler.finish()
 
@@ -160,7 +163,7 @@ async def _stream_llm_call(
             finish_reason=finish_reason,
             request_id=request_id,
             usage=usage,
-            provider_metadata=accumulated_metadata if accumulated_metadata else None,
+            provider_metadata=accumulated_provider_metadata or None,
         )
 
     except Exception as e:

--- a/nemoguardrails/actions/llm/utils.py
+++ b/nemoguardrails/actions/llm/utils.py
@@ -129,8 +129,7 @@ async def _stream_llm_call(
 
             await handler.push_chunk(content, chunk_metadata)
 
-        if accumulated_metadata:
-            llm_response_metadata_var.set(accumulated_metadata)
+        llm_response_metadata_var.set(accumulated_metadata or None)
 
         await handler.finish()
 
@@ -148,6 +147,9 @@ async def _stream_llm_call(
             tool_calls_var.set(None)
 
         reasoning_content = "".join(accumulated_reasoning) if accumulated_reasoning else None
+        # TODO: call _extract_and_remove_think_tags on the completed response
+        # to handle models that stream reasoning via <think> tags in content
+        # rather than via delta_reasoning. Pre-existing gap, not introduced here.
         reasoning_trace_var.set(reasoning_content)
 
         return LLMResponse(

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -388,6 +388,7 @@ def _finalize_tool_call_acc(acc: Dict[int, Dict[str, Any]]) -> List[ToolCall]:
         try:
             args_dict = json.loads(raw_args) if raw_args else {}
         except json.JSONDecodeError:
+            log.warning("Failed to parse tool call arguments for '%s' (index %d): %r", entry["name"], idx, raw_args)
             args_dict = {}
         result.append(
             ToolCall(

--- a/nemoguardrails/integrations/langchain/llm_adapter.py
+++ b/nemoguardrails/integrations/langchain/llm_adapter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import uuid
 from typing import Any, AsyncIterator, Dict, List, NamedTuple, Optional, Union
@@ -205,8 +206,33 @@ class LangChainLLMAdapter:
     ) -> AsyncIterator[LLMResponseChunk]:
         llm = self._prepare_llm(kwargs)
         messages = self._to_langchain_input(prompt)
+
+        tool_call_acc: Dict[int, Dict[str, Any]] = {}
+
         async for chunk in llm.astream(messages, stop=stop):
-            yield _langchain_chunk_to_llm_response_chunk(chunk)
+            for tc_chunk in getattr(chunk, "tool_call_chunks", None) or []:
+                idx = tc_chunk.get("index", 0)
+                if idx not in tool_call_acc:
+                    tool_call_acc[idx] = {
+                        "id": tc_chunk.get("id") or "",
+                        "name": tc_chunk.get("name") or "",
+                        "arguments_buffer": "",
+                    }
+                else:
+                    if tc_chunk.get("id"):
+                        tool_call_acc[idx]["id"] = tc_chunk["id"]
+                    if tc_chunk.get("name"):
+                        tool_call_acc[idx]["name"] = tc_chunk["name"]
+                arg_fragment = tc_chunk.get("args") or ""
+                if arg_fragment:
+                    tool_call_acc[idx]["arguments_buffer"] += arg_fragment
+
+            response_chunk = _langchain_chunk_to_llm_response_chunk(chunk)
+
+            if response_chunk.finish_reason == "tool_calls" and tool_call_acc:
+                response_chunk.delta_tool_calls = _finalize_tool_call_acc(tool_call_acc)
+
+            yield response_chunk
 
 
 class LangChainFramework:
@@ -352,6 +378,28 @@ def _extract_tool_calls(response: Any) -> Optional[List[ToolCall]]:
         )
         for tc in raw
     ]
+
+
+def _finalize_tool_call_acc(acc: Dict[int, Dict[str, Any]]) -> List[ToolCall]:
+    result = []
+    for idx in sorted(acc.keys()):
+        entry = acc[idx]
+        raw_args = entry["arguments_buffer"]
+        try:
+            args_dict = json.loads(raw_args) if raw_args else {}
+        except json.JSONDecodeError:
+            args_dict = {}
+        result.append(
+            ToolCall(
+                id=entry["id"] or str(uuid.uuid4()),
+                type="function",
+                function=ToolCallFunction(
+                    name=entry["name"],
+                    arguments=args_dict,
+                ),
+            )
+        )
+    return result
 
 
 def _extract_usage(response: Any) -> Optional[UsageInfo]:

--- a/tests/test_actions_llm_utils.py
+++ b/tests/test_actions_llm_utils.py
@@ -25,7 +25,13 @@ from nemoguardrails.actions.llm.utils import (
     _update_token_stats_from_chunk,
     llm_call,
 )
-from nemoguardrails.context import llm_call_info_var, llm_stats_var, reasoning_trace_var, tool_calls_var
+from nemoguardrails.context import (
+    llm_call_info_var,
+    llm_response_metadata_var,
+    llm_stats_var,
+    reasoning_trace_var,
+    tool_calls_var,
+)
 from nemoguardrails.exceptions import LLMCallException
 from nemoguardrails.integrations.langchain.llm_adapter import (
     LangChainLLMAdapter,
@@ -572,3 +578,62 @@ class TestStreamLlmCallAccumulation:
         result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
 
         assert result.request_id == "req-123"
+
+    @pytest.mark.asyncio
+    async def test_clears_tool_calls_var_when_none(self):
+        tool_calls_var.set([{"id": "stale", "type": "function", "function": {"name": "old", "arguments": {}}}])
+
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="no tools here", finish_reason="stop"),
+            ]
+        )
+
+        await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert tool_calls_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_clears_reasoning_var_when_none(self):
+        reasoning_trace_var.set("stale reasoning")
+
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="no reasoning", finish_reason="stop"),
+            ]
+        )
+
+        await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert reasoning_trace_var.get() is None
+
+    @pytest.mark.asyncio
+    async def test_provider_metadata_stored_flat(self):
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(
+                    delta_content="hi",
+                    provider_metadata={"system_fingerprint": "fp_abc"},
+                    finish_reason="stop",
+                ),
+            ]
+        )
+
+        await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        metadata = llm_response_metadata_var.get()
+        assert metadata == {"system_fingerprint": "fp_abc"}
+
+    @pytest.mark.asyncio
+    async def test_clears_metadata_var_when_none(self):
+        llm_response_metadata_var.set({"stale": True})
+
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="no metadata", finish_reason="stop"),
+            ]
+        )
+
+        await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert llm_response_metadata_var.get() is None

--- a/tests/test_actions_llm_utils.py
+++ b/tests/test_actions_llm_utils.py
@@ -539,6 +539,7 @@ class TestStreamLlmCallAccumulation:
         assert result.reasoning == "Let me think..."
         assert result.model == "gpt-4o"
         assert result.finish_reason == "stop"
+        assert reasoning_trace_var.get() == "Let me think..."
 
     @pytest.mark.asyncio
     async def test_text_only(self):

--- a/tests/test_actions_llm_utils.py
+++ b/tests/test_actions_llm_utils.py
@@ -21,6 +21,7 @@ from nemoguardrails.actions.llm.utils import (
     _log_completion,
     _store_reasoning_traces,
     _store_tool_calls,
+    _stream_llm_call,
     _update_token_stats_from_chunk,
     llm_call,
 )
@@ -32,6 +33,7 @@ from nemoguardrails.integrations.langchain.llm_adapter import (
 )
 from nemoguardrails.logging.explain import LLMCallInfo
 from nemoguardrails.logging.stats import LLMStats
+from nemoguardrails.streaming import StreamingHandler
 from nemoguardrails.types import ChatMessage, LLMResponse, LLMResponseChunk, Role, ToolCall, ToolCallFunction, UsageInfo
 
 
@@ -482,3 +484,90 @@ class TestLlmCallDictToChatMessageConversion:
         await llm_call(model, [])
 
         assert received_prompt == []
+
+
+def _make_chunk_model(chunks):
+    class _Model:
+        model_name = "test-model"
+        provider_name = "test"
+        provider_url = None
+
+        async def generate_async(self, prompt, *, stop=None, **kwargs):
+            return LLMResponse(content="")
+
+        async def stream_async(self, prompt, *, stop=None, **kwargs):
+            for c in chunks:
+                yield c
+
+    return _Model()
+
+
+class TestStreamLlmCallAccumulation:
+    @pytest.mark.asyncio
+    async def test_accumulates_tool_calls(self):
+        tc = [ToolCall(id="call_1", function=ToolCallFunction(name="get_weather", arguments={"city": "Paris"}))]
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(model="gpt-4o"),
+                LLMResponseChunk(delta_tool_calls=tc, finish_reason="tool_calls"),
+                LLMResponseChunk(usage=UsageInfo(input_tokens=10, output_tokens=5, total_tokens=15)),
+            ]
+        )
+
+        result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert result.tool_calls == tc
+        assert result.model == "gpt-4o"
+        assert result.finish_reason == "tool_calls"
+        assert result.usage.total_tokens == 15
+        assert tool_calls_var.get() is not None
+
+    @pytest.mark.asyncio
+    async def test_accumulates_reasoning(self):
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_reasoning="Let me ", model="gpt-4o"),
+                LLMResponseChunk(delta_reasoning="think..."),
+                LLMResponseChunk(delta_content="42", finish_reason="stop"),
+                LLMResponseChunk(usage=UsageInfo(input_tokens=5, output_tokens=3, total_tokens=8)),
+            ]
+        )
+
+        result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert result.content == "42"
+        assert result.reasoning == "Let me think..."
+        assert result.model == "gpt-4o"
+        assert result.finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_text_only(self):
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="Hello", model="gpt-4o"),
+                LLMResponseChunk(delta_content=" world", finish_reason="stop"),
+                LLMResponseChunk(usage=UsageInfo(input_tokens=5, output_tokens=2, total_tokens=7)),
+            ]
+        )
+
+        result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert result.content == "Hello world"
+        assert result.tool_calls is None
+        assert result.reasoning is None
+        assert result.model == "gpt-4o"
+        assert result.finish_reason == "stop"
+        assert result.usage.total_tokens == 7
+
+    @pytest.mark.asyncio
+    async def test_request_id_accumulated(self):
+        model = _make_chunk_model(
+            [
+                LLMResponseChunk(delta_content="hi", request_id="req-123", model="gpt-4o"),
+                LLMResponseChunk(finish_reason="stop"),
+            ]
+        )
+
+        result = await _stream_llm_call(model, "test", StreamingHandler(), stop=None)
+
+        assert result.request_id == "req-123"

--- a/tests/test_langchain_llm_adapter.py
+++ b/tests/test_langchain_llm_adapter.py
@@ -554,3 +554,117 @@ class TestChatMessageToLangChain:
         assert isinstance(results[0], SystemMessage)
         assert isinstance(results[1], HumanMessage)
         assert isinstance(results[2], AIMessage)
+
+
+def _make_lc_chunk(content="", tool_call_chunks=None, response_metadata=None, usage_metadata=None):
+    return MagicMock(
+        content=content,
+        tool_call_chunks=tool_call_chunks or [],
+        response_metadata=response_metadata,
+        usage_metadata=usage_metadata,
+        generation_info=None,
+    )
+
+
+def _make_adapter_with_chunks(chunks):
+    mock_llm = MagicMock()
+
+    async def mock_astream(*args, **kwargs):
+        for c in chunks:
+            yield c
+
+    mock_llm.astream = mock_astream
+    return LangChainLLMAdapter(mock_llm)
+
+
+async def _collect_stream(adapter, prompt="test"):
+    results = []
+    async for chunk in adapter.stream_async(prompt):
+        results.append(chunk)
+    return results
+
+
+class TestStreamingToolCalls:
+    @pytest.mark.asyncio
+    async def test_single_tool_call(self):
+        adapter = _make_adapter_with_chunks(
+            [
+                _make_lc_chunk(tool_call_chunks=[{"index": 0, "id": "call_abc", "name": "get_weather", "args": ""}]),
+                _make_lc_chunk(tool_call_chunks=[{"index": 0, "args": '{"city"'}]),
+                _make_lc_chunk(tool_call_chunks=[{"index": 0, "args": ':"Paris"}'}]),
+                _make_lc_chunk(response_metadata={"finish_reason": "tool_calls"}),
+            ]
+        )
+
+        results = await _collect_stream(adapter)
+
+        assert results[0].delta_tool_calls is None
+        assert results[1].delta_tool_calls is None
+        assert results[2].delta_tool_calls is None
+        final = results[3]
+        assert final.finish_reason == "tool_calls"
+        assert len(final.delta_tool_calls) == 1
+        assert final.delta_tool_calls[0].id == "call_abc"
+        assert final.delta_tool_calls[0].function.name == "get_weather"
+        assert final.delta_tool_calls[0].function.arguments == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls(self):
+        adapter = _make_adapter_with_chunks(
+            [
+                _make_lc_chunk(
+                    tool_call_chunks=[
+                        {"index": 0, "id": "call_1", "name": "get_weather", "args": ""},
+                        {"index": 1, "id": "call_2", "name": "get_time", "args": ""},
+                    ]
+                ),
+                _make_lc_chunk(
+                    tool_call_chunks=[
+                        {"index": 0, "args": '{"city":"Paris"}'},
+                        {"index": 1, "args": '{"city":"Paris"}'},
+                    ]
+                ),
+                _make_lc_chunk(response_metadata={"finish_reason": "tool_calls"}),
+            ]
+        )
+
+        results = await _collect_stream(adapter)
+
+        final = results[-1]
+        assert len(final.delta_tool_calls) == 2
+        assert final.delta_tool_calls[0].function.name == "get_weather"
+        assert final.delta_tool_calls[1].function.name == "get_time"
+        assert final.delta_tool_calls[0].function.arguments == {"city": "Paris"}
+        assert final.delta_tool_calls[1].function.arguments == {"city": "Paris"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_falls_back_to_empty_dict(self):
+        adapter = _make_adapter_with_chunks(
+            [
+                _make_lc_chunk(tool_call_chunks=[{"index": 0, "id": "call_x", "name": "broken", "args": ""}]),
+                _make_lc_chunk(tool_call_chunks=[{"index": 0, "args": "{not valid json"}]),
+                _make_lc_chunk(response_metadata={"finish_reason": "tool_calls"}),
+            ]
+        )
+
+        results = await _collect_stream(adapter)
+
+        assert results[-1].delta_tool_calls[0].function.arguments == {}
+
+    @pytest.mark.asyncio
+    async def test_text_only_stream_unaffected(self):
+        adapter = _make_adapter_with_chunks(
+            [
+                _make_lc_chunk(content="Hello"),
+                _make_lc_chunk(content=" world", response_metadata={"finish_reason": "stop"}),
+            ]
+        )
+
+        results = await _collect_stream(adapter)
+
+        assert len(results) == 2
+        assert results[0].delta_content == "Hello"
+        assert results[0].delta_tool_calls is None
+        assert results[1].delta_content == " world"
+        assert results[1].finish_reason == "stop"
+        assert results[1].delta_tool_calls is None


### PR DESCRIPTION
## Description

addresses https://github.com/NVIDIA-NeMo/Guardrails/pull/1760#discussion_r3075819901

part of #1760

must be merged after #1773 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses now include complete metadata: reasoning chains, tool calls, model information, finish reasons, request IDs, and token usage statistics
  * Improved tool calling during streaming with better handling of fragmented tool call arguments across multiple chunks
  * Enhanced context preservation and metadata tracking during streaming operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->