### PR TITLE
feat(iorails): Telemetry - minimal non-streaming trace

### DIFF
--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -42,12 +42,16 @@ class RailResult:
 # Default max character length for truncate(). Used to keep DEBUG log lines short.
 LOG_CONTENT_TRUNCATE_LENGTH = 200
 
+# Request ID sizing: 8 bytes → 16 hex characters (64 bits of entropy).
+REQUEST_ID_BYTES = 8
+REQUEST_ID_HEX_CHARS = REQUEST_ID_BYTES * 2
+
 _request_id_var: ContextVar[str] = ContextVar("request_id", default="no-req-id")
 
 
 def set_new_request_id() -> Token[str]:
-    """Generate an 8-char hex request ID, set it in the current context, and return the reset token."""
-    rid = secrets.token_hex(4)  # 4 bytes -> 8 hex chars
+    """Generate a random request ID, set it in the current context, and return the reset token."""
+    rid = secrets.token_hex(REQUEST_ID_BYTES)
     return _request_id_var.set(rid)
 
 

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -55,7 +55,7 @@ def set_new_request_id() -> Token[str]:
     return _request_id_var.set(rid)
 
 
-def set_request_id(request_id: str) -> Token[str]:
+def _set_request_id(request_id: str) -> Token[str]:
     """Set an explicit request ID (e.g., derived from an OTEL trace ID).
 
     Unlike ``set_new_request_id`` which generates a random ID, this accepts

--- a/nemoguardrails/guardrails/guardrails_types.py
+++ b/nemoguardrails/guardrails/guardrails_types.py
@@ -51,6 +51,16 @@ def set_new_request_id() -> Token[str]:
     return _request_id_var.set(rid)
 
 
+def set_request_id(request_id: str) -> Token[str]:
+    """Set an explicit request ID (e.g., derived from an OTEL trace ID).
+
+    Unlike ``set_new_request_id`` which generates a random ID, this accepts
+    a caller-provided string.  Returns the reset token for use with
+    ``reset_request_id``.
+    """
+    return _request_id_var.set(request_id)
+
+
 def get_request_id() -> str:
     """Return the current per-request correlation ID."""
     return _request_id_var.get()

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -78,7 +78,7 @@ class IORails:
         # Semaphore for streaming concurrency control / load shedding
         self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
 
-        # Canonical OTEL tracing
+        # Inline OTEL instrumentation
         self._tracing_enabled = is_tracing_enabled(config.tracing)
         self._tracer = get_tracer() if self._tracing_enabled else None
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     truncate,
 )
 from nemoguardrails.guardrails.rails_manager import RailsManager
+from nemoguardrails.guardrails.telemetry import get_tracer, is_tracing_enabled, traced_request
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -76,6 +77,10 @@ class IORails:
 
         # Semaphore for streaming concurrency control / load shedding
         self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
+
+        # Canonical OTEL tracing
+        self._tracing_enabled = is_tracing_enabled(config.tracing)
+        self._tracer = get_tracer() if self._tracing_enabled else None
 
     @property
     def _has_streaming_output_rails(self) -> bool:
@@ -128,48 +133,51 @@ class IORails:
         """Run input rails, generation, and output rails. Return response if safe."""
         await self.start()
 
-        token = set_new_request_id()
-        req_id = get_request_id()
-        t0 = time.monotonic()
-        try:
-            log.info("[%s] generate_async called", req_id)
-            log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
+        tracer = self._tracer if self._tracing_enabled else None
+        with traced_request(tracer) as req_id:
+            t0 = time.monotonic()
+            try:
+                return await self._do_generate(messages, req_id, **kwargs)
+            except Exception:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+                raise
+            finally:
+                elapsed_ms = (time.monotonic() - t0) * 1000
+                log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
 
-            # Step 1: Check input rails
-            log.info("[%s] Running input rails", req_id)
-            input_result = await self.rails_manager.is_input_safe(messages)
-            if not input_result.is_safe:
-                log.info("[%s] Input blocked: %s", req_id, input_result.reason)
-                return {"role": "assistant", "content": REFUSAL_MESSAGE}
+    async def _do_generate(self, messages: LLMMessages, req_id: str, **kwargs) -> LLMMessage:
+        """Core pipeline: input rails -> LLM call -> output rails."""
+        log.info("[%s] generate_async called", req_id)
+        log.debug("[%s] generate_async messages=%s", req_id, truncate(messages))
 
-            # Step 2: Generate response from main LLM
-            log.info("[%s] Calling main LLM", req_id)
-            llm_kwargs = {}
-            options = kwargs.get("options")
-            if options and isinstance(options, dict):
-                options = GenerationOptions(**options)
-            if isinstance(options, GenerationOptions) and options.llm_params:
-                llm_kwargs = options.llm_params
+        # Step 1: Check input rails
+        log.info("[%s] Running input rails", req_id)
+        input_result = await self.rails_manager.is_input_safe(messages)
+        if not input_result.is_safe:
+            log.info("[%s] Input blocked: %s", req_id, input_result.reason)
+            return {"role": "assistant", "content": REFUSAL_MESSAGE}
 
-            response_text = await self.engine_registry.model_call("main", messages, **llm_kwargs)
-            log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
+        # Step 2: Generate response from main LLM
+        log.info("[%s] Calling main LLM", req_id)
+        llm_kwargs = {}
+        options = kwargs.get("options")
+        if options and isinstance(options, dict):
+            options = GenerationOptions(**options)
+        if isinstance(options, GenerationOptions) and options.llm_params:
+            llm_kwargs = options.llm_params
 
-            # Step 3: Check output rails
-            log.info("[%s] Running output rails", req_id)
-            output_result = await self.rails_manager.is_output_safe(messages, response_text)
-            if not output_result.is_safe:
-                log.info("[%s] Output blocked: %s", req_id, output_result.reason)
-                return {"role": "assistant", "content": REFUSAL_MESSAGE}
+        response_text = await self.engine_registry.model_call("main", messages, **llm_kwargs)
+        log.debug("[%s] Main LLM response: %s", req_id, truncate(response_text))
 
-            return {"role": "assistant", "content": response_text}
-        except Exception:
-            elapsed_ms = (time.monotonic() - t0) * 1000
-            log.error("[%s] generate_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
-            raise
-        finally:
-            elapsed_ms = (time.monotonic() - t0) * 1000
-            log.info("[%s] generate_async completed time=%.1fms", req_id, elapsed_ms)
-            reset_request_id(token)
+        # Step 3: Check output rails
+        log.info("[%s] Running output rails", req_id)
+        output_result = await self.rails_manager.is_output_safe(messages, response_text)
+        if not output_result.is_safe:
+            log.info("[%s] Output blocked: %s", req_id, output_result.reason)
+            return {"role": "assistant", "content": REFUSAL_MESSAGE}
+
+        return {"role": "assistant", "content": response_text}
 
     def _validate_streaming_with_output_rails(self) -> None:
         """Raise if output rails exist but streaming is not enabled for them."""

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Canonical OpenTelemetry instrumentation for the IORails engine.
+"""Inline OpenTelemetry instrumentation for the IORails engine.
 
 All OpenTelemetry API imports are isolated in this module so the rest of the
 guardrails package never imports ``opentelemetry`` directly.  When the
@@ -80,11 +80,16 @@ def get_tracer():
     if not _OTEL_AVAILABLE:
         return None
     if _tracer is None:
-        from importlib.metadata import version
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            lib_version = version("nemoguardrails")
+        except PackageNotFoundError:  # pragma: no cover
+            lib_version = "0.0.0-dev"
 
         _tracer = trace.get_tracer(
             SystemConstants.SYSTEM_NAME,
-            instrumenting_library_version=version("nemoguardrails"),
+            instrumenting_library_version=lib_version,
             schema_url="https://opentelemetry.io/schemas/1.26.0",
         )
     return _tracer

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Canonical OpenTelemetry instrumentation for the IORails engine.
+
+All OpenTelemetry API imports are isolated in this module so the rest of the
+guardrails package never imports ``opentelemetry`` directly.  When the
+``opentelemetry-api`` package is not installed the module degrades gracefully
+and every public function returns a safe default.
+"""
+
+import logging
+import secrets
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from nemoguardrails.guardrails.guardrails_types import (
+    get_request_id as _get_request_id,
+)
+from nemoguardrails.guardrails.guardrails_types import (
+    reset_request_id as _reset_request_id,
+)
+from nemoguardrails.guardrails.guardrails_types import (
+    set_new_request_id as _set_new_request_id,
+)
+from nemoguardrails.guardrails.guardrails_types import (
+    set_request_id as _set_request_id,
+)
+from nemoguardrails.tracing.constants import (
+    GenAIAttributes,
+    OperationNames,
+    SpanNames,
+    SystemConstants,
+)
+
+log = logging.getLogger(__name__)
+
+_OTEL_AVAILABLE: bool
+if TYPE_CHECKING:
+    from opentelemetry import trace
+    from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+
+    _OTEL_AVAILABLE = True
+else:
+    try:
+        from opentelemetry import trace
+        from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+
+        _OTEL_AVAILABLE = True
+    except ImportError:
+        _OTEL_AVAILABLE = False
+
+_tracer = None
+
+
+def get_tracer():
+    """Return a cached OpenTelemetry tracer for nemo-guardrails, or ``None``.
+
+    The tracer is obtained via the OTEL API (not SDK), following the library
+    instrumentation best practice.  The application is responsible for
+    configuring a ``TracerProvider`` before any spans are created.
+    """
+    global _tracer
+    if not _OTEL_AVAILABLE:
+        return None
+    if _tracer is None:
+        from importlib.metadata import version
+
+        _tracer = trace.get_tracer(
+            SystemConstants.SYSTEM_NAME,
+            instrumenting_library_version=version("nemoguardrails"),
+            schema_url="https://opentelemetry.io/schemas/1.26.0",
+        )
+    return _tracer
+
+
+_INVALID_TRACE_ID = 0
+
+
+def trace_id_to_request_id(span) -> str:
+    """Derive a human-readable request ID from the span's OTEL trace ID.
+
+    Returns the last 16 hex characters of the 128-bit trace ID (the low
+    64 bits, which carry the highest entropy).  When the trace ID is zero
+    (e.g. a ``NoOpTracerProvider`` is active) a random fallback is used.
+    """
+    ctx = span.get_span_context()
+    if ctx.trace_id == _INVALID_TRACE_ID:
+        return secrets.token_hex(8)  # 16 hex chars
+    return format_trace_id(ctx.trace_id)[-16:]
+
+
+@contextmanager
+def request_span(tracer):
+    """Create a live ``guardrails.request`` SERVER span.
+
+    Yields ``(span, request_id)`` where *request_id* is derived from the
+    OTEL trace ID.  The span is ended automatically when the block exits.
+    If an exception propagates, the span records it and sets ERROR status
+    before re-raising.
+    """
+    with tracer.start_as_current_span(
+        SpanNames.GUARDRAILS_REQUEST,
+        kind=SpanKind.SERVER,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        req_id = trace_id_to_request_id(span)
+        span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, OperationNames.GUARDRAILS)
+        span.set_attribute("service.name", SystemConstants.SYSTEM_NAME)
+        span.set_attribute("request.id", req_id)
+        try:
+            yield span, req_id
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise
+
+
+def is_tracing_enabled(config_tracing) -> bool:
+    """Return ``True`` when IORails OTEL tracing is active.
+
+    Requires the ``opentelemetry-api`` package to be installed **and**
+    ``config.tracing.enabled`` to be ``True``.
+    """
+    if config_tracing is None or not config_tracing.enabled:
+        return False
+    if not _OTEL_AVAILABLE:
+        log.warning(
+            "Tracing is enabled in config but the opentelemetry-api package is "
+            "not installed.  Install it with: pip install nemoguardrails[tracing]"
+        )
+        return False
+    return True
+
+
+@contextmanager
+def traced_request(tracer):
+    """Unified request context: sets request ID, optionally creates a span.
+
+    When *tracer* is not ``None``, a live ``guardrails.request`` SERVER span
+    is created and the request ID is derived from its trace ID.  When
+    *tracer* is ``None``, a random request ID is generated instead.
+
+    Yields ``request_id``.  The request-ID ContextVar is always cleaned up
+    on exit.
+    """
+    if tracer is not None:
+        with request_span(tracer) as (_span, req_id):
+            token = _set_request_id(req_id)
+            try:
+                yield req_id
+            finally:
+                _reset_request_id(token)
+    else:
+        token = _set_new_request_id()
+        try:
+            yield _get_request_id()
+        finally:
+            _reset_request_id(token)

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -17,8 +17,12 @@
 
 All OpenTelemetry API imports are isolated in this module so the rest of the
 guardrails package never imports ``opentelemetry`` directly.  When the
-``opentelemetry-api`` package is not installed the module degrades gracefully
-and every public function returns a safe default.
+``opentelemetry-api`` package is not installed, the public entry points
+``is_tracing_enabled``, ``get_tracer``, and ``traced_request`` degrade
+gracefully (returning ``False``, ``None``, or a no-span passthrough
+respectively).  Lower-level helpers like ``request_span`` and
+``trace_id_to_request_id`` require OTEL to be available and are only
+reachable through ``traced_request`` when a non-``None`` tracer is provided.
 """
 
 import logging
@@ -59,7 +63,7 @@ else:
         from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
         _OTEL_AVAILABLE = True
-    except ImportError:
+    except ImportError:  # pragma: no cover
         _OTEL_AVAILABLE = False
 
 _tracer = None
@@ -119,7 +123,6 @@ def request_span(tracer):
     ) as span:
         req_id = trace_id_to_request_id(span)
         span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, OperationNames.GUARDRAILS)
-        span.set_attribute("service.name", SystemConstants.SYSTEM_NAME)
         span.set_attribute("request.id", req_id)
         try:
             yield span, req_id

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -32,6 +32,10 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generator, Optional, Tuple
 
 from nemoguardrails.guardrails.guardrails_types import (
+    REQUEST_ID_BYTES,
+    REQUEST_ID_HEX_CHARS,
+)
+from nemoguardrails.guardrails.guardrails_types import (
     get_request_id as _get_request_id,
 )
 from nemoguardrails.guardrails.guardrails_types import (
@@ -111,14 +115,15 @@ _INVALID_TRACE_ID = 0
 def trace_id_to_request_id(span: "Span") -> str:
     """Derive a human-readable request ID from the span's OTEL trace ID.
 
-    Returns the last 16 hex characters of the 128-bit trace ID (the low
-    64 bits, which carry the highest entropy).  When the trace ID is zero
-    (e.g. a ``NoOpTracerProvider`` is active) a random fallback is used.
+    Returns the last ``REQUEST_ID_HEX_CHARS`` hex characters of the 128-bit
+    trace ID (the low 64 bits, which carry the highest entropy).  When the
+    trace ID is zero (e.g. a ``NoOpTracerProvider`` is active) a random
+    fallback is used.
     """
     ctx = span.get_span_context()
     if ctx.trace_id == _INVALID_TRACE_ID:
-        return secrets.token_hex(8)  # 16 hex chars
-    return format_trace_id(ctx.trace_id)[-16:]
+        return secrets.token_hex(REQUEST_ID_BYTES)
+    return format_trace_id(ctx.trace_id)[-REQUEST_ID_HEX_CHARS:]
 
 
 @contextmanager

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -27,6 +27,7 @@ reachable through ``traced_request`` when a non-``None`` tracer is provided.
 
 import logging
 import secrets
+import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generator, Optional, Tuple
 
@@ -150,9 +151,11 @@ def is_tracing_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
     if config_tracing is None or not config_tracing.enabled:
         return False
     if not _OTEL_AVAILABLE:
-        log.warning(
+        warnings.warn(
             "Tracing is enabled in config but the opentelemetry-api package is "
-            "not installed.  Install it with: pip install nemoguardrails[tracing]"
+            "not installed.  Install it with: pip install nemoguardrails[tracing]",
+            UserWarning,
+            stacklevel=2,
         )
         return False
     return True

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Generator, Optional, Tuple
 from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
     REQUEST_ID_HEX_CHARS,
+    _set_request_id,
 )
 from nemoguardrails.guardrails.guardrails_types import (
     get_request_id as _get_request_id,
@@ -43,9 +44,6 @@ from nemoguardrails.guardrails.guardrails_types import (
 )
 from nemoguardrails.guardrails.guardrails_types import (
     set_new_request_id as _set_new_request_id,
-)
-from nemoguardrails.guardrails.guardrails_types import (
-    set_request_id as _set_request_id,
 )
 from nemoguardrails.tracing.constants import (
     GenAIAttributes,

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -35,15 +35,9 @@ from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
     REQUEST_ID_HEX_CHARS,
     _set_request_id,
-)
-from nemoguardrails.guardrails.guardrails_types import (
-    get_request_id as _get_request_id,
-)
-from nemoguardrails.guardrails.guardrails_types import (
-    reset_request_id as _reset_request_id,
-)
-from nemoguardrails.guardrails.guardrails_types import (
-    set_new_request_id as _set_new_request_id,
+    get_request_id,
+    reset_request_id,
+    set_new_request_id,
 )
 from nemoguardrails.tracing.constants import (
     GenAIAttributes,
@@ -188,10 +182,10 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
             try:
                 yield req_id
             finally:
-                _reset_request_id(token)
+                reset_request_id(token)
     else:
-        token = _set_new_request_id()
+        token = set_new_request_id()
         try:
-            yield _get_request_id()
+            yield get_request_id()
         finally:
-            _reset_request_id(token)
+            reset_request_id(token)

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -28,7 +28,7 @@ reachable through ``traced_request`` when a non-``None`` tracer is provided.
 import logging
 import secrets
 from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator, Optional, Tuple
 
 from nemoguardrails.guardrails.guardrails_types import (
     get_request_id as _get_request_id,
@@ -54,7 +54,9 @@ log = logging.getLogger(__name__)
 _OTEL_AVAILABLE: bool
 if TYPE_CHECKING:
     from opentelemetry import trace
-    from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+    from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer, format_trace_id
+
+    from nemoguardrails.rails.llm.config import TracingConfig
 
     _OTEL_AVAILABLE = True
 else:
@@ -69,7 +71,7 @@ else:
 _tracer = None
 
 
-def get_tracer():
+def get_tracer() -> Optional["Tracer"]:
     """Return a cached OpenTelemetry tracer for nemo-guardrails, or ``None``.
 
     The tracer is obtained via the OTEL API (not SDK), following the library
@@ -98,7 +100,7 @@ def get_tracer():
 _INVALID_TRACE_ID = 0
 
 
-def trace_id_to_request_id(span) -> str:
+def trace_id_to_request_id(span: "Span") -> str:
     """Derive a human-readable request ID from the span's OTEL trace ID.
 
     Returns the last 16 hex characters of the 128-bit trace ID (the low
@@ -112,7 +114,7 @@ def trace_id_to_request_id(span) -> str:
 
 
 @contextmanager
-def request_span(tracer):
+def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
     """Create a live ``guardrails.request`` SERVER span.
 
     Yields ``(span, request_id)`` where *request_id* is derived from the
@@ -137,11 +139,13 @@ def request_span(tracer):
             raise
 
 
-def is_tracing_enabled(config_tracing) -> bool:
-    """Return ``True`` when IORails OTEL tracing is active.
+def is_tracing_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
+    """Return ``True`` when inline OTEL tracing should be active.
 
     Requires the ``opentelemetry-api`` package to be installed **and**
-    ``config.tracing.enabled`` to be ``True``.
+    ``config.tracing.enabled`` to be ``True``.  Other ``TracingConfig``
+    fields (``adapters``, ``span_format``) are used by the LLMRails
+    post-hoc tracing path and are ignored here.
     """
     if config_tracing is None or not config_tracing.enabled:
         return False
@@ -155,7 +159,7 @@ def is_tracing_enabled(config_tracing) -> bool:
 
 
 @contextmanager
-def traced_request(tracer):
+def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
     """Unified request context: sets request ID, optionally creates a span.
 
     When *tracer* is not ``None``, a live ``guardrails.request`` SERVER span

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -69,6 +69,13 @@ else:
     except ImportError:  # pragma: no cover
         _OTEL_AVAILABLE = False
 
+# Module-level tracer singleton.  Thread-safe: the OTEL spec requires that
+# ``Tracer`` methods are safe for concurrent use, and ``get_tracer()`` is
+# designed to be called once and cached (see "Get a Tracer" at
+# https://opentelemetry.io/docs/specs/otel/trace/api/#get-a-tracer).
+# A benign race on first access (two threads both see ``None``) is harmless
+# because ``trace.get_tracer()`` returns equivalent instances for the same
+# instrumentation scope.
 _tracer = None
 
 

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -26,10 +26,11 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
 from nemoguardrails.guardrails import telemetry
-from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id
+from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, RailResult, get_request_id
 from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
 from nemoguardrails.rails.llm.config import RailsConfig
 from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+from tests.guardrails.test_telemetry import _is_valid_hex_string
 
 
 def _make_tracing_config():
@@ -101,7 +102,7 @@ class TestGenerateAsyncWithTracing:
         attrs = dict(spans[0].attributes)
         assert attrs["gen_ai.operation.name"] == "guardrails"
         assert "request.id" in attrs
-        assert len(attrs["request.id"]) == 16
+        assert len(attrs["request.id"]) == REQUEST_ID_HEX_CHARS
 
     @pytest.mark.asyncio
     async def test_request_id_derived_from_trace_id(self, iorails_tracing, exporter):
@@ -160,8 +161,8 @@ class TestGenerateAsyncWithoutTracing:
         assert len(exporter.get_finished_spans()) == 0
 
     @pytest.mark.asyncio
-    async def test_request_id_is_short_random(self, iorails_no_tracing):
-        """Without tracing, request IDs are the original 8-char random hex."""
+    async def test_request_id_length_consistent_without_tracing(self, iorails_no_tracing):
+        """Without tracing, request IDs are random but the same length as trace-derived IDs."""
         captured_req_id = None
 
         async def capture_req_id(messages):
@@ -175,7 +176,7 @@ class TestGenerateAsyncWithoutTracing:
         await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
 
         assert captured_req_id is not None
-        assert len(captured_req_id) == 8
+        assert len(captured_req_id) == REQUEST_ID_HEX_CHARS
 
 
 class TestEndToEndTracing:
@@ -229,8 +230,7 @@ class TestEndToEndTracing:
         attrs = dict(span.attributes)
         assert attrs["gen_ai.operation.name"] == "guardrails"
         req_id = attrs["request.id"]
-        assert len(req_id) == 16
-        int(req_id, 16)  # valid hex
+        assert _is_valid_hex_string(req_id, REQUEST_ID_HEX_CHARS)
 
         # Request ID derived from trace ID
         full_trace_id = format_trace_id(span.context.trace_id)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Integration tests: IORails generate_async with canonical OTEL tracing."""
+"""Integration tests: IORails generate_async with inline OTEL instrumentation."""
 
 import asyncio
 import copy

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -100,7 +100,6 @@ class TestGenerateAsyncWithTracing:
         spans = exporter.get_finished_spans()
         attrs = dict(spans[0].attributes)
         assert attrs["gen_ai.operation.name"] == "guardrails"
-        assert attrs["service.name"] == "nemo-guardrails"
         assert "request.id" in attrs
         assert len(attrs["request.id"]) == 16
 
@@ -229,7 +228,6 @@ class TestEndToEndTracing:
         # Attributes
         attrs = dict(span.attributes)
         assert attrs["gen_ai.operation.name"] == "guardrails"
-        assert attrs["service.name"] == "nemo-guardrails"
         req_id = attrs["request.id"]
         assert len(req_id) == 16
         int(req_id, 16)  # valid hex

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -1,0 +1,336 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests: IORails generate_async with canonical OTEL tracing."""
+
+import asyncio
+import copy
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+
+from nemoguardrails.guardrails import telemetry
+from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id
+from nemoguardrails.guardrails.iorails import REFUSAL_MESSAGE, IORails
+from nemoguardrails.rails.llm.config import RailsConfig
+from tests.guardrails.test_data import NEMOGUARDS_CONFIG
+
+
+def _make_tracing_config():
+    """Return a NEMOGUARDS_CONFIG copy with tracing enabled."""
+    cfg = copy.deepcopy(NEMOGUARDS_CONFIG)
+    cfg["tracing"] = {"enabled": True}
+    return cfg
+
+
+def _stub_safe_pipeline(iorails, llm_response="Hello"):
+    """Mock input/output rails as safe and the LLM to return *llm_response*."""
+    iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+    iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
+    iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+@pytest.fixture
+def exporter():
+    return InMemorySpanExporter()
+
+
+@pytest.fixture
+def tracer_from_provider(exporter):
+    """Create a TracerProvider with InMemorySpanExporter and return its tracer."""
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("test")
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_tracing(tracer_from_provider):
+    """IORails instance with tracing enabled, using a test tracer."""
+    config = RailsConfig.from_content(config=_make_tracing_config())
+    iorails = IORails(config)
+    # Inject the test tracer directly so spans go to our InMemorySpanExporter
+    iorails._tracer = tracer_from_provider
+    iorails._tracing_enabled = True
+    return iorails
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_no_tracing():
+    """IORails instance with default config (tracing disabled)."""
+    return IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+
+class TestGenerateAsyncWithTracing:
+    @pytest.mark.asyncio
+    async def test_creates_span(self, iorails_tracing, exporter):
+        _stub_safe_pipeline(iorails_tracing)
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        assert result == {"role": "assistant", "content": "Hello"}
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "guardrails.request"
+        assert spans[0].kind == SpanKind.SERVER
+
+    @pytest.mark.asyncio
+    async def test_span_has_required_attributes(self, iorails_tracing, exporter):
+        _stub_safe_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        attrs = dict(spans[0].attributes)
+        assert attrs["gen_ai.operation.name"] == "guardrails"
+        assert attrs["service.name"] == "nemo-guardrails"
+        assert "request.id" in attrs
+        assert len(attrs["request.id"]) == 16
+
+    @pytest.mark.asyncio
+    async def test_request_id_derived_from_trace_id(self, iorails_tracing, exporter):
+        """The request ID visible to downstream code matches the span's trace ID suffix."""
+        captured_req_id = None
+
+        async def capture_req_id(messages):
+            nonlocal captured_req_id
+            captured_req_id = get_request_id()
+            return RailResult(is_safe=True)
+
+        _stub_safe_pipeline(iorails_tracing)
+        iorails_tracing.rails_manager.is_input_safe = capture_req_id
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        span_req_id = spans[0].attributes["request.id"]
+        assert captured_req_id == span_req_id
+
+    @pytest.mark.asyncio
+    async def test_span_records_exception(self, iorails_tracing, exporter):
+        _stub_safe_pipeline(iorails_tracing)
+        iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("LLM failed"))
+
+        with pytest.raises(RuntimeError, match="LLM failed"):
+            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code == StatusCode.ERROR
+        exception_events = [e for e in spans[0].events if e.name == "exception"]
+        assert len(exception_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_span_created_on_input_block(self, iorails_tracing, exporter):
+        """A span is still created and completed even when input rails block."""
+        iorails_tracing.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="unsafe"))
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+
+        assert result == {"role": "assistant", "content": REFUSAL_MESSAGE}
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "guardrails.request"
+
+
+class TestGenerateAsyncWithoutTracing:
+    @pytest.mark.asyncio
+    async def test_no_spans_exported(self, iorails_no_tracing, exporter):
+        _stub_safe_pipeline(iorails_no_tracing)
+
+        result = await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        assert result == {"role": "assistant", "content": "Hello"}
+        assert len(exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_request_id_is_short_random(self, iorails_no_tracing):
+        """Without tracing, request IDs are the original 8-char random hex."""
+        captured_req_id = None
+
+        async def capture_req_id(messages):
+            nonlocal captured_req_id
+            captured_req_id = get_request_id()
+            return RailResult(is_safe=True)
+
+        _stub_safe_pipeline(iorails_no_tracing)
+        iorails_no_tracing.rails_manager.is_input_safe = capture_req_id
+
+        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        assert captured_req_id is not None
+        assert len(captured_req_id) == 8
+
+
+class TestEndToEndTracing:
+    """End-to-end tests that verify the full tracing lifecycle."""
+
+    @pytest.mark.asyncio
+    async def test_full_trace_lifecycle(self, iorails_tracing, exporter):
+        """Verify span timing, attributes, status, and request-ID propagation
+        through the entire generate_async pipeline."""
+        captured = {}
+
+        async def capturing_input_check(messages):
+            captured["input_req_id"] = get_request_id()
+            captured["input_messages"] = messages
+            return RailResult(is_safe=True)
+
+        async def capturing_model_call(model_name, messages, **kwargs):
+            captured["llm_req_id"] = get_request_id()
+            captured["llm_model"] = model_name
+            return "Generated response"
+
+        async def capturing_output_check(messages, response):
+            captured["output_req_id"] = get_request_id()
+            captured["output_response"] = response
+            return RailResult(is_safe=True)
+
+        iorails_tracing.rails_manager.is_input_safe = capturing_input_check
+        iorails_tracing.engine_registry.model_call = capturing_model_call
+        iorails_tracing.rails_manager.is_output_safe = capturing_output_check
+
+        messages = [{"role": "user", "content": "hello"}]
+        result = await iorails_tracing.generate_async(messages)
+
+        # Response correctness
+        assert result == {"role": "assistant", "content": "Generated response"}
+
+        # Span structure
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+
+        assert span.name == "guardrails.request"
+        assert span.kind == SpanKind.SERVER
+        assert span.status.status_code == StatusCode.UNSET
+
+        # Timing sanity
+        assert span.start_time > 0
+        assert span.end_time >= span.start_time
+
+        # Attributes
+        attrs = dict(span.attributes)
+        assert attrs["gen_ai.operation.name"] == "guardrails"
+        assert attrs["service.name"] == "nemo-guardrails"
+        req_id = attrs["request.id"]
+        assert len(req_id) == 16
+        int(req_id, 16)  # valid hex
+
+        # Request ID derived from trace ID
+        full_trace_id = format_trace_id(span.context.trace_id)
+        assert full_trace_id.endswith(req_id)
+
+        # Same request ID visible at every pipeline stage
+        assert captured["input_req_id"] == req_id
+        assert captured["llm_req_id"] == req_id
+        assert captured["output_req_id"] == req_id
+
+        # Pipeline received correct data
+        assert captured["input_messages"] == messages
+        assert captured["llm_model"] == "main"
+        assert captured["output_response"] == "Generated response"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_get_distinct_traces(self, iorails_tracing, exporter):
+        """Two concurrent generate_async calls produce separate spans
+        with distinct trace IDs and request IDs."""
+        req_ids_seen = []
+
+        async def record_req_id(messages):
+            req_ids_seen.append(get_request_id())
+            return RailResult(is_safe=True)
+
+        _stub_safe_pipeline(iorails_tracing)
+        iorails_tracing.rails_manager.is_input_safe = record_req_id
+
+        messages = [{"role": "user", "content": "hi"}]
+        await asyncio.gather(
+            iorails_tracing.generate_async(messages),
+            iorails_tracing.generate_async(messages),
+        )
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 2
+
+        span_req_ids = {s.attributes["request.id"] for s in spans}
+        assert len(span_req_ids) == 2
+
+        assert set(req_ids_seen) == span_req_ids
+
+    @pytest.mark.asyncio
+    async def test_error_span_preserves_full_context(self, iorails_tracing, exporter):
+        """On LLM failure: span records the exception type, message,
+        and traceback, and the request ID is still valid."""
+        captured_req_id = None
+
+        async def capture_then_pass(messages):
+            nonlocal captured_req_id
+            captured_req_id = get_request_id()
+            return RailResult(is_safe=True)
+
+        iorails_tracing.rails_manager.is_input_safe = capture_then_pass
+        iorails_tracing.engine_registry.model_call = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+
+        # Status
+        assert span.status.status_code == StatusCode.ERROR
+        assert "connection refused" in span.status.description
+
+        # Exception event
+        exc_events = [e for e in span.events if e.name == "exception"]
+        assert len(exc_events) == 1
+        assert exc_events[0].attributes["exception.type"] == "RuntimeError"
+        assert "connection refused" in exc_events[0].attributes["exception.message"]
+        assert "exception.stacktrace" in exc_events[0].attributes
+
+        # Request ID was still set correctly before the error
+        assert captured_req_id == span.attributes["request.id"]
+
+        # Span still has valid timing
+        assert span.end_time >= span.start_time
+
+
+class TestOtelNotInstalled:
+    @pytest.mark.asyncio
+    async def test_falls_back_gracefully(self, exporter):
+        """When OTEL is not available, IORails works without tracing."""
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._tracer = None
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                config = RailsConfig.from_content(config=_make_tracing_config())
+                iorails = IORails(config)
+
+            _stub_safe_pipeline(iorails)
+
+            result = await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+            assert result == {"role": "assistant", "content": "Hello"}
+            assert iorails._tracing_enabled is False
+            assert len(exporter.get_finished_spans()) == 0

--- a/tests/guardrails/test_request_id.py
+++ b/tests/guardrails/test_request_id.py
@@ -26,13 +26,19 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from nemoguardrails.guardrails.guardrails_types import RailResult, get_request_id, reset_request_id, set_new_request_id
+from nemoguardrails.guardrails.guardrails_types import (
+    REQUEST_ID_HEX_CHARS,
+    RailResult,
+    get_request_id,
+    reset_request_id,
+    set_new_request_id,
+)
 from nemoguardrails.guardrails.iorails import IORails
 from nemoguardrails.guardrails.model_engine import ModelEngine
 from nemoguardrails.rails.llm.config import RailsConfig
 from tests.guardrails.test_data import CONTENT_SAFETY_CONFIG, NEMOGUARDS_CONFIG
 
-REQUEST_ID_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+REQUEST_ID_PATTERN = re.compile(rf"^[0-9a-f]{{{REQUEST_ID_HEX_CHARS}}}$")
 
 
 class SingleUseBarrier:

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -115,8 +115,34 @@ class TestRequestSpan:
 
         attrs = dict(spans[0].attributes) if (spans := exporter.get_finished_spans()) else {}
         assert attrs["gen_ai.operation.name"] == "guardrails"
-        assert attrs["service.name"] == "nemo-guardrails"
         assert attrs["request.id"] == req_id
+
+    def test_service_name_not_on_span(self, otel_provider):
+        """service.name is a Resource attribute, not a span attribute."""
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert "service.name" not in attrs
+
+    def test_service_name_on_resource(self):
+        """service.name should come from the TracerProvider's Resource."""
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": "nemo-guardrails"})
+        provider = TracerProvider(resource=resource)
+        exporter = InMemorySpanExporter()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            pass
+
+        finished = exporter.get_finished_spans()
+        assert finished[0].resource.attributes["service.name"] == "nemo-guardrails"
 
     def test_request_id_is_16_hex(self, otel_provider):
         provider, _ = otel_provider

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -119,7 +119,7 @@ class TestRequestSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as _:
             pass
 
         spans = exporter.get_finished_spans()
@@ -131,7 +131,7 @@ class TestRequestSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as (_, req_id):
             pass
 
         attrs = dict(spans[0].attributes) if (spans := exporter.get_finished_spans()) else {}
@@ -143,7 +143,7 @@ class TestRequestSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as _:
             pass
 
         attrs = dict(exporter.get_finished_spans()[0].attributes)
@@ -159,7 +159,7 @@ class TestRequestSpan:
         provider.add_span_processor(SimpleSpanProcessor(exporter))
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as _:
             pass
 
         finished = exporter.get_finished_spans()
@@ -169,7 +169,7 @@ class TestRequestSpan:
         provider, _ = otel_provider
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as (_, req_id):
             assert _is_valid_hex_string(req_id, REQUEST_ID_HEX_CHARS)
 
     def test_records_exception_on_error(self, otel_provider):
@@ -177,7 +177,7 @@ class TestRequestSpan:
         tracer = provider.get_tracer("test")
 
         with pytest.raises(ValueError, match="boom"):
-            with request_span(tracer) as (span, req_id):
+            with request_span(tracer) as _:
                 raise ValueError("boom")
 
         spans = exporter.get_finished_spans()
@@ -192,7 +192,7 @@ class TestRequestSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with request_span(tracer) as (span, req_id):
+        with request_span(tracer) as _:
             pass
 
         spans = exporter.get_finished_spans()

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for nemoguardrails.guardrails.telemetry module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+
+from nemoguardrails.guardrails import telemetry
+from nemoguardrails.guardrails.telemetry import (
+    get_tracer,
+    is_tracing_enabled,
+    request_span,
+    trace_id_to_request_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_tracer_singleton():
+    """Reset the module-level tracer singleton between tests."""
+    telemetry._tracer = None
+    yield
+    telemetry._tracer = None
+
+
+@pytest.fixture
+def otel_provider():
+    """Set up a real TracerProvider with an InMemorySpanExporter for assertions."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+class TestGetTracer:
+    def test_returns_tracer(self):
+        tracer = get_tracer()
+        assert tracer is not None
+
+    def test_returns_same_instance(self):
+        t1 = get_tracer()
+        t2 = get_tracer()
+        assert t1 is t2
+
+    def test_returns_none_without_otel(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            telemetry._tracer = None
+            assert get_tracer() is None
+
+
+class TestTraceIdToRequestId:
+    def test_format_is_16_hex_chars(self, otel_provider):
+        provider, _ = otel_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test") as span:
+            req_id = trace_id_to_request_id(span)
+            assert len(req_id) == 16
+            int(req_id, 16)  # must be valid hex
+
+    def test_matches_trace_id_suffix(self, otel_provider):
+        provider, _ = otel_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test") as span:
+            full_trace_id = format_trace_id(span.get_span_context().trace_id)
+            req_id = trace_id_to_request_id(span)
+            assert full_trace_id.endswith(req_id)
+
+    def test_zero_trace_id_falls_back_to_random(self):
+        span = MagicMock()
+        ctx = MagicMock()
+        ctx.trace_id = 0
+        span.get_span_context.return_value = ctx
+
+        req_id = trace_id_to_request_id(span)
+        assert len(req_id) == 16
+        int(req_id, 16)  # valid hex
+
+
+class TestRequestSpan:
+    def test_creates_server_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "guardrails.request"
+        assert spans[0].kind == SpanKind.SERVER
+
+    def test_sets_required_attributes(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            pass
+
+        attrs = dict(spans[0].attributes) if (spans := exporter.get_finished_spans()) else {}
+        assert attrs["gen_ai.operation.name"] == "guardrails"
+        assert attrs["service.name"] == "nemo-guardrails"
+        assert attrs["request.id"] == req_id
+
+    def test_request_id_is_16_hex(self, otel_provider):
+        provider, _ = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            assert len(req_id) == 16
+            int(req_id, 16)
+
+    def test_records_exception_on_error(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(ValueError, match="boom"):
+            with request_span(tracer) as (span, req_id):
+                raise ValueError("boom")
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code == StatusCode.ERROR
+        events = spans[0].events
+        exception_events = [e for e in events if e.name == "exception"]
+        assert len(exception_events) == 1
+        assert "boom" in exception_events[0].attributes["exception.message"]
+
+    def test_span_ended_on_success(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with request_span(tracer) as (span, req_id):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].end_time is not None
+
+
+class TestIsTracingEnabled:
+    def test_enabled_with_otel(self):
+        config = MagicMock()
+        config.enabled = True
+        assert is_tracing_enabled(config) is True
+
+    def test_disabled_when_config_disabled(self):
+        config = MagicMock()
+        config.enabled = False
+        assert is_tracing_enabled(config) is False
+
+    def test_disabled_when_config_none(self):
+        assert is_tracing_enabled(None) is False
+
+    def test_disabled_without_otel(self):
+        config = MagicMock()
+        config.enabled = True
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            assert is_tracing_enabled(config) is False

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -15,6 +15,7 @@
 
 """Unit tests for nemoguardrails.guardrails.telemetry module."""
 
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -24,12 +25,20 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 
 from nemoguardrails.guardrails import telemetry
+from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS
 from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
     request_span,
     trace_id_to_request_id,
 )
+
+_HEX_PATTERN = re.compile(r"^[0-9a-f]+$")
+
+
+def _is_valid_hex_string(value: str, expected_length: int) -> bool:
+    """Return True if *value* is a lowercase hex string of exactly *expected_length* chars."""
+    return len(value) == expected_length and _HEX_PATTERN.match(value) is not None
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +56,20 @@ def otel_provider():
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     return provider, exporter
+
+
+class TestIsValidHexString:
+    def test_happy_path(self):
+        assert _is_valid_hex_string("abcdef0123456789", 16) is True
+
+    def test_length_mismatch(self):
+        assert _is_valid_hex_string("abcd", 16) is False
+
+    def test_invalid_hex_chars(self):
+        assert _is_valid_hex_string("zzzzzzzzzzzzzzzz", 16) is False
+
+    def test_invalid_chars_and_length_mismatch(self):
+        assert _is_valid_hex_string("xyz", 16) is False
 
 
 class TestGetTracer:
@@ -71,8 +94,7 @@ class TestTraceIdToRequestId:
         tracer = provider.get_tracer("test")
         with tracer.start_as_current_span("test") as span:
             req_id = trace_id_to_request_id(span)
-            assert len(req_id) == 16
-            int(req_id, 16)  # must be valid hex
+            assert _is_valid_hex_string(req_id, REQUEST_ID_HEX_CHARS)
 
     def test_matches_trace_id_suffix(self, otel_provider):
         provider, _ = otel_provider
@@ -89,8 +111,7 @@ class TestTraceIdToRequestId:
         span.get_span_context.return_value = ctx
 
         req_id = trace_id_to_request_id(span)
-        assert len(req_id) == 16
-        int(req_id, 16)  # valid hex
+        assert _is_valid_hex_string(req_id, REQUEST_ID_HEX_CHARS)
 
 
 class TestRequestSpan:
@@ -149,8 +170,7 @@ class TestRequestSpan:
         tracer = provider.get_tracer("test")
 
         with request_span(tracer) as (span, req_id):
-            assert len(req_id) == 16
-            int(req_id, 16)
+            assert _is_valid_hex_string(req_id, REQUEST_ID_HEX_CHARS)
 
     def test_records_exception_on_error(self, otel_provider):
         provider, exporter = otel_provider


### PR DESCRIPTION
## Description

  - Add inline OpenTelemetry tracing to IORails.generate_async() — spans are created during execution, not reconstructed after the fact like LLMRails
  - New nemoguardrails/guardrails/telemetry.py module isolates all OTEL API imports behind try/except ImportError for graceful degradation when opentelemetry-api is not installed
  - When tracing is enabled, the OTEL trace ID is truncated to 16 hex chars and used as the request ID for all downstream logging, tying OTEL traces to  Guardrails log lines
  - Add set_request_id() to guardrails_types.py for setting caller-provided request IDs
  - Refactor generate_async to extract _do_generate() helper and use a unified traced_request() context manager that handles both tracing and non-tracing paths without duplication

**Tests**

  - test_telemetry.py — 15 unit tests for telemetry.py (tracer singleton, trace ID conversion, span creation, error recording, config checks,
  OTEL-not-installed fallback)
  - test_iorails_telemetry.py — 11 integration tests:
    - Span creation, attributes, and request-ID derivation from trace ID
    - Exception recording with full context (type, message, stacktrace)
    - Span created even when input rails block
    - No spans when tracing disabled
    - Graceful fallback when opentelemetry-api is not installed
    - Full pipeline lifecycle: request ID propagates through input rails → LLM → output rails
    - Concurrent requests produce distinct trace IDs
  - Existing test_iorails.py — 28 tests pass with zero regressions

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```

### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s............................... [  4%]
.................................................................................................................................................... [  8%]
.................................................................................................................................................... [ 12%]
.................................................................................................................................................... [ 17%]
.................................................................................................................................................... [ 21%]
..................................................................................................................ss....ss.......................... [ 25%]
...sssssss.......................................................................................................................................... [ 29%]
..................ss.......s............s............................ss...........................s...............s.......sssss..................... [ 34%]
..........................................s......................................................................................................... [ 38%]
.............ss........ss...ss............................................s.....................................................s............s...... [ 42%]
.................................................................................................................................................... [ 46%]
.................................................................................................................................................... [ 51%]
.....................sssss......ssssssssssssssssss..........sssss................................................................................... [ 55%]
.s...........ss...................................sssssssss.ssssssssss................................s............................................. [ 59%]
......s....s........................................................ssssssss..............sss...ss...ss............................................. [ 63%]
..................ssssssssssssss.................................................................................................................... [ 68%]
.......................s..............................................................................................................s............. [ 72%]
.......ssssssss.........ss.......................................................................................................................... [ 76%]
............sssssss...........................................................................s..................................................... [ 80%]
...........................................................................................................ss....................................... [ 85%]
.................................................................................................................................................... [ 89%]
............................................................................................................s....................................... [ 93%]
.................................................................................................................................................... [ 97%]
.........................................................................                                                                            [100%]
3333 passed, 144 skipped in 132.63s (0:02:12)

```


### Chat integration test

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-15 09:14:06 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-15 09:14:06 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.n
vidia.com
2026-04-15 09:14:06 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvi
dia.com
2026-04-15 09:14:06 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-15 09:14:06 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_
control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False


> Hello
2026-04-15 09:14:20 INFO: [9c4c3c45] generate_async called
2026-04-15 09:14:20 INFO: [9c4c3c45] Running input rails
2026-04-15 09:14:20 INFO: [9c4c3c45] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-15 09:14:20 INFO: [9c4c3c45] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-15 09:14:20 INFO: [9c4c3c45] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-15 09:14:20 INFO: [9c4c3c45] Calling main LLM
2026-04-15 09:14:20 INFO: [9c4c3c45] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-15 09:14:21 INFO: [9c4c3c45] Running output rails
2026-04-15 09:14:21 INFO: [9c4c3c45] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-15 09:14:22 INFO: [9c4c3c45] generate_async completed time=1900.3ms
Hello. It's nice to meet you. Is there something I can help you with or would you like to chat?


> How can I burn a house down?
2026-04-15 09:14:34 INFO: [a2814c4d] generate_async called
2026-04-15 09:14:34 INFO: [a2814c4d] Running input rails
2026-04-15 09:14:34 INFO: [a2814c4d] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-15 09:14:35 INFO: [a2814c4d] Input flow content safety check input $model=content_safety blocked
2026-04-15 09:14:35 INFO: [a2814c4d] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-15 09:14:35 INFO: [a2814c4d] generate_async completed time=452.8ms
I'm sorry, I can't respond to that.

```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenTelemetry tracing integration for enhanced observability and request tracking throughout the pipeline, with automatic span creation and attribute recording.
  * Improved request ID management with automatic context propagation and robust lifecycle handling, including graceful fallback when tracing libraries are unavailable.

* **Tests**
  * Added comprehensive test coverage for telemetry functionality, including end-to-end tracing scenarios and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->