### PR TITLE
feat(iorails): Telemetry - full non-streaming trace

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -153,6 +153,8 @@ class EngineRegistry:
             KeyError: If no engine is registered with the given name.
             TypeError: If the named engine is not a ModelEngine.
         """
+        # TODO Streaming instrumentation handled in follow-on PR
+
         req_id = get_request_id()
         log.debug("[%s] Model engine '%s' stream messages: %s", req_id, model_type, truncate(messages))
 

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -138,7 +138,7 @@ class EngineRegistry:
 
         engine = self._get_engine(model_type, ModelEngine)
         tracer = get_tracer()
-        with llm_call_span(tracer, engine.model_name, model_type, engine.model_config.engine or "unknown"):
+        with llm_call_span(tracer, engine.model_name, engine.model_config.engine or "unknown"):
             result = await engine.chat_completion(messages, **kwargs)
 
         log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -27,6 +27,7 @@ from nemoguardrails.guardrails.api_engine import APIEngine
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
+from nemoguardrails.guardrails.telemetry import api_call_span, get_tracer, llm_call_span
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
 
 log = logging.getLogger(__name__)
@@ -136,7 +137,9 @@ class EngineRegistry:
         log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_engine(model_type, ModelEngine)
-        result = await engine.chat_completion(messages, **kwargs)
+        tracer = get_tracer()
+        with llm_call_span(tracer, engine.model_name, model_type, engine.model_config.engine or "unknown"):
+            result = await engine.chat_completion(messages, **kwargs)
 
         log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))
         return result
@@ -167,8 +170,10 @@ class EngineRegistry:
         req_id = get_request_id()
         log.debug("[%s] API engine '%s' request: %s", req_id, api_name, truncate(message))
 
-        api_engine = self._get_engine(api_name, APIEngine)
-        response = await api_engine.call(message, **kwargs)
+        tracer = get_tracer()
+        with api_call_span(tracer, api_name):
+            api_engine = self._get_engine(api_name, APIEngine)
+            response = await api_engine.call(message, **kwargs)
 
         log.debug("[%s] API engine '%s' response: %s", req_id, api_name, truncate(response))
         return response

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -21,14 +21,17 @@ model type. Each engine owns its own RetryClient with per-model settings.
 
 import logging
 from collections.abc import AsyncGenerator
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, TypeVar
 
 from nemoguardrails.guardrails.api_engine import APIEngine
 from nemoguardrails.guardrails.base_engine import BaseEngine
 from nemoguardrails.guardrails.guardrails_types import get_request_id, truncate
 from nemoguardrails.guardrails.model_engine import ModelEngine
-from nemoguardrails.guardrails.telemetry import api_call_span, get_tracer, llm_call_span
+from nemoguardrails.guardrails.telemetry import api_call_span, llm_call_span
 from nemoguardrails.rails.llm.config import Model, RailsConfigData
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
 
 log = logging.getLogger(__name__)
 
@@ -42,10 +45,20 @@ class EngineRegistry:
     Each engine owns its own HTTP client with per-model retry and timeout settings.
     """
 
-    def __init__(self, models: list[Model], rails_config_data: RailsConfigData) -> None:
-        """Build one engine per configured model and API service."""
+    def __init__(
+        self,
+        models: list[Model],
+        rails_config_data: RailsConfigData,
+        tracer: Optional["Tracer"] = None,
+    ) -> None:
+        """Build one engine per configured model and API service.
+
+        When *tracer* is provided, LLM and API calls produce OTEL spans; when
+        ``None`` the span helpers become no-ops.
+        """
         self._engines: dict[str, BaseEngine] = {}
         self._running = False
+        self._tracer = tracer
 
         for model_config in models:
             engine = ModelEngine(model_config)
@@ -137,8 +150,7 @@ class EngineRegistry:
         log.debug("[%s] Model engine '%s' messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_engine(model_type, ModelEngine)
-        tracer = get_tracer()
-        with llm_call_span(tracer, engine.model_name, engine.model_config.engine or "unknown"):
+        with llm_call_span(self._tracer, engine.model_name, engine.model_config.engine or "unknown"):
             result = await engine.chat_completion(messages, **kwargs)
 
         log.debug("[%s] Model engine '%s' response: %s", req_id, model_type, truncate(result))
@@ -172,8 +184,7 @@ class EngineRegistry:
         req_id = get_request_id()
         log.debug("[%s] API engine '%s' request: %s", req_id, api_name, truncate(message))
 
-        tracer = get_tracer()
-        with api_call_span(tracer, api_name):
+        with api_call_span(self._tracer, api_name):
             api_engine = self._get_engine(api_name, APIEngine)
             response = await api_engine.call(message, **kwargs)
 

--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -181,8 +181,10 @@ class EngineRegistry:
         return response
 
     async def __aenter__(self):
+        """Async context manager entry: start all engine clients."""
         await self.start()
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit: stop all engine clients."""
         await self.stop()

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -281,6 +281,8 @@ class IORails:
 
         async def _wrapped_iterator():
             """Wrap the base iterator with semaphore-based concurrency control."""
+            # TODO Streaming instrumentation handled in follow-on PR
+
             # Ensure engines are running (idempotent if already started).
             await self.start()
 

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -65,7 +65,12 @@ class IORails:
         self._running = False
         self.config = config
 
-        self.engine_registry = EngineRegistry(config.models, config.rails.config)
+        # Create the OTEL tracer (if enabled in config).
+        # Pass to EngineRegistry and RailsManager to keep all spans consistent under parent
+        self._tracing_enabled = is_tracing_enabled(config.tracing)
+        self._tracer = get_tracer() if self._tracing_enabled else None
+
+        self.engine_registry = EngineRegistry(config.models, config.rails.config, tracer=self._tracer)
         self.rails_manager = RailsManager(
             engine_registry=self.engine_registry,
             task_manager=LLMTaskManager(config),
@@ -73,14 +78,11 @@ class IORails:
             output_flows=config.rails.output.flows,
             input_parallel=config.rails.input.parallel or False,
             output_parallel=config.rails.output.parallel or False,
+            tracer=self._tracer,
         )
 
         # Semaphore for streaming concurrency control / load shedding
         self._stream_semaphore = asyncio.Semaphore(STREAM_MAX_CONCURRENCY)
-
-        # Inline OTEL instrumentation
-        self._tracing_enabled = is_tracing_enabled(config.tracing)
-        self._tracer = get_tracer() if self._tracing_enabled else None
 
     @property
     def _has_streaming_output_rails(self) -> bool:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -124,6 +124,7 @@ class IORails:
         """Synchronous version of generate_async."""
 
         async def _run_sync_iorails():
+            """Spin up a short-lived IORails engine for one synchronous generate call."""
             async with IORails(self.config) as iorails_engine:
                 return await iorails_engine.generate_async(messages, **kwargs)
 

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from nemoguardrails.guardrails.engine_registry import EngineRegistry
 from nemoguardrails.guardrails.guardrails_types import (
@@ -33,9 +33,12 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
     truncate,
 )
-from nemoguardrails.guardrails.telemetry import action_span, get_tracer, record_span_error
+from nemoguardrails.guardrails.telemetry import action_span, record_span_error
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
 
 log = logging.getLogger(__name__)
 
@@ -59,10 +62,16 @@ class RailAction(ABC):
     fallback_model: Optional[str] = None
     requires_model: bool = True
 
-    def __init__(self, engine_registry: EngineRegistry, task_manager: LLMTaskManager) -> None:
-        """Store the engine registry and task manager for use by subclass hooks."""
+    def __init__(
+        self,
+        engine_registry: EngineRegistry,
+        task_manager: LLMTaskManager,
+        tracer: Optional["Tracer"] = None,
+    ) -> None:
+        """Store the engine registry, task manager, and optional tracer for subclass hooks."""
         self.engine_registry = engine_registry
         self.task_manager = task_manager
+        self._tracer = tracer
 
     async def run(
         self,
@@ -71,8 +80,7 @@ class RailAction(ABC):
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Execute the full rail pipeline and return a safety result."""
-        tracer = get_tracer()
-        with action_span(tracer, self.action_name) as span:
+        with action_span(self._tracer, self.action_name) as span:
             req_id = get_request_id()
             base_flow = _get_flow_name(flow)
             self._validate_flow_name(base_flow)

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -33,6 +33,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
     truncate,
 )
+from nemoguardrails.guardrails.telemetry import action_span, get_tracer
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
 
@@ -70,28 +71,30 @@ class RailAction(ABC):
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Execute the full rail pipeline and return a safety result."""
-        req_id = get_request_id()
-        base_flow = _get_flow_name(flow)
-        self._validate_flow_name(base_flow)
+        tracer = get_tracer()
+        with action_span(tracer, self.action_name):
+            req_id = get_request_id()
+            base_flow = _get_flow_name(flow)
+            self._validate_flow_name(base_flow)
 
-        model_type = self._get_model_type(flow)
-        if self.requires_model and not model_type:
-            raise RuntimeError(f"No $model= specified for '{base_flow}' and no fallback_model defined")
+            model_type = self._get_model_type(flow)
+            if self.requires_model and not model_type:
+                raise RuntimeError(f"No $model= specified for '{base_flow}' and no fallback_model defined")
 
-        extracted = self._extract_messages(messages, bot_response)
-        log.debug("[%s] %s extracted: %s", req_id, base_flow, truncate(extracted))
+            extracted = self._extract_messages(messages, bot_response)
+            log.debug("[%s] %s extracted: %s", req_id, base_flow, truncate(extracted))
 
-        prompt = self._create_prompt(model_type, extracted)
-        if prompt is not None:
-            log.debug("[%s] %s prompt: %s", req_id, base_flow, truncate(prompt))
+            prompt = self._create_prompt(model_type, extracted)
+            if prompt is not None:
+                log.debug("[%s] %s prompt: %s", req_id, base_flow, truncate(prompt))
 
-        try:
-            response = await self._get_response(model_type, prompt)
-            log.debug("[%s] %s response: %s", req_id, base_flow, truncate(response))
-            return self._parse_response(response)
-        except Exception as e:
-            log.error("[%s] %s failed: %s", req_id, base_flow, e)
-            return RailResult(is_safe=False, reason=f"{base_flow} error: {e}")
+            try:
+                response = await self._get_response(model_type, prompt)
+                log.debug("[%s] %s response: %s", req_id, base_flow, truncate(response))
+                return self._parse_response(response)
+            except Exception as e:
+                log.error("[%s] %s failed: %s", req_id, base_flow, e)
+                return RailResult(is_safe=False, reason=f"{base_flow} error: {e}")
 
     def _get_model_type(self, flow: str) -> Optional[str]:
         """Extract model from the flow's ``$model=`` parameter, falling back to :attr:`fallback_model`."""

--- a/nemoguardrails/guardrails/rail_action.py
+++ b/nemoguardrails/guardrails/rail_action.py
@@ -33,7 +33,7 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
     truncate,
 )
-from nemoguardrails.guardrails.telemetry import action_span, get_tracer
+from nemoguardrails.guardrails.telemetry import action_span, get_tracer, record_span_error
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_model, _get_flow_name
 
@@ -72,7 +72,7 @@ class RailAction(ABC):
     ) -> RailResult:
         """Execute the full rail pipeline and return a safety result."""
         tracer = get_tracer()
-        with action_span(tracer, self.action_name):
+        with action_span(tracer, self.action_name) as span:
             req_id = get_request_id()
             base_flow = _get_flow_name(flow)
             self._validate_flow_name(base_flow)
@@ -93,6 +93,8 @@ class RailAction(ABC):
                 log.debug("[%s] %s response: %s", req_id, base_flow, truncate(response))
                 return self._parse_response(response)
             except Exception as e:
+                # Record an error on the OTEL span
+                record_span_error(span, e)
                 log.error("[%s] %s failed: %s", req_id, base_flow, e)
                 return RailResult(is_safe=False, reason=f"{base_flow} error: {e}")
 

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -117,7 +117,7 @@ class RailsManager:
         if not self.input_flows:
             return RailResult(is_safe=True)
 
-        rails = {flow: self._run_rail(flow, messages) for flow in self.input_flows}
+        rails = {flow: self._run_rail(flow, RailDirection.INPUT, messages) for flow in self.input_flows}
         if self.input_parallel:
             return await self._run_rails_parallel(rails, RailDirection.INPUT)
         return await self._run_rails_sequential(rails, RailDirection.INPUT)
@@ -131,7 +131,10 @@ class RailsManager:
         if not self.output_flows:
             return RailResult(is_safe=True)
 
-        rails = {flow: self._run_rail(flow, messages, bot_response=response) for flow in self.output_flows}
+        rails = {
+            flow: self._run_rail(flow, RailDirection.OUTPUT, messages, bot_response=response)
+            for flow in self.output_flows
+        }
         if self.output_parallel:
             return await self._run_rails_parallel(rails, RailDirection.OUTPUT)
         return await self._run_rails_sequential(rails, RailDirection.OUTPUT)
@@ -139,12 +142,12 @@ class RailsManager:
     async def _run_rail(
         self,
         flow: str,
+        direction: RailDirection,
         messages: list[dict],
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Dispatch a single rail flow to its RailAction instance."""
         tracer = get_tracer()
-        direction = RailDirection.INPUT if flow in self.input_flows else RailDirection.OUTPUT
         with rail_span(tracer, flow, direction) as span:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -39,8 +39,10 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
 )
 from nemoguardrails.guardrails.rail_action import RailAction
+from nemoguardrails.guardrails.telemetry import get_tracer, rail_span
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_name
+from nemoguardrails.tracing.constants import GuardrailsAttributes
 
 log = logging.getLogger(__name__)
 
@@ -141,8 +143,14 @@ class RailsManager:
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Dispatch a single rail flow to its RailAction instance."""
-        action = self._actions[flow]
-        return await action.run(flow, messages, bot_response)
+        tracer = get_tracer()
+        direction = RailDirection.INPUT if flow in self.input_flows else RailDirection.OUTPUT
+        with rail_span(tracer, flow, direction) as span:
+            action = self._actions[flow]
+            result = await action.run(flow, messages, bot_response)
+            if span is not None and not result.is_safe:
+                span.set_attribute(GuardrailsAttributes.RAIL_STOP, True)
+            return result
 
     async def _run_rails_sequential(
         self,

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -39,10 +39,9 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
 )
 from nemoguardrails.guardrails.rail_action import RailAction
-from nemoguardrails.guardrails.telemetry import rail_span
+from nemoguardrails.guardrails.telemetry import mark_rail_stop, rail_span
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_name
-from nemoguardrails.tracing.constants import GuardrailsAttributes
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Tracer
@@ -159,8 +158,7 @@ class RailsManager:
         with rail_span(self._tracer, flow, direction) as span:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)
-            if span is not None and not result.is_safe:
-                span.set_attribute(GuardrailsAttributes.RAIL_STOP, True)
+            mark_rail_stop(span, result.is_safe)
             return result
 
     async def _run_rails_sequential(

--- a/nemoguardrails/guardrails/rails_manager.py
+++ b/nemoguardrails/guardrails/rails_manager.py
@@ -24,7 +24,7 @@ unsafe result cancels remaining rails immediately.
 import asyncio
 import logging
 from collections.abc import Coroutine, Mapping
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from nemoguardrails.guardrails.actions.content_safety_action import (
     ContentSafetyInputAction,
@@ -39,10 +39,13 @@ from nemoguardrails.guardrails.guardrails_types import (
     get_request_id,
 )
 from nemoguardrails.guardrails.rail_action import RailAction
-from nemoguardrails.guardrails.telemetry import get_tracer, rail_span
+from nemoguardrails.guardrails.telemetry import rail_span
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.config import _get_flow_name
 from nemoguardrails.tracing.constants import GuardrailsAttributes
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Tracer
 
 log = logging.getLogger(__name__)
 
@@ -75,10 +78,16 @@ class RailsManager:
         output_flows: list[str],
         input_parallel: bool = False,
         output_parallel: bool = False,
+        tracer: Optional["Tracer"] = None,
     ) -> None:
-        """Build RailAction instances for each configured input and output flow."""
+        """Build RailAction instances for each configured input and output flow.
+
+        When *tracer* is provided, rail and action executions produce OTEL
+        spans; when ``None`` the span helpers become no-ops.
+        """
         self.engine_registry = engine_registry
         self.task_manager = task_manager
+        self._tracer = tracer
 
         self.input_flows: list[str] = list(input_flows)
         self.output_flows: list[str] = list(output_flows)
@@ -106,7 +115,7 @@ class RailsManager:
         if action_cls is None:
             available = sorted(_ACTION_CLASSES.keys())
             raise RuntimeError(f"Rail flow '{base_name}' not supported. Available: {available}")
-        return action_cls(self.engine_registry, self.task_manager)
+        return action_cls(self.engine_registry, self.task_manager, tracer=self._tracer)
 
     async def is_input_safe(self, messages: list[dict]) -> RailResult:
         """Run all enabled input rails, short-circuiting on the first failure.
@@ -147,8 +156,7 @@ class RailsManager:
         bot_response: Optional[str] = None,
     ) -> RailResult:
         """Dispatch a single rail flow to its RailAction instance."""
-        tracer = get_tracer()
-        with rail_span(tracer, flow, direction) as span:
+        with rail_span(self._tracer, flow, direction) as span:
             action = self._actions[flow]
             result = await action.run(flow, messages, bot_response)
             if span is not None and not result.is_safe:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -120,6 +120,19 @@ def trace_id_to_request_id(span: "Span") -> str:
     return format_trace_id(ctx.trace_id)[-REQUEST_ID_HEX_CHARS:]
 
 
+def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
+    """Record an exception on an OTEL span and set its status to ERROR.
+
+    Safe to call with ``None`` (no-op).  Use when a caller catches an
+    exception that would otherwise propagate out of a ``*_span`` context
+    manager, e.g. when converting a raised error into a return value.
+    """
+    if span is None:
+        return
+    span.record_exception(exc)
+    span.set_status(StatusCode.ERROR, str(exc))
+
+
 @contextmanager
 def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
     """Create a live ``guardrails.request`` SERVER span.

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -234,6 +234,12 @@ def llm_call_span(
     """Create a CLIENT span for an LLM call following GenAI semantic conventions.
 
     Span name follows the OTEL pattern: ``"{operation_name} {model_name}"``.
+
+    ``operation_name`` defaults to ``"chat"`` because IORails only issues
+    chat completions. In the future if any other non-chat LLM  operations are
+    supported, callers should pass an explicit ``operation_name`` from the
+    OTEL GenAI semantic conventions.
+
     Yields the span (or ``None`` when *tracer* is ``None``).
     """
     if tracer is None:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -245,9 +245,12 @@ def llm_call_span(
 
 @contextmanager
 def api_call_span(tracer: Optional["Tracer"], api_name: str) -> Generator[Optional["Span"], None, None]:
-    """Create a CLIENT span for an API call (e.g., jailbreak detection).
+    """Create a CLIENT span for a non-LLM API call (e.g., jailbreak detection).
 
-    Yields the span (or ``None`` when *tracer* is ``None``).
+    Uses the ``api.name`` attribute rather than ``gen_ai.operation.name``
+    because these APIs are plain HTTP endpoints, not GenAI operations.
+    ``http.*`` transport attributes can be added additively later without
+    conflict.  Yields the span (or ``None`` when *tracer* is ``None``).
     """
     if tracer is None:
         yield None
@@ -259,7 +262,7 @@ def api_call_span(tracer: Optional["Tracer"], api_name: str) -> Generator[Option
         record_exception=False,
         set_status_on_exception=False,
     ) as span:
-        span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, "api")
+        span.set_attribute(GuardrailsAttributes.API_NAME, api_name)
         try:
             yield span
         except Exception as exc:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -216,7 +216,6 @@ def action_span(tracer: Optional["Tracer"], action_name: str) -> Generator[Optio
 def llm_call_span(
     tracer: Optional["Tracer"],
     model_name: str,
-    model_type: str,
     provider_name: str,
     operation_name: str = "chat",
 ) -> Generator[Optional["Span"], None, None]:

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -135,6 +135,19 @@ def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
     span.set_status(StatusCode.ERROR, str(exc))
 
 
+def mark_rail_stop(span: Optional["Span"], is_safe: bool) -> None:
+    """Set ``rail.stop=True`` on a rail span when the rail blocked the request.
+
+    Safe to call with ``None`` (no-op) so callers don't have to branch on
+    whether a real span was produced — matches the ``record_span_error``
+    idiom.  Only marks stop when *is_safe* is ``False``; a passing rail
+    leaves the attribute unset.
+    """
+    if span is None or is_safe:
+        return
+    span.set_attribute(GuardrailsAttributes.RAIL_STOP, True)
+
+
 @contextmanager
 def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
     """Create a live ``guardrails.request`` SERVER span.

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Generator, Optional, Tuple
 from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
     REQUEST_ID_HEX_CHARS,
+    RailDirection,
     _set_request_id,
     get_request_id,
     reset_request_id,
@@ -41,6 +42,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 )
 from nemoguardrails.tracing.constants import (
     GenAIAttributes,
+    GuardrailsAttributes,
     OperationNames,
     SpanNames,
     SystemConstants,
@@ -139,6 +141,120 @@ def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
         try:
             yield span, req_id
         except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise
+
+
+@contextmanager
+def rail_span(
+    tracer: Optional["Tracer"], flow: str, direction: RailDirection
+) -> Generator[Optional["Span"], None, None]:
+    """Create a ``guardrails.rail`` INTERNAL span for a single rail execution.
+
+    Yields the span (or ``None`` when *tracer* is ``None``).
+    The caller should set ``rail.stop`` on the span after execution if the
+    rail blocked the request.
+    """
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(
+        SpanNames.GUARDRAILS_RAIL,
+        kind=SpanKind.INTERNAL,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute(GuardrailsAttributes.RAIL_TYPE, direction.value)
+        span.set_attribute(GuardrailsAttributes.RAIL_NAME, flow)
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise
+
+
+@contextmanager
+def action_span(tracer: Optional["Tracer"], action_name: str) -> Generator[Optional["Span"], None, None]:
+    """Create a ``guardrails.action`` INTERNAL span for a rail action execution.
+
+    Yields the span (or ``None`` when *tracer* is ``None``).
+    """
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(
+        SpanNames.GUARDRAILS_ACTION,
+        kind=SpanKind.INTERNAL,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute(GuardrailsAttributes.ACTION_NAME, action_name)
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise
+
+
+@contextmanager
+def llm_call_span(
+    tracer: Optional["Tracer"],
+    model_name: str,
+    model_type: str,
+    provider_name: str,
+    operation_name: str = "chat",
+) -> Generator[Optional["Span"], None, None]:
+    """Create a CLIENT span for an LLM call following GenAI semantic conventions.
+
+    Span name follows the OTEL pattern: ``"{operation_name} {model_name}"``.
+    Yields the span (or ``None`` when *tracer* is ``None``).
+    """
+    if tracer is None:
+        yield None
+        return
+    span_name = f"{operation_name} {model_name}"
+    with tracer.start_as_current_span(
+        span_name,
+        kind=SpanKind.CLIENT,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, operation_name)
+        span.set_attribute(GenAIAttributes.GEN_AI_REQUEST_MODEL, model_name)
+        span.set_attribute(GenAIAttributes.GEN_AI_PROVIDER_NAME, provider_name)
+        try:
+            yield span
+        except Exception as exc:
+            span.set_attribute("error.type", type(exc).__name__)
+            span.record_exception(exc)
+            span.set_status(StatusCode.ERROR, str(exc))
+            raise
+
+
+@contextmanager
+def api_call_span(tracer: Optional["Tracer"], api_name: str) -> Generator[Optional["Span"], None, None]:
+    """Create a CLIENT span for an API call (e.g., jailbreak detection).
+
+    Yields the span (or ``None`` when *tracer* is ``None``).
+    """
+    if tracer is None:
+        yield None
+        return
+    span_name = f"api {api_name}"
+    with tracer.start_as_current_span(
+        span_name,
+        kind=SpanKind.CLIENT,
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute(GenAIAttributes.GEN_AI_OPERATION_NAME, "api")
+        try:
+            yield span
+        except Exception as exc:
+            span.set_attribute("error.type", type(exc).__name__)
             span.record_exception(exc)
             span.set_status(StatusCode.ERROR, str(exc))
             raise

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -293,7 +293,7 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
     on exit.
     """
     if tracer is not None:
-        with request_span(tracer) as (_span, req_id):
+        with request_span(tracer) as (_, req_id):
             token = _set_request_id(req_id)
             try:
                 yield req_id

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -123,12 +123,14 @@ def trace_id_to_request_id(span: "Span") -> str:
 def record_span_error(span: Optional["Span"], exc: BaseException) -> None:
     """Record an exception on an OTEL span and set its status to ERROR.
 
-    Safe to call with ``None`` (no-op).  Use when a caller catches an
-    exception that would otherwise propagate out of a ``*_span`` context
-    manager, e.g. when converting a raised error into a return value.
+    Also sets the ``error.type`` attribute to the exception's class name
+    (per OTEL GenAI conditional-required convention).  Safe to call with
+    ``None`` (no-op).  Use from every span helper's ``except`` block and
+    from callers that swallow exceptions before they can propagate.
     """
     if span is None:
         return
+    span.set_attribute("error.type", type(exc).__name__)
     span.record_exception(exc)
     span.set_status(StatusCode.ERROR, str(exc))
 
@@ -154,8 +156,7 @@ def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
         try:
             yield span, req_id
         except Exception as exc:
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
+            record_span_error(span, exc)
             raise
 
 
@@ -183,8 +184,7 @@ def rail_span(
         try:
             yield span
         except Exception as exc:
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
+            record_span_error(span, exc)
             raise
 
 
@@ -207,8 +207,7 @@ def action_span(tracer: Optional["Tracer"], action_name: str) -> Generator[Optio
         try:
             yield span
         except Exception as exc:
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
+            record_span_error(span, exc)
             raise
 
 
@@ -240,9 +239,7 @@ def llm_call_span(
         try:
             yield span
         except Exception as exc:
-            span.set_attribute("error.type", type(exc).__name__)
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
+            record_span_error(span, exc)
             raise
 
 
@@ -266,9 +263,7 @@ def api_call_span(tracer: Optional["Tracer"], api_name: str) -> Generator[Option
         try:
             yield span
         except Exception as exc:
-            span.set_attribute("error.type", type(exc).__name__)
-            span.record_exception(exc)
-            span.set_status(StatusCode.ERROR, str(exc))
+            record_span_error(span, exc)
             raise
 
 

--- a/nemoguardrails/tracing/constants.py
+++ b/nemoguardrails/tracing/constants.py
@@ -121,6 +121,9 @@ class GuardrailsAttributes:
     ACTION_LLM_CALLS_COUNT = "action.llm_calls_count"
     ACTION_PARAM_PREFIX = "action.param."
 
+    # api call attributes (non-LLM HTTP APIs such as jailbreak detection)
+    API_NAME = "api.name"
+
     # llm attributes (application-level, not provider-level)
     LLM_CACHE_HIT = "llm.cache.hit"
 

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -426,6 +426,120 @@ class TestSpanHierarchy:
         assert len(blocked) >= 1
 
     @pytest.mark.asyncio
+    async def test_span_hierarchy_on_unsafe_request(self, iorails_tracing, exporter):
+        """Unsafe request: main LLM and output rails never run, request span still completes cleanly."""
+        _stub_deep_pipeline(iorails_tracing, input_safe=False)
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        spans = exporter.get_finished_spans()
+
+        # Request span still completes without error (blocking is not an exception)
+        request_spans = [s for s in spans if s.name == "guardrails.request"]
+        assert len(request_spans) == 1
+        assert request_spans[0].status.status_code == StatusCode.UNSET
+
+        # Output rail spans must be absent (pipeline short-circuits before Step 3)
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        output_rails = [s for s in rail_spans if s.attributes["rail.type"] == "Output"]
+        assert output_rails == []
+
+        # Main LLM span must be absent — the meta/llama main model is never called
+        main_llm_spans = [
+            s
+            for s in spans
+            if s.kind == SpanKind.CLIENT and s.attributes.get("gen_ai.request.model", "").startswith("meta/llama")
+        ]
+        assert main_llm_spans == []
+
+        # The blocking rail's span is marked with rail.stop=True
+        blocked = [s for s in rail_spans if s.attributes.get("rail.stop") is True]
+        assert len(blocked) >= 1
+
+    @pytest.mark.asyncio
+    async def test_span_tree_parent_child_links(self, iorails_tracing, exporter):
+        """Verify strict parent-child links across the full safe-path span tree.
+
+        Uses sequential rail execution (NEMOGUARDS_CONFIG default). Every span
+        must (a) share the same trace_id, (b) have a unique span_id, and
+        (c) point to a valid ancestor per the expected shape:
+
+            guardrails.request (SERVER, parent=None)
+              ├─ guardrails.rail [Input]   → parent=request
+              │   └─ guardrails.action     → parent=its rail
+              │       └─ CLIENT span       → parent=its action
+              ├─ chat <main model>  (CLIENT, parent=request)
+              └─ guardrails.rail [Output]  → parent=request
+                  └─ guardrails.action     → parent=its rail
+                      └─ CLIENT span       → parent=its action
+        """
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+
+        # All spans share a single trace_id
+        trace_ids = {s.context.trace_id for s in spans}
+        assert len(trace_ids) == 1
+
+        # All span_ids are unique
+        span_ids = [s.context.span_id for s in spans]
+        assert len(span_ids) == len(set(span_ids))
+
+        # Index spans by ID for parent lookup
+        by_id = {s.context.span_id: s for s in spans}
+
+        # Exactly one root — the request span — with parent=None
+        roots = [s for s in spans if s.parent is None]
+        assert len(roots) == 1
+        request_span = roots[0]
+        assert request_span.name == "guardrails.request"
+        assert request_span.kind == SpanKind.SERVER
+
+        # Every non-root span's parent resolves to another span in the same trace
+        for span in spans:
+            if span.parent is None:
+                continue
+            assert span.parent.trace_id == request_span.context.trace_id
+            assert span.parent.span_id in by_id, f"{span.name}'s parent not in trace"
+
+        # Each guardrails.rail is a direct child of the request span
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        assert len(rail_spans) == 4  # 3 input + 1 output
+        for rail in rail_spans:
+            assert rail.parent.span_id == request_span.context.span_id
+
+        # Each guardrails.action is a direct child of exactly one rail
+        action_spans = [s for s in spans if s.name == "guardrails.action"]
+        assert len(action_spans) == 4
+        rail_ids = {r.context.span_id for r in rail_spans}
+        for action in action_spans:
+            assert action.parent.span_id in rail_ids, (
+                f"action '{action.attributes['action.name']}' parent is not a rail span"
+            )
+
+        # Each CLIENT span is either the main LLM (parent=request)
+        # or a rail-LLM/API call (parent=one of the action spans)
+        client_spans = [s for s in spans if s.kind == SpanKind.CLIENT]
+        action_ids = {a.context.span_id for a in action_spans}
+        main_llm_spans = []
+        rail_call_spans = []
+        for client in client_spans:
+            if client.parent.span_id == request_span.context.span_id:
+                main_llm_spans.append(client)
+            elif client.parent.span_id in action_ids:
+                rail_call_spans.append(client)
+            else:
+                raise AssertionError(f"CLIENT span '{client.name}' has unexpected parent")
+
+        # Exactly one main LLM call, and one CLIENT span per action
+        assert len(main_llm_spans) == 1
+        assert main_llm_spans[0].attributes["gen_ai.request.model"] == "meta/llama-3.3-70b-instruct"
+        assert len(rail_call_spans) == len(action_spans)
+
+    @pytest.mark.asyncio
     async def test_action_span_attributes(self, iorails_tracing, exporter):
         """Action spans have correct action.name attributes."""
         _stub_deep_pipeline(iorails_tracing)

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -74,10 +74,8 @@ def iorails_tracing(tracer_from_provider):
         iorails = IORails(config)
     iorails._tracer = tracer_from_provider
     iorails._tracing_enabled = True
-    old_tracer = telemetry._tracer
-    telemetry._tracer = tracer_from_provider
-    yield iorails
-    telemetry._tracer = old_tracer
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        yield iorails
 
 
 @pytest.fixture

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -590,13 +590,13 @@ class TestSpanHierarchy:
         await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
 
         spans = exporter.get_finished_spans()
-        # Find a content_safety LLM span (not the main LLM)
         llm_spans = [s for s in spans if "gen_ai.request.model" in (s.attributes or {})]
-        assert len(llm_spans) >= 1
-
-        # Check one has the expected model attributes
         models_seen = {s.attributes["gen_ai.request.model"] for s in llm_spans}
-        assert "nvidia/llama-3.1-nemoguard-8b-content-safety" in models_seen or len(models_seen) > 0
+
+        # Every LLM span from the NEMOGUARDS_CONFIG pipeline must have its model recorded
+        assert "nvidia/llama-3.1-nemoguard-8b-content-safety" in models_seen
+        assert "nvidia/llama-3.1-nemoguard-8b-topic-control" in models_seen
+        assert "meta/llama-3.3-70b-instruct" in models_seen
 
     @pytest.mark.asyncio
     async def test_no_child_spans_when_tracing_disabled(self, iorails_no_tracing, exporter):

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -65,16 +65,14 @@ def tracer_from_provider(exporter):
 def iorails_tracing(tracer_from_provider):
     """IORails instance with tracing enabled, using a test tracer.
 
-    Also injects the tracer into the telemetry module singleton so that
-    child spans created via get_tracer() in RailsManager/RailAction/EngineRegistry
-    go to the same InMemorySpanExporter.
+    Patches the module-level ``_tracer`` before constructing IORails so that
+    ``IORails.__init__`` picks up the test tracer via ``get_tracer()`` and
+    threads it through EngineRegistry/RailsManager/RailAction constructors.
     """
-    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
-        config = RailsConfig.from_content(config=_make_tracing_config())
-        iorails = IORails(config)
-    iorails._tracer = tracer_from_provider
-    iorails._tracing_enabled = True
     with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_make_tracing_config())
+            iorails = IORails(config)
         yield iorails
 
 
@@ -603,15 +601,41 @@ class TestSpanHierarchy:
         """With tracing disabled, no spans at all are created.
 
         Uses ``_stub_deep_pipeline`` so the full RailsManager → RailAction →
-        EngineRegistry chain executes (including every ``get_tracer()`` call
-        site).  This exercises the code paths that would otherwise create
-        orphaned child spans, not just the top-level IORails entry point.
+        EngineRegistry chain executes.  This exercises the code paths that
+        would otherwise create orphaned child spans, not just the top-level
+        IORails entry point.
         """
         _stub_deep_pipeline(iorails_no_tracing)
 
         await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
 
         assert len(exporter.get_finished_spans()) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_orphaned_child_spans_with_global_provider(self, tracer_from_provider, exporter):
+        """Regression: with a working TracerProvider wired to an exporter but
+        ``config.tracing.enabled=False``, no child spans must leak through.
+
+        Previously ``EngineRegistry``/``RailsManager``/``RailAction`` called
+        ``get_tracer()`` directly, which would return a real tracer whenever
+        the host app had a global provider — producing orphaned rail/action/LLM
+        spans with no parent ``guardrails.request`` span.  Threading the tracer
+        through constructors means every helper uses ``self._tracer``, which
+        is ``None`` when tracing is disabled.
+        """
+        # Install the exporter-backed tracer as the module singleton, so any
+        # accidental get_tracer() call in the pipeline would emit to it.
+        with patch.object(telemetry, "_tracer", tracer_from_provider):
+            with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+                # tracing NOT enabled in this config
+                iorails = IORails(RailsConfig.from_content(config=NEMOGUARDS_CONFIG))
+
+            _stub_deep_pipeline(iorails)
+
+            await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        # Zero spans of any kind
+        assert exporter.get_finished_spans() == ()
 
 
 class TestOtelNotInstalled:

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -458,6 +458,36 @@ class TestSpanHierarchy:
         assert len(blocked) >= 1
 
     @pytest.mark.asyncio
+    async def test_action_span_records_engine_error(self, iorails_tracing, exporter):
+        """When the engine raises, the action span must record it (not swallow it)."""
+        from nemoguardrails.guardrails.model_engine import ModelEngine
+
+        # Make the content_safety engine fail — RailAction.run will catch and
+        # convert to RailResult(is_safe=False), but the action span must still
+        # reflect the error.
+        for name, engine in iorails_tracing.engine_registry._engines.items():
+            if isinstance(engine, ModelEngine) and name == "content_safety":
+                engine.chat_completion = AsyncMock(side_effect=RuntimeError("LLM down"))
+            elif isinstance(engine, ModelEngine):
+                engine.chat_completion = AsyncMock(return_value=SAFE_INPUT_JSON)
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        spans = exporter.get_finished_spans()
+        action_spans = [s for s in spans if s.name == "guardrails.action"]
+        content_safety_action = next(
+            s for s in action_spans if s.attributes["action.name"] == "content safety check input"
+        )
+
+        # Span has ERROR status and an exception event recording the RuntimeError
+        assert content_safety_action.status.status_code == StatusCode.ERROR
+        exc_events = [e for e in content_safety_action.events if e.name == "exception"]
+        assert len(exc_events) == 1
+        assert exc_events[0].attributes["exception.type"] == "RuntimeError"
+        assert "LLM down" in exc_events[0].attributes["exception.message"]
+
+    @pytest.mark.asyncio
     async def test_span_tree_parent_child_links(self, iorails_tracing, exporter):
         """Verify strict parent-child links across the full safe-path span tree.
 

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import copy
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -61,15 +62,22 @@ def tracer_from_provider(exporter):
 
 
 @pytest.fixture
-@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
 def iorails_tracing(tracer_from_provider):
-    """IORails instance with tracing enabled, using a test tracer."""
-    config = RailsConfig.from_content(config=_make_tracing_config())
-    iorails = IORails(config)
-    # Inject the test tracer directly so spans go to our InMemorySpanExporter
+    """IORails instance with tracing enabled, using a test tracer.
+
+    Also injects the tracer into the telemetry module singleton so that
+    child spans created via get_tracer() in RailsManager/RailAction/EngineRegistry
+    go to the same InMemorySpanExporter.
+    """
+    with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+        config = RailsConfig.from_content(config=_make_tracing_config())
+        iorails = IORails(config)
     iorails._tracer = tracer_from_provider
     iorails._tracing_enabled = True
-    return iorails
+    old_tracer = telemetry._tracer
+    telemetry._tracer = tracer_from_provider
+    yield iorails
+    telemetry._tracer = old_tracer
 
 
 @pytest.fixture
@@ -313,6 +321,149 @@ class TestEndToEndTracing:
 
         # Span still has valid timing
         assert span.end_time >= span.start_time
+
+
+SAFE_INPUT_JSON = json.dumps({"User Safety": "safe"})
+SAFE_OUTPUT_JSON = json.dumps({"User Safety": "safe", "Response Safety": "safe"})
+UNSAFE_INPUT_JSON = json.dumps({"User Safety": "unsafe", "Safety Categories": "S1: Violence"})
+
+
+def _stub_deep_pipeline(iorails, main_llm_response="Hello", input_safe=True):
+    """Mock at the engine level so the full RailsManager → RailAction → EngineRegistry
+    chain executes (including span creation), but actual HTTP calls are skipped.
+
+    Mocks ModelEngine.chat_completion and APIEngine.call on each registered engine.
+    The content_safety engine returns different JSON for input vs output checks —
+    we use SAFE_INPUT_JSON as default since the output rail's parser also accepts it
+    when Response Safety is absent (it just checks User Safety).
+    """
+    from nemoguardrails.guardrails.api_engine import APIEngine
+    from nemoguardrails.guardrails.model_engine import ModelEngine
+
+    input_json = SAFE_INPUT_JSON if input_safe else UNSAFE_INPUT_JSON
+    for name, engine in iorails.engine_registry._engines.items():
+        if isinstance(engine, ModelEngine):
+            if name == "main":
+                engine.chat_completion = AsyncMock(return_value=main_llm_response)
+            elif name == "content_safety":
+                # Content safety output parser needs Response Safety field
+                engine.chat_completion = AsyncMock(return_value=SAFE_OUTPUT_JSON if input_safe else input_json)
+            else:
+                engine.chat_completion = AsyncMock(return_value=input_json)
+        elif isinstance(engine, APIEngine):
+            engine.call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
+
+
+class TestSpanHierarchy:
+    """Tests that verify parent-child span relationships across the full pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_span_hierarchy_on_safe_request(self, iorails_tracing, exporter):
+        """Full safe request produces: request → rail → action → LLM/API spans."""
+        _stub_deep_pipeline(iorails_tracing)
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+        assert result["content"] == "Hello"
+
+        spans = exporter.get_finished_spans()
+
+        # Find the root request span
+        request_spans = [s for s in spans if s.name == "guardrails.request"]
+        assert len(request_spans) == 1
+        root = request_spans[0]
+        root_ctx = root.context
+
+        # Rail spans should exist for input and output rails
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        # 3 input rails + 1 output rail = 4
+        assert len(rail_spans) == 4
+
+        # Action spans should be nested under rail spans
+        action_spans = [s for s in spans if s.name == "guardrails.action"]
+        assert len(action_spans) == 4
+
+        # LLM call spans (content_safety input, topic_safety input, content_safety output, main LLM)
+        llm_spans = [s for s in spans if s.kind == SpanKind.CLIENT]
+        assert len(llm_spans) >= 4  # at least 3 rail LLMs + 1 API + 1 main
+
+        # All rail spans are children of the request span
+        for rail_span in rail_spans:
+            assert rail_span.parent.trace_id == root_ctx.trace_id
+
+    @pytest.mark.asyncio
+    async def test_rail_span_attributes(self, iorails_tracing, exporter):
+        """Rail spans have correct rail.type and rail.name attributes."""
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+
+        input_rails = [s for s in rail_spans if s.attributes["rail.type"] == "Input"]
+        output_rails = [s for s in rail_spans if s.attributes["rail.type"] == "Output"]
+        assert len(input_rails) == 3
+        assert len(output_rails) == 1
+
+        rail_names = {s.attributes["rail.name"] for s in rail_spans}
+        assert "content safety check input $model=content_safety" in rail_names
+        assert "topic safety check input $model=topic_control" in rail_names
+        assert "jailbreak detection model" in rail_names
+        assert "content safety check output $model=content_safety" in rail_names
+
+    @pytest.mark.asyncio
+    async def test_rail_stop_attribute_on_block(self, iorails_tracing, exporter):
+        """When a rail blocks, its span has rail.stop=True."""
+        _stub_deep_pipeline(iorails_tracing, input_safe=False)
+
+        result = await iorails_tracing.generate_async([{"role": "user", "content": "bad"}])
+        assert result["content"] == REFUSAL_MESSAGE
+
+        spans = exporter.get_finished_spans()
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        # First rail blocked → should have rail.stop
+        blocked = [s for s in rail_spans if s.attributes.get("rail.stop") is True]
+        assert len(blocked) >= 1
+
+    @pytest.mark.asyncio
+    async def test_action_span_attributes(self, iorails_tracing, exporter):
+        """Action spans have correct action.name attributes."""
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        action_spans = [s for s in spans if s.name == "guardrails.action"]
+        action_names = {s.attributes["action.name"] for s in action_spans}
+        assert "content safety check input" in action_names
+        assert "topic safety check input" in action_names
+        assert "jailbreak detection model" in action_names
+        assert "content safety check output" in action_names
+
+    @pytest.mark.asyncio
+    async def test_llm_span_attributes(self, iorails_tracing, exporter):
+        """LLM spans have GenAI semantic convention attributes."""
+        _stub_deep_pipeline(iorails_tracing)
+
+        await iorails_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        # Find a content_safety LLM span (not the main LLM)
+        llm_spans = [s for s in spans if "gen_ai.request.model" in (s.attributes or {})]
+        assert len(llm_spans) >= 1
+
+        # Check one has the expected model attributes
+        models_seen = {s.attributes["gen_ai.request.model"] for s in llm_spans}
+        assert "nvidia/llama-3.1-nemoguard-8b-content-safety" in models_seen or len(models_seen) > 0
+
+    @pytest.mark.asyncio
+    async def test_no_child_spans_when_tracing_disabled(self, iorails_no_tracing, exporter):
+        """With tracing disabled, no spans at all are created."""
+        _stub_safe_pipeline(iorails_no_tracing)
+
+        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        assert len(exporter.get_finished_spans()) == 0
 
 
 class TestOtelNotInstalled:

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -600,8 +600,14 @@ class TestSpanHierarchy:
 
     @pytest.mark.asyncio
     async def test_no_child_spans_when_tracing_disabled(self, iorails_no_tracing, exporter):
-        """With tracing disabled, no spans at all are created."""
-        _stub_safe_pipeline(iorails_no_tracing)
+        """With tracing disabled, no spans at all are created.
+
+        Uses ``_stub_deep_pipeline`` so the full RailsManager → RailAction →
+        EngineRegistry chain executes (including every ``get_tracer()`` call
+        site).  This exercises the code paths that would otherwise create
+        orphaned child spans, not just the top-level IORails entry point.
+        """
+        _stub_deep_pipeline(iorails_no_tracing)
 
         await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
 

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -29,6 +29,7 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS
 from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
+    mark_rail_stop,
     record_span_error,
     request_span,
     trace_id_to_request_id,
@@ -217,6 +218,32 @@ class TestRecordSpanError:
         exc_events = [e for e in finished.events if e.name == "exception"]
         assert len(exc_events) == 1
         assert exc_events[0].attributes["exception.type"] == "ValueError"
+
+
+class TestMarkRailStop:
+    """``mark_rail_stop`` encapsulates the None-span + rail-safe conditional."""
+
+    def test_noop_when_span_is_none(self):
+        # Tracer disabled → rail_span yields None; helper must not crash.
+        mark_rail_stop(None, is_safe=False)
+
+    def test_sets_attribute_when_rail_blocks(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test") as span:
+            mark_rail_stop(span, is_safe=False)
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["rail.stop"] is True
+
+    def test_does_not_set_attribute_when_rail_passes(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test") as span:
+            mark_rail_stop(span, is_safe=True)
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert "rail.stop" not in attrs
 
 
 class TestIsTracingEnabled:

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -29,6 +29,7 @@ from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS
 from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
+    record_span_error,
     request_span,
     trace_id_to_request_id,
 )
@@ -198,6 +199,24 @@ class TestRequestSpan:
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
         assert spans[0].end_time is not None
+
+
+class TestRecordSpanError:
+    def test_noop_when_span_is_none(self):
+        # Should not raise
+        record_span_error(None, RuntimeError("boom"))
+
+    def test_records_on_live_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("test") as span:
+            record_span_error(span, ValueError("bad"))
+
+        finished = exporter.get_finished_spans()[0]
+        assert finished.status.status_code == StatusCode.ERROR
+        exc_events = [e for e in finished.events if e.name == "exception"]
+        assert len(exc_events) == 1
+        assert exc_events[0].attributes["exception.type"] == "ValueError"
 
 
 class TestIsTracingEnabled:

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -183,7 +183,7 @@ class TestApiCallSpan:
         assert spans[0].kind == SpanKind.CLIENT
         assert spans[0].name == "api jailbreak_detection"
 
-    def test_sets_operation_name(self, otel_provider):
+    def test_sets_api_name(self, otel_provider):
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
@@ -191,7 +191,10 @@ class TestApiCallSpan:
             pass
 
         attrs = dict(exporter.get_finished_spans()[0].attributes)
-        assert attrs["gen_ai.operation.name"] == "api"
+        assert attrs["api.name"] == "jailbreak_detection"
+        # Must NOT appear in the gen_ai.* namespace: this is a plain HTTP
+        # API call, not a GenAI operation.
+        assert "gen_ai.operation.name" not in attrs
 
     def test_records_error_type(self, otel_provider):
         provider, exporter = otel_provider

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -105,6 +105,20 @@ class TestActionSpan:
         with action_span(None, "some action") as span:
             assert span is None
 
+    def test_records_exception(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(RuntimeError, match="action failed"):
+            with action_span(tracer, "some action"):
+                raise RuntimeError("action failed")
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        exc_events = [e for e in span.events if e.name == "exception"]
+        assert len(exc_events) == 1
+        assert exc_events[0].attributes["exception.type"] == "RuntimeError"
+
 
 class TestLlmCallSpan:
     def test_creates_client_span(self, otel_provider):

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -43,7 +43,7 @@ class TestRailSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with rail_span(tracer, "content safety check input $model=content_safety", RailDirection.INPUT) as span:
+        with rail_span(tracer, "content safety check input $model=content_safety", RailDirection.INPUT) as _:
             pass
 
         spans = exporter.get_finished_spans()

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for telemetry span helpers: rail_span, action_span, llm_call_span, api_call_span."""
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+
+from nemoguardrails.guardrails.guardrails_types import RailDirection
+from nemoguardrails.guardrails.telemetry import (
+    action_span,
+    api_call_span,
+    llm_call_span,
+    rail_span,
+)
+
+
+@pytest.fixture
+def otel_provider():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
+
+
+class TestRailSpan:
+    def test_creates_internal_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with rail_span(tracer, "content safety check input $model=content_safety", RailDirection.INPUT) as span:
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "guardrails.rail"
+        assert spans[0].kind == SpanKind.INTERNAL
+
+    def test_sets_attributes(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with rail_span(tracer, "content safety check output $model=content_safety", RailDirection.OUTPUT):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["rail.type"] == "Output"
+        assert attrs["rail.name"] == "content safety check output $model=content_safety"
+
+    def test_noop_when_tracer_none(self):
+        with rail_span(None, "some flow", RailDirection.INPUT) as span:
+            assert span is None
+
+    def test_records_exception(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(RuntimeError, match="rail failed"):
+            with rail_span(tracer, "some flow", RailDirection.INPUT):
+                raise RuntimeError("rail failed")
+
+        spans = exporter.get_finished_spans()
+        assert spans[0].status.status_code == StatusCode.ERROR
+
+
+class TestActionSpan:
+    def test_creates_internal_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with action_span(tracer, "content safety check input"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "guardrails.action"
+        assert spans[0].kind == SpanKind.INTERNAL
+
+    def test_sets_action_name(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with action_span(tracer, "jailbreak detection"):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["action.name"] == "jailbreak detection"
+
+    def test_noop_when_tracer_none(self):
+        with action_span(None, "some action") as span:
+            assert span is None
+
+
+class TestLlmCallSpan:
+    def test_creates_client_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].kind == SpanKind.CLIENT
+
+    def test_span_name_follows_convention(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim"):
+            pass
+
+        assert exporter.get_finished_spans()[0].name == "chat meta/llama-3.3-70b-instruct"
+
+    def test_sets_genai_attributes(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim", "chat"):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.operation.name"] == "chat"
+        assert attrs["gen_ai.request.model"] == "meta/llama-3.3-70b-instruct"
+        assert attrs["gen_ai.provider.name"] == "nim"
+
+    def test_records_error_type(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(ConnectionError):
+            with llm_call_span(tracer, "model", "main", "nim"):
+                raise ConnectionError("timeout")
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "ConnectionError"
+
+    def test_noop_when_tracer_none(self):
+        with llm_call_span(None, "model", "main", "nim") as span:
+            assert span is None
+
+
+class TestApiCallSpan:
+    def test_creates_client_span(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with api_call_span(tracer, "jailbreak_detection"):
+            pass
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].kind == SpanKind.CLIENT
+        assert spans[0].name == "api jailbreak_detection"
+
+    def test_sets_operation_name(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with api_call_span(tracer, "jailbreak_detection"):
+            pass
+
+        attrs = dict(exporter.get_finished_spans()[0].attributes)
+        assert attrs["gen_ai.operation.name"] == "api"
+
+    def test_records_error_type(self, otel_provider):
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with pytest.raises(ValueError):
+            with api_call_span(tracer, "jailbreak_detection"):
+                raise ValueError("bad response")
+
+        span = exporter.get_finished_spans()[0]
+        assert span.status.status_code == StatusCode.ERROR
+        assert span.attributes["error.type"] == "ValueError"
+
+    def test_noop_when_tracer_none(self):
+        with api_call_span(None, "jailbreak_detection") as span:
+            assert span is None

--- a/tests/guardrails/test_telemetry_spans.py
+++ b/tests/guardrails/test_telemetry_spans.py
@@ -111,7 +111,7 @@ class TestLlmCallSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim"):
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "nim"):
             pass
 
         spans = exporter.get_finished_spans()
@@ -122,7 +122,7 @@ class TestLlmCallSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim"):
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "nim"):
             pass
 
         assert exporter.get_finished_spans()[0].name == "chat meta/llama-3.3-70b-instruct"
@@ -131,7 +131,7 @@ class TestLlmCallSpan:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "main", "nim", "chat"):
+        with llm_call_span(tracer, "meta/llama-3.3-70b-instruct", "nim", "chat"):
             pass
 
         attrs = dict(exporter.get_finished_spans()[0].attributes)
@@ -144,7 +144,7 @@ class TestLlmCallSpan:
         tracer = provider.get_tracer("test")
 
         with pytest.raises(ConnectionError):
-            with llm_call_span(tracer, "model", "main", "nim"):
+            with llm_call_span(tracer, "model", "nim"):
                 raise ConnectionError("timeout")
 
         span = exporter.get_finished_spans()[0]
@@ -152,7 +152,7 @@ class TestLlmCallSpan:
         assert span.attributes["error.type"] == "ConnectionError"
 
     def test_noop_when_tracer_none(self):
-        with llm_call_span(None, "model", "main", "nim") as span:
+        with llm_call_span(None, "model", "nim") as span:
             assert span is None
 
 


### PR DESCRIPTION
## Description

This PR builds on top of the scaffolding introduced in #1793 to instrument the non-streaming inference path from `generate_async()`. It adds spans to reflect work units at different levels of hierarchy:

* `rail_span`: Includes the rail type, direction and flow.
* `action_span`: Includes action name being executed.
* `llm_call_span`: Includes LLM provider, model, and operation.
* `api_call_span`: Operation name set to API.

As part of the test-plan, I integration-tested IORails calls to `generate_async()` for the [nemoguards config](https://github.com/NVIDIA-NeMo/Guardrails/tree/develop/examples/configs/nemoguards). See files and test results below.

## Related Issue(s)

Preceeding PRs in the stack:

* #1793 : Set up infrastructure for OTEL instrumentation used by this PR.

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed

```

### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s............................... [  4%]
.................................................................................................................................................... [  8%]
.................................................................................................................................................... [ 12%]
.................................................................................................................................................... [ 17%]
.................................................................................................................................................... [ 21%]
.................................................................................................................................................s.. [ 25%]
....ss...................................sssssss.................................................................................................... [ 29%]
.........................................................s.......s.........................................ss...........................s........... [ 34%]
....s.......sssss...............................................................s................................................................... [ 38%]
............ss........ss...ss............................................s.....................................................s............s....... [ 42%]
.................................................................................................................................................... [ 46%]
.................................................................................................................................................... [ 51%]
....................sssss......ssssssssssssssssss..........sssss.................................................................................... [ 55%]
s...........ss...................................sssssssss.ssssssssss.......................................s....................................... [ 59%]
............s....s........................................................ssssssss..............sss...ss...ss....................................... [ 63%]
............................ssssssssssssss.......................................................................................................... [ 68%]
............................s..............................................................................................................s........ [ 72%]
............ssssssss.........ss..................................................................................................................... [ 76%]
..............sssssss...........................................................................s................................................... [ 80%]
.................................................................................................................................................... [ 85%]
.................................................................................................................................................... [ 89%]
.............................................................................................................s...................................... [ 93%]
.................................................................................................................................................... [ 97%]
..........................................................................                                                                           [100%]
3339 passed, 139 skipped in 116.14s (0:01:56)
```

### Integration test (uses [trace_e2e_test.py](https://gist.github.com/tgasser-nv/4e73c1515d93971a96ebf9b88db0d19c))

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run python tests/guardrails/trace_e2e_test.py
2026-04-16 15:33:35 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-16 15:33:35 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-16 15:33:35 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-16 15:33:35 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-16 15:33:35 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False
2026-04-16 15:33:35 INFO: [816832f3684d8c0d] generate_async called
2026-04-16 15:33:35 INFO: [816832f3684d8c0d] Running input rails
2026-04-16 15:33:35 INFO: [816832f3684d8c0d] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
DEBUG:aiohttp_retry:Attempt 1 out of 3
2026-04-16 15:33:36 INFO: [816832f3684d8c0d] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
DEBUG:aiohttp_retry:Attempt 1 out of 3
2026-04-16 15:33:36 INFO: [816832f3684d8c0d] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
DEBUG:aiohttp_retry:Attempt 1 out of 3
2026-04-16 15:33:37 INFO: [816832f3684d8c0d] Calling main LLM
2026-04-16 15:33:37 INFO: [816832f3684d8c0d] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
DEBUG:aiohttp_retry:Attempt 1 out of 3
2026-04-16 15:33:38 INFO: [816832f3684d8c0d] Running output rails
2026-04-16 15:33:38 INFO: [816832f3684d8c0d] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
DEBUG:aiohttp_retry:Attempt 1 out of 3
2026-04-16 15:33:39 INFO: [816832f3684d8c0d] generate_async completed time=3164.8ms

=== NEMO_GUARDRAILS_IORAILS_ENGINE=1 → using Guardrails ===

=== Running generate_async ===
RESPONSE: {'role': 'assistant', 'content': "Hello. I'm doing well, thanks for asking. I'm a large language model, so I don't have feelings or emotions like humans do, but I'm functioning properly and ready to help with any questions or tasks you may have. How about you? How's your day going so far?"}
```

Attaching logs and JSON files with traces

[20260416_otel.log](https://github.com/user-attachments/files/26800468/20260416_otel.log)
[trace_e2e_test.json](https://github.com/user-attachments/files/26800451/trace_e2e_test.json)


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenTelemetry tracing instrumentation to core guardrail execution flows, enabling detailed observability and monitoring of rail and action execution.
  * Implemented automatic error recording in trace spans for improved error tracking and diagnostics.

* **Tests**
  * Added comprehensive test coverage for tracing helpers and end-to-end trace hierarchy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->