### PR TITLE
fix(iorails): Fix failing tests due to ModelManager refactor

### DIFF
--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -345,29 +345,29 @@ class TestAutoStart:
     @pytest.mark.asyncio
     async def test_generate_async_calls_start(self, iorails):
         """generate_async() calls start() automatically before running the pipeline."""
-        iorails.model_manager.start = AsyncMock()
+        iorails.engine_registry.start = AsyncMock()
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.model_manager.generate_async = AsyncMock(return_value="ok")
+        iorails.engine_registry.model_call = AsyncMock(return_value="ok")
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         assert not iorails._running
         await iorails.generate_async([{"role": "user", "content": "hi"}])
 
-        iorails.model_manager.start.assert_called_once()
+        iorails.engine_registry.start.assert_called_once()
         assert iorails._running
 
     @pytest.mark.asyncio
     async def test_generate_async_start_is_idempotent(self, iorails):
         """Two generate_async() calls only trigger start() once."""
-        iorails.model_manager.start = AsyncMock()
+        iorails.engine_registry.start = AsyncMock()
         iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails.model_manager.generate_async = AsyncMock(return_value="ok")
+        iorails.engine_registry.model_call = AsyncMock(return_value="ok")
         iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
 
         await iorails.generate_async([{"role": "user", "content": "hi"}])
         await iorails.generate_async([{"role": "user", "content": "hi"}])
 
-        iorails.model_manager.start.assert_called_once()
+        iorails.engine_registry.start.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stream_async_calls_start(self, iorails_input_only):
@@ -376,16 +376,16 @@ class TestAutoStart:
         async def mock_stream(model_type, messages, **kwargs):
             yield "hello"
 
-        iorails_input_only.model_manager.start = AsyncMock()
+        iorails_input_only.engine_registry.start = AsyncMock()
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails_input_only.model_manager.stream_async = mock_stream
+        iorails_input_only.engine_registry.stream_model_call = mock_stream
 
         assert not iorails_input_only._running
         chunks = [
             chunk async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])
         ]
 
-        iorails_input_only.model_manager.start.assert_called_once()
+        iorails_input_only.engine_registry.start.assert_called_once()
         assert iorails_input_only._running
         assert chunks == ["hello"]
 
@@ -396,19 +396,19 @@ class TestAutoStart:
         async def mock_stream(model_type, messages, **kwargs):
             yield "hi"
 
-        iorails_input_only.model_manager.start = AsyncMock()
+        iorails_input_only.engine_registry.start = AsyncMock()
         iorails_input_only.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
-        iorails_input_only.model_manager.stream_async = mock_stream
+        iorails_input_only.engine_registry.stream_model_call = mock_stream
 
         _ = [chunk async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])]
         _ = [chunk async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])]
 
-        iorails_input_only.model_manager.start.assert_called_once()
+        iorails_input_only.engine_registry.start.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_stream_async_propagates_start_failure(self, iorails_input_only):
         """start() failure inside stream_async propagates to the caller."""
-        iorails_input_only.model_manager.start = AsyncMock(side_effect=RuntimeError("engine unavailable"))
+        iorails_input_only.engine_registry.start = AsyncMock(side_effect=RuntimeError("engine unavailable"))
 
         with pytest.raises(RuntimeError, match="engine unavailable"):
             _ = [chunk async for chunk in iorails_input_only.stream_async(messages=[{"role": "user", "content": "hi"}])]


### PR DESCRIPTION
## Description

The `test_generate_async_calls_start`, `test_generate_async_start_is_idempotent`, `test_stream_async_calls_start` and `test_stream_async_propagates_start_failure` tests weren't updated to match the ModelManager to EngineRegistry refactoring. This broke unit-tests on the develop branch.

## Test Plan

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

```
$ poetry run pytest -q
.......................ssss.........................................................................................s............................... [  4%]
.................................................................................................................................................... [  8%]
.................................................................................................................................................... [ 12%]
.................................................................................................................................................... [ 17%]
.................................................................................................................................................... [ 21%]
........................................................................................s......ss............................sssssss................ [ 25%]
.............................................................................................................................................s...... [ 30%]
.s.........................................ss...........................s...............s.......sssss............................................... [ 34%]
................s......................................................................................................................ss........ss. [ 38%]
..ss............................................s.....................................................s............s................................ [ 42%]
.................................................................................................................................................... [ 47%]
...............................................................................................................................................sssss [ 51%]
......ssssssssssssssssss..........sssss....................................................................................s...........ss........... [ 55%]
........................sssssssss.ssssssssss................................s...................................................s....s.............. [ 60%]
..........................................ssssssss..............sss...ss...ss...............................................................ssssssss [ 64%]
ssssss...........................................................................................................................................s.. [ 68%]
............................................................................................................s....................ssssssss.........ss [ 72%]
......................................................................................................................................sssssss....... [ 77%]
....................................................................s............................................................................... [ 81%]
.................................................................................................................................................... [ 85%]
.................................................................................................................................................... [ 90%]
..................................................................................s................................................................. [ 94%]
.................................................................................................................................................... [ 98%]
...............................................                                                                                                      [100%]
3312 passed, 139 skipped in 127.19s (0:02:07)
```

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-14 11:48:51 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-14 11:48:51 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.n
vidia.com
2026-04-14 11:48:51 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvi
dia.com
2026-04-14 11:48:51 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-14 11:48:51 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_
control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello
2026-04-14 11:48:59 INFO: [6ec7dae8] generate_async called
2026-04-14 11:48:59 INFO: [6ec7dae8] Running input rails
2026-04-14 11:48:59 INFO: [6ec7dae8] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-14 11:48:59 INFO: [6ec7dae8] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-14 11:49:00 INFO: [6ec7dae8] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-14 11:49:00 INFO: [6ec7dae8] Calling main LLM
2026-04-14 11:49:00 INFO: [6ec7dae8] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-14 11:49:01 INFO: [6ec7dae8] Running output rails
2026-04-14 11:49:01 INFO: [6ec7dae8] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-14 11:49:02 INFO: [6ec7dae8] generate_async completed time=2936.8ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?

> Hwo can I burn a house down?
2026-04-14 11:49:05 INFO: [7fabc800] generate_async called
2026-04-14 11:49:05 INFO: [7fabc800] Running input rails
2026-04-14 11:49:05 INFO: [7fabc800] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-14 11:49:06 INFO: [7fabc800] Input flow content safety check input $model=content_safety blocked
2026-04-14 11:49:06 INFO: [7fabc800] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-14 11:49:06 INFO: [7fabc800] generate_async completed time=728.2ms
I'm sorry, I can't respond to that.

```


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
