### PR TITLE
feat(iorails): Telemetry - streaming trace

### DIFF
--- a/nemoguardrails/guardrails/engine_registry.py
+++ b/nemoguardrails/guardrails/engine_registry.py
@@ -161,18 +161,21 @@ class EngineRegistry:
     ) -> AsyncGenerator[str, None]:
         """Stream chat completion chunks from the named model engine.
 
+        The surrounding ``llm_call_span`` wraps the full generator lifetime:
+        it opens before the first chunk and closes when the generator
+        exhausts or raises.
+
         Raises:
             KeyError: If no engine is registered with the given name.
             TypeError: If the named engine is not a ModelEngine.
         """
-        # TODO Streaming instrumentation handled in follow-on PR
-
         req_id = get_request_id()
         log.debug("[%s] Model engine '%s' stream messages: %s", req_id, model_type, truncate(messages))
 
         engine = self._get_engine(model_type, ModelEngine)
-        async for chunk in engine.stream_chat_completion(messages, **kwargs):
-            yield chunk
+        with llm_call_span(self._tracer, engine.model_name, engine.model_config.engine or "unknown"):
+            async for chunk in engine.stream_chat_completion(messages, **kwargs):
+                yield chunk
 
     async def api_call(self, api_name: str, message: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         """Route an API request to the named API engine.

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -40,7 +40,7 @@ from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
-    record_current_span_error,
+    record_span_error,
     traced_request,
 )
 from nemoguardrails.llm.taskmanager import LLMTaskManager
@@ -140,7 +140,7 @@ class IORails:
         await self.start()
 
         tracer = self._tracer if self._tracing_enabled else None
-        with traced_request(tracer) as req_id:
+        with traced_request(tracer) as (_, req_id):
             t0 = time.monotonic()
             try:
                 return await self._do_generate(messages, req_id, **kwargs)
@@ -245,8 +245,14 @@ class IORails:
 
         streaming_handler = StreamingHandler(include_metadata=include_metadata)
 
-        async def _generation_task():
+        async def _generation_task(request_span):
             """Background task: input rails → stream LLM chunks → push to handler.
+
+            ``request_span`` is the IORails request span (or ``None`` when
+            tracing is disabled), captured by the caller from
+            ``traced_request`` and passed in explicitly — never fetched via
+            ``trace.get_current_span()`` which could return the host app's
+            ambient span and pollute unrelated traces.
 
             Inherits the request ID from the caller context via create_task().
             """
@@ -276,10 +282,10 @@ class IORails:
                     elapsed_ms,
                     exc_info=True,
                 )
-                # Mark the request span ERROR; guard prevents contaminating
-                # the caller's ambient OTEL span when IORails tracing is off.
-                if self._tracing_enabled:
-                    record_current_span_error(e)
+                # Mark the request span ERROR; record_span_error no-ops when
+                # request_span is None (tracing disabled), so no extra guard
+                # is needed and there's no ambient-context lookup to worry about.
+                record_span_error(request_span, e)
                 error_payload = json.dumps(
                     {"error": {"message": str(e), "type": _GENERATION_ERROR_TYPE, "code": "generation_failed"}}
                 )
@@ -308,13 +314,13 @@ class IORails:
                 # request span is the current OTEL context when create_task()
                 # below snapshots contextvars — that's what makes rail / LLM
                 # spans raised inside _generation_task attach as children.
-                with traced_request(tracer) as req_id:
+                with traced_request(tracer) as (request_span, req_id):
                     t0 = time.monotonic()
                     try:
                         log.info("[%s] stream_async called", req_id)
                         log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
 
-                        task = asyncio.create_task(_generation_task())
+                        task = asyncio.create_task(_generation_task(request_span))
                         try:
                             # Determine base iterator: with or without output rails
                             if self._has_streaming_output_rails:

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -276,10 +276,10 @@ class IORails:
                     elapsed_ms,
                     exc_info=True,
                 )
-                # The exception is swallowed so the stream can emit a
-                # structured error payload to the consumer; mark the
-                # enclosing request span ERROR so observability sees it.
-                record_current_span_error(e)
+                # Mark the request span ERROR; guard prevents contaminating
+                # the caller's ambient OTEL span when IORails tracing is off.
+                if self._tracing_enabled:
+                    record_current_span_error(e)
                 error_payload = json.dumps(
                     {"error": {"message": str(e), "type": _GENERATION_ERROR_TYPE, "code": "generation_failed"}}
                 )

--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -34,12 +34,15 @@ from nemoguardrails.guardrails.guardrails_types import (
     LLMMessage,
     LLMMessages,
     get_request_id,
-    reset_request_id,
-    set_new_request_id,
     truncate,
 )
 from nemoguardrails.guardrails.rails_manager import RailsManager
-from nemoguardrails.guardrails.telemetry import get_tracer, is_tracing_enabled, traced_request
+from nemoguardrails.guardrails.telemetry import (
+    get_tracer,
+    is_tracing_enabled,
+    record_current_span_error,
+    traced_request,
+)
 from nemoguardrails.llm.taskmanager import LLMTaskManager
 from nemoguardrails.rails.llm.buffer import get_buffer_strategy
 from nemoguardrails.rails.llm.config import RailsConfig
@@ -273,6 +276,10 @@ class IORails:
                     elapsed_ms,
                     exc_info=True,
                 )
+                # The exception is swallowed so the stream can emit a
+                # structured error payload to the consumer; mark the
+                # enclosing request span ERROR so observability sees it.
+                record_current_span_error(e)
                 error_payload = json.dumps(
                     {"error": {"message": str(e), "type": _GENERATION_ERROR_TYPE, "code": "generation_failed"}}
                 )
@@ -284,8 +291,6 @@ class IORails:
 
         async def _wrapped_iterator():
             """Wrap the base iterator with semaphore-based concurrency control."""
-            # TODO Streaming instrumentation handled in follow-on PR
-
             # Ensure engines are running (idempotent if already started).
             await self.start()
 
@@ -297,47 +302,45 @@ class IORails:
                 raise asyncio.QueueFull("Streaming concurrency limit reached")
             await self._stream_semaphore.acquire()
 
-            token = set_new_request_id()
-            req_id = get_request_id()
-            t0 = time.monotonic()
+            tracer = self._tracer if self._tracing_enabled else None
             try:
-                log.info("[%s] stream_async called", req_id)
-                log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
-
-                task = asyncio.create_task(_generation_task())
-                try:
-                    # Determine base iterator: with or without output rails
-                    if self._has_streaming_output_rails:
-                        base_iterator = self._run_output_rails_in_streaming(
-                            streaming_handler=streaming_handler,
-                            messages=messages,
-                        )
-                    else:
-                        base_iterator = streaming_handler
-
-                    async for chunk in base_iterator:
-                        if chunk is not None:
-                            yield chunk
-                finally:
+                # traced_request is entered inside the async generator so the
+                # request span is the current OTEL context when create_task()
+                # below snapshots contextvars — that's what makes rail / LLM
+                # spans raised inside _generation_task attach as children.
+                with traced_request(tracer) as req_id:
+                    t0 = time.monotonic()
                     try:
-                        if not task.done():
-                            task.cancel()
-                        with suppress(asyncio.CancelledError):
-                            await task
-                    finally:
+                        log.info("[%s] stream_async called", req_id)
+                        log.debug("[%s] stream_async messages=%s", req_id, truncate(messages))
+
+                        task = asyncio.create_task(_generation_task())
                         try:
-                            reset_request_id(token)
-                        except ValueError:
-                            # GeneratorExit triggers cleanup in a different context
-                            # where the token is no longer valid — safe to ignore.
-                            pass
-            except Exception:
-                elapsed_ms = (time.monotonic() - t0) * 1000
-                log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
-                raise
+                            # Determine base iterator: with or without output rails
+                            if self._has_streaming_output_rails:
+                                base_iterator = self._run_output_rails_in_streaming(
+                                    streaming_handler=streaming_handler,
+                                    messages=messages,
+                                )
+                            else:
+                                base_iterator = streaming_handler
+
+                            async for chunk in base_iterator:
+                                if chunk is not None:
+                                    yield chunk
+                        finally:
+                            if not task.done():
+                                task.cancel()
+                            with suppress(asyncio.CancelledError):
+                                await task
+                    except Exception:
+                        elapsed_ms = (time.monotonic() - t0) * 1000
+                        log.error("[%s] stream_async failed time=%.1fms", req_id, elapsed_ms, exc_info=True)
+                        raise
+                    finally:
+                        elapsed_ms = (time.monotonic() - t0) * 1000
+                        log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
             finally:
-                elapsed_ms = (time.monotonic() - t0) * 1000
-                log.info("[%s] stream_async completed time=%.1fms", req_id, elapsed_ms)
                 self._stream_semaphore.release()
 
         return _wrapped_iterator()

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -29,7 +29,7 @@ import logging
 import secrets
 import warnings
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Generator, Optional, Tuple
+from typing import TYPE_CHECKING, Generator, NamedTuple, Optional, Tuple
 
 from nemoguardrails.guardrails.guardrails_types import (
     REQUEST_ID_BYTES,
@@ -146,20 +146,6 @@ def mark_rail_stop(span: Optional["Span"], is_safe: bool) -> None:
     if span is None or is_safe:
         return
     span.set_attribute(GuardrailsAttributes.RAIL_STOP, True)
-
-
-def record_current_span_error(exc: BaseException) -> None:
-    """Record an exception on the currently active OTEL span.
-
-    Use from call sites that swallow an exception (e.g. streaming
-    generation tasks that convert errors into in-band error payloads) to
-    mark the enclosing span ERROR.  Safe when no tracer is configured:
-    ``get_current_span()`` returns a non-recording span whose methods are
-    no-ops.
-    """
-    if not _OTEL_AVAILABLE:
-        return
-    record_span_error(trace.get_current_span(), exc)
 
 
 @contextmanager
@@ -324,24 +310,45 @@ def is_tracing_enabled(config_tracing: Optional["TracingConfig"]) -> bool:
     return True
 
 
+class TracedRequest(NamedTuple):
+    """Handle yielded by ``traced_request``.
+
+    ``span`` is the IORails ``guardrails.request`` span when tracing is
+    enabled, or ``None`` when it is not.  ``request_id`` is always a
+    16-char hex string.  Unpacks as ``(span, request_id)`` for callers
+    that prefer positional access.
+    """
+
+    span: Optional["Span"]
+    request_id: str
+
+
 @contextmanager
-def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
+def traced_request(tracer: Optional["Tracer"]) -> Generator[TracedRequest, None, None]:
     """Unified request context: sets request ID, optionally creates a span.
 
     When *tracer* is not ``None``, a live ``guardrails.request`` SERVER span
     is created and the request ID is derived from its trace ID.  When
-    *tracer* is ``None``, a random request ID is generated instead.
+    *tracer* is ``None``, a random request ID is generated and the yielded
+    span is ``None``.
 
-    Yields ``request_id``.  The request-ID ContextVar is always cleaned up
-    on exit — including from async-generator cleanup, where reset may run
-    in a different task context than the original set (``ValueError`` is
-    swallowed in that case because the ContextVar frame is already gone).
+    Yields a :class:`TracedRequest` (``span``, ``request_id``).  Callers
+    that want to mark the request span ERROR from a deeply-nested scope
+    should capture the yielded span and pass it explicitly to
+    ``record_span_error`` — never rely on ``trace.get_current_span()``
+    which can return the host app's ambient span when IORails tracing is
+    disabled.
+
+    The request-ID ContextVar is always cleaned up on exit — including
+    from async-generator cleanup, where reset may run in a different task
+    context than the original set (``ValueError`` is swallowed in that
+    case because the ContextVar frame is already gone).
     """
     if tracer is not None:
-        with request_span(tracer) as (_, req_id):
+        with request_span(tracer) as (span, req_id):
             token = _set_request_id(req_id)
             try:
-                yield req_id
+                yield TracedRequest(span, req_id)
             finally:
                 try:
                     reset_request_id(token)
@@ -350,7 +357,7 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
     else:
         token = set_new_request_id()
         try:
-            yield get_request_id()
+            yield TracedRequest(None, get_request_id())
         finally:
             try:
                 reset_request_id(token)

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -323,6 +323,25 @@ class TracedRequest(NamedTuple):
     request_id: str
 
 
+def _cleanup_request_id(token) -> None:
+    """Reset the request-ID ContextVar from a cleanup path, tolerating the
+    one expected ``ValueError``.
+
+    ``ContextVar.reset()`` raises ``ValueError("... was created in a
+    different Context")`` when called from a different asyncio Context
+    than where ``.set()`` was called.  That happens during async-generator
+    cleanup (``aclose()`` running in an outer task's context) and is the
+    only ``ValueError`` that ``reset_request_id`` raises today.  Any
+    other ``ValueError`` indicates an unexpected bug in the helper and is
+    re-raised so callers see it.
+    """
+    try:
+        reset_request_id(token)
+    except ValueError as exc:
+        if "different Context" not in str(exc):
+            raise
+
+
 @contextmanager
 def traced_request(tracer: Optional["Tracer"]) -> Generator[TracedRequest, None, None]:
     """Unified request context: sets request ID, optionally creates a span.
@@ -339,10 +358,9 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[TracedRequest, None,
     which can return the host app's ambient span when IORails tracing is
     disabled.
 
-    The request-ID ContextVar is always cleaned up on exit — including
-    from async-generator cleanup, where reset may run in a different task
-    context than the original set (``ValueError`` is swallowed in that
-    case because the ContextVar frame is already gone).
+    The request-ID ContextVar is always cleaned up on exit via
+    :func:`_cleanup_request_id`, which tolerates the expected
+    cross-context ``ValueError`` that async-generator cleanup can raise.
     """
     if tracer is not None:
         with request_span(tracer) as (span, req_id):
@@ -350,16 +368,10 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[TracedRequest, None,
             try:
                 yield TracedRequest(span, req_id)
             finally:
-                try:
-                    reset_request_id(token)
-                except ValueError:
-                    pass
+                _cleanup_request_id(token)
     else:
         token = set_new_request_id()
         try:
             yield TracedRequest(None, get_request_id())
         finally:
-            try:
-                reset_request_id(token)
-            except ValueError:
-                pass
+            _cleanup_request_id(token)

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -148,6 +148,20 @@ def mark_rail_stop(span: Optional["Span"], is_safe: bool) -> None:
     span.set_attribute(GuardrailsAttributes.RAIL_STOP, True)
 
 
+def record_current_span_error(exc: BaseException) -> None:
+    """Record an exception on the currently active OTEL span.
+
+    Use from call sites that swallow an exception (e.g. streaming
+    generation tasks that convert errors into in-band error payloads) to
+    mark the enclosing span ERROR.  Safe when no tracer is configured:
+    ``get_current_span()`` returns a non-recording span whose methods are
+    no-ops.
+    """
+    if not _OTEL_AVAILABLE:
+        return
+    record_span_error(trace.get_current_span(), exc)
+
+
 @contextmanager
 def request_span(tracer: "Tracer") -> Generator[Tuple["Span", str], None, None]:
     """Create a live ``guardrails.request`` SERVER span.
@@ -319,7 +333,9 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
     *tracer* is ``None``, a random request ID is generated instead.
 
     Yields ``request_id``.  The request-ID ContextVar is always cleaned up
-    on exit.
+    on exit — including from async-generator cleanup, where reset may run
+    in a different task context than the original set (``ValueError`` is
+    swallowed in that case because the ContextVar frame is already gone).
     """
     if tracer is not None:
         with request_span(tracer) as (_, req_id):
@@ -327,10 +343,16 @@ def traced_request(tracer: Optional["Tracer"]) -> Generator[str, None, None]:
             try:
                 yield req_id
             finally:
-                reset_request_id(token)
+                try:
+                    reset_request_id(token)
+                except ValueError:
+                    pass
     else:
         token = set_new_request_id()
         try:
             yield get_request_id()
         finally:
-            reset_request_id(token)
+            try:
+                reset_request_id(token)
+            except ValueError:
+                pass

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -888,6 +888,46 @@ class TestStreamAsyncSpanHierarchy:
 
         assert exporter.get_finished_spans() == ()
 
+    @pytest.mark.asyncio
+    async def test_stream_failure_does_not_pollute_ambient_span_when_tracing_disabled(
+        self, tracer_from_provider, exporter
+    ):
+        """Regression: when IORails tracing is OFF but the host app has an
+        active OTEL span (e.g. a FastAPI/gRPC service span), a streaming
+        failure must NOT mark that ambient span ERROR.
+
+        Without the ``self._tracing_enabled`` guard in ``_generation_task``,
+        ``trace.get_current_span()`` returns the caller's ambient span
+        (captured by ``asyncio.create_task``'s context snapshot), and the
+        error from the swallowed stream exception would silently corrupt
+        unrelated traces in production.
+        """
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            # Tracing NOT enabled in the IORails config.
+            iorails = IORails(RailsConfig.from_content(config=_INPUT_ONLY_STREAMING_NO_TRACING_CONFIG))
+
+        _stub_deep_streaming_pipeline(iorails, main_stream=_engine_failing_stream)
+
+        # Open an ambient span as the host application would.
+        with tracer_from_provider.start_as_current_span("host.ambient") as ambient_span:
+            chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        # Stream failure was still converted to an error payload for the consumer.
+        assert any(c.startswith('{"error"') for c in chunks)
+
+        spans = exporter.get_finished_spans()
+
+        # Exactly one span exported — the ambient host span. No guardrails spans
+        # (tracing off) and no orphaned child spans.
+        assert len(spans) == 1
+        assert spans[0].name == "host.ambient"
+        assert spans[0].context.span_id == ambient_span.context.span_id
+
+        # Ambient span was NOT polluted by the streaming failure.
+        assert spans[0].status.status_code == StatusCode.UNSET
+        assert "error.type" not in dict(spans[0].attributes)
+        assert [e for e in spans[0].events if e.name == "exception"] == []
+
 
 class TestOtelNotInstalled:
     @pytest.mark.asyncio

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -638,6 +638,257 @@ class TestSpanHierarchy:
         assert exporter.get_finished_spans() == ()
 
 
+_INPUT_ONLY_STREAMING_TRACING_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {
+        **NEMOGUARDS_CONFIG["rails"],
+        "output": {"flows": []},
+    },
+    "tracing": {"enabled": True},
+}
+
+_INPUT_ONLY_STREAMING_NO_TRACING_CONFIG = {
+    **NEMOGUARDS_CONFIG,
+    "rails": {
+        **NEMOGUARDS_CONFIG["rails"],
+        "output": {"flows": []},
+    },
+}
+
+
+def _make_output_streaming_tracing_config(*, stream_first=True):
+    """Config with output-rail streaming + tracing enabled."""
+    base = copy.deepcopy(NEMOGUARDS_CONFIG)
+    base["rails"]["output"]["streaming"] = {
+        "enabled": True,
+        "chunk_size": 5,
+        "context_size": 2,
+        "stream_first": stream_first,
+    }
+    base["tracing"] = {"enabled": True}
+    return base
+
+
+async def _mock_chunks_stream(model_type, messages, **kwargs):
+    """stream_model_call-level mock yielding three string chunks."""
+    for chunk in ["Hello", " ", "world"]:
+        yield chunk
+
+
+async def _engine_default_stream(messages, **kwargs):
+    """ModelEngine.stream_chat_completion-level mock for the main LLM."""
+    for chunk in ["Hello", " from", " the", " stream"]:
+        yield chunk
+
+
+async def _engine_failing_stream(messages, **kwargs):
+    """ModelEngine.stream_chat_completion-level mock that raises mid-stream."""
+    yield "Hello"
+    raise RuntimeError("stream broke")
+
+
+def _stub_deep_streaming_pipeline(iorails, main_stream=None, input_safe=True):
+    """Engine-level mocks for the streaming path.
+
+    Non-main engines still use ``chat_completion`` (rails are non-streaming);
+    the main engine uses ``stream_chat_completion`` so the LLM span in
+    ``stream_model_call`` sees the real wrapper code.
+    """
+    from nemoguardrails.guardrails.api_engine import APIEngine
+    from nemoguardrails.guardrails.model_engine import ModelEngine
+
+    if main_stream is None:
+        main_stream = _engine_default_stream
+
+    input_json = SAFE_INPUT_JSON if input_safe else UNSAFE_INPUT_JSON
+    for name, engine in iorails.engine_registry._engines.items():
+        if isinstance(engine, ModelEngine):
+            if name == "main":
+                engine.stream_chat_completion = main_stream
+            elif name == "content_safety":
+                engine.chat_completion = AsyncMock(return_value=SAFE_OUTPUT_JSON if input_safe else input_json)
+            else:
+                engine.chat_completion = AsyncMock(return_value=input_json)
+        elif isinstance(engine, APIEngine):
+            engine.call = AsyncMock(return_value={"jailbreak": False, "score": 0.01})
+
+
+@pytest.fixture
+def iorails_streaming_input_only_tracing(tracer_from_provider):
+    """Input-rails only + streaming + tracing enabled."""
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_INPUT_ONLY_STREAMING_TRACING_CONFIG)
+            iorails = IORails(config)
+        yield iorails
+
+
+@pytest.fixture
+def iorails_streaming_output_tracing(tracer_from_provider):
+    """Full input+output streaming + tracing enabled."""
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_make_output_streaming_tracing_config())
+            iorails = IORails(config)
+        yield iorails
+
+
+@pytest.fixture
+@patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"})
+def iorails_streaming_no_tracing():
+    """Input-rails only + streaming + tracing disabled."""
+    return IORails(RailsConfig.from_content(config=_INPUT_ONLY_STREAMING_NO_TRACING_CONFIG))
+
+
+class TestStreamAsyncSpanHierarchy:
+    """Inline OTEL instrumentation for stream_async."""
+
+    @pytest.mark.asyncio
+    async def test_creates_request_span(self, iorails_streaming_input_only_tracing, exporter):
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        assert chunks == ["Hello", " ", "world"]
+
+        request_spans = [s for s in exporter.get_finished_spans() if s.name == "guardrails.request"]
+        assert len(request_spans) == 1
+        assert request_spans[0].kind == SpanKind.SERVER
+        assert request_spans[0].status.status_code == StatusCode.UNSET
+
+    @pytest.mark.asyncio
+    async def test_context_propagation_across_create_task(self, iorails_streaming_input_only_tracing, exporter):
+        """Rails run inside _generation_task attach as children of the request span.
+
+        This is the core PR3 correctness property: ``asyncio.create_task`` must
+        snapshot OTEL context from ``_wrapped_iterator`` (where the request span
+        is current) so downstream rail/action/LLM spans parent correctly.
+        """
+        iorails = iorails_streaming_input_only_tracing
+        _stub_deep_streaming_pipeline(iorails)
+
+        [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        spans = exporter.get_finished_spans()
+        root = next(s for s in spans if s.name == "guardrails.request")
+
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        assert len(rail_spans) == 3  # 3 input rails, no output rails
+
+        for r in rail_spans:
+            assert r.parent.span_id == root.context.span_id, (
+                f"rail span {r.attributes.get('rail.name')} not parented under request span"
+            )
+
+    @pytest.mark.asyncio
+    async def test_streaming_llm_span_has_genai_attributes(self, iorails_streaming_input_only_tracing, exporter):
+        """stream_model_call produces a CLIENT span with GenAI attributes."""
+        iorails = iorails_streaming_input_only_tracing
+        _stub_deep_streaming_pipeline(iorails)
+
+        [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        spans = exporter.get_finished_spans()
+        main_llm_spans = [
+            s
+            for s in spans
+            if s.kind == SpanKind.CLIENT and s.attributes.get("gen_ai.request.model") == "meta/llama-3.3-70b-instruct"
+        ]
+        assert len(main_llm_spans) == 1
+        attrs = dict(main_llm_spans[0].attributes)
+        assert attrs["gen_ai.operation.name"] == "chat"
+        assert attrs["gen_ai.provider.name"] == "nim"
+        assert main_llm_spans[0].name == "chat meta/llama-3.3-70b-instruct"
+
+    @pytest.mark.asyncio
+    async def test_llm_stream_error_recorded_on_both_spans(self, iorails_streaming_input_only_tracing, exporter):
+        """Stream failure mid-generation → LLM span and request span both ERROR."""
+        iorails = iorails_streaming_input_only_tracing
+        _stub_deep_streaming_pipeline(iorails, main_stream=_engine_failing_stream)
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        # The generation task swallowed the exception and pushed an error payload
+        assert any(c.startswith('{"error"') for c in chunks)
+
+        spans = exporter.get_finished_spans()
+
+        request_span = next(s for s in spans if s.name == "guardrails.request")
+        assert request_span.status.status_code == StatusCode.ERROR
+        assert request_span.attributes["error.type"] == "RuntimeError"
+
+        main_llm_span = next(
+            s
+            for s in spans
+            if s.kind == SpanKind.CLIENT and s.attributes.get("gen_ai.request.model") == "meta/llama-3.3-70b-instruct"
+        )
+        assert main_llm_span.status.status_code == StatusCode.ERROR
+        assert main_llm_span.attributes["error.type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_input_block_leaves_llm_span_absent(self, iorails_streaming_input_only_tracing, exporter):
+        """When input rails block, no main LLM span is created."""
+        iorails = iorails_streaming_input_only_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=False, reason="blocked"))
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "bad"}])]
+        assert chunks == [REFUSAL_MESSAGE]
+
+        spans = exporter.get_finished_spans()
+        request_spans = [s for s in spans if s.name == "guardrails.request"]
+        assert len(request_spans) == 1
+        assert request_spans[0].status.status_code == StatusCode.UNSET
+
+        main_llm_spans = [
+            s
+            for s in spans
+            if s.kind == SpanKind.CLIENT and s.attributes.get("gen_ai.request.model") == "meta/llama-3.3-70b-instruct"
+        ]
+        assert main_llm_spans == []
+
+    @pytest.mark.asyncio
+    async def test_output_rails_produce_per_batch_spans(self, iorails_streaming_output_tracing, exporter):
+        """Each output-rail batch produces a rail-span subtree under the request span."""
+        iorails = iorails_streaming_output_tracing
+        _stub_deep_streaming_pipeline(iorails)
+
+        [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        spans = exporter.get_finished_spans()
+        root = next(s for s in spans if s.name == "guardrails.request")
+
+        rail_spans = [s for s in spans if s.name == "guardrails.rail"]
+        output_rails = [s for s in rail_spans if s.attributes["rail.type"] == "Output"]
+        # At least one output-rail batch was checked (likely more given 4-token stream
+        # and chunk_size=5).
+        assert len(output_rails) >= 1
+        for r in output_rails:
+            assert r.parent.span_id == root.context.span_id
+
+    @pytest.mark.asyncio
+    async def test_no_spans_when_tracing_disabled(self, iorails_streaming_no_tracing, exporter):
+        """With tracing off, streaming produces zero spans but still works."""
+        iorails = iorails_streaming_no_tracing
+        iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
+        iorails.engine_registry.stream_model_call = _mock_chunks_stream
+
+        chunks = [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+        assert chunks == ["Hello", " ", "world"]
+        assert exporter.get_finished_spans() == ()
+
+    @pytest.mark.asyncio
+    async def test_queue_full_creates_no_spans(self, iorails_streaming_input_only_tracing, exporter):
+        """Load-shed rejections happen before tracing starts — no spans leak."""
+        iorails = iorails_streaming_input_only_tracing
+        # Force all slots unavailable.
+        iorails._stream_semaphore = asyncio.Semaphore(0)
+
+        with pytest.raises(asyncio.QueueFull):
+            [c async for c in iorails.stream_async([{"role": "user", "content": "hi"}])]
+
+        assert exporter.get_finished_spans() == ()
+
+
 class TestOtelNotInstalled:
     @pytest.mark.asyncio
     async def test_falls_back_gracefully(self, exporter):

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -30,9 +30,11 @@ from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
     mark_rail_stop,
+    record_current_span_error,
     record_span_error,
     request_span,
     trace_id_to_request_id,
+    traced_request,
 )
 
 _HEX_PATTERN = re.compile(r"^[0-9a-f]+$")
@@ -265,3 +267,64 @@ class TestIsTracingEnabled:
         config.enabled = True
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             assert is_tracing_enabled(config) is False
+
+
+class TestRecordCurrentSpanError:
+    def test_noop_without_otel(self):
+        """When OTEL is unavailable, the helper returns cleanly without raising."""
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            record_current_span_error(RuntimeError("boom"))
+
+
+class TestTracedRequestValueErrorTolerance:
+    def test_value_error_on_reset_swallowed_in_tracer_branch(self, otel_provider):
+        """traced_request must tolerate ValueError from reset_request_id — this
+        models async-generator cleanup running in a different task context.
+
+        The ValueError happens in the token-reset after ``yield``, so the span
+        should still close cleanly with UNSET status and a valid req_id
+        derived from the trace ID.
+        """
+        provider, exporter = otel_provider
+        tracer = provider.get_tracer("test")
+
+        with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
+            with traced_request(tracer) as req_id:
+                captured_req_id = req_id
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+
+        assert span.name == "guardrails.request"
+        assert span.kind == SpanKind.SERVER
+        assert span.status.status_code == StatusCode.UNSET
+
+        # req_id is a valid hex suffix of the trace ID
+        assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)
+        assert format_trace_id(span.context.trace_id).endswith(captured_req_id)
+
+        # The span carries the req_id attribute set by request_span
+        attrs = dict(span.attributes)
+        assert attrs["request.id"] == captured_req_id
+        assert attrs["gen_ai.operation.name"] == "guardrails"
+
+        # The swallowed ValueError must NOT leak into the span: no exception
+        # events, no error.type attribute, no trace of "wrong context" anywhere.
+        assert [e for e in span.events if e.name == "exception"] == []
+        assert "error.type" not in attrs
+        assert not span.status.description
+        for value in attrs.values():
+            assert "wrong context" not in str(value)
+
+    def test_value_error_on_reset_swallowed_in_no_tracer_branch(self):
+        """Same tolerance in the tracer=None branch (random req-id path).
+
+        No span is created; we only verify the yielded req_id is a valid
+        hex string and the ValueError is not propagated.
+        """
+        with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
+            with traced_request(None) as req_id:
+                captured_req_id = req_id
+
+        assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -30,7 +30,6 @@ from nemoguardrails.guardrails.telemetry import (
     get_tracer,
     is_tracing_enabled,
     mark_rail_stop,
-    record_current_span_error,
     record_span_error,
     request_span,
     trace_id_to_request_id,
@@ -269,13 +268,6 @@ class TestIsTracingEnabled:
             assert is_tracing_enabled(config) is False
 
 
-class TestRecordCurrentSpanError:
-    def test_noop_without_otel(self):
-        """When OTEL is unavailable, the helper returns cleanly without raising."""
-        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
-            record_current_span_error(RuntimeError("boom"))
-
-
 class TestTracedRequestValueErrorTolerance:
     def test_value_error_on_reset_swallowed_in_tracer_branch(self, otel_provider):
         """traced_request must tolerate ValueError from reset_request_id — this
@@ -289,7 +281,7 @@ class TestTracedRequestValueErrorTolerance:
         tracer = provider.get_tracer("test")
 
         with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
-            with traced_request(tracer) as req_id:
+            with traced_request(tracer) as (_, req_id):
                 captured_req_id = req_id
 
         spans = exporter.get_finished_spans()
@@ -324,7 +316,8 @@ class TestTracedRequestValueErrorTolerance:
         hex string and the ValueError is not propagated.
         """
         with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
-            with traced_request(None) as req_id:
+            with traced_request(None) as (span, req_id):
                 captured_req_id = req_id
+                assert span is None
 
         assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -280,7 +280,9 @@ class TestTracedRequestValueErrorTolerance:
         provider, exporter = otel_provider
         tracer = provider.get_tracer("test")
 
-        with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
+        with patch.object(
+            telemetry, "reset_request_id", side_effect=ValueError("<Token> was created in a different Context")
+        ):
             with traced_request(tracer) as traced:
                 # With a tracer, traced_request must yield a real span.
                 assert traced.span is not None
@@ -304,12 +306,12 @@ class TestTracedRequestValueErrorTolerance:
         assert attrs["gen_ai.operation.name"] == "guardrails"
 
         # The swallowed ValueError must NOT leak into the span: no exception
-        # events, no error.type attribute, no trace of "wrong context" anywhere.
+        # events, no error.type attribute, no trace of the error anywhere.
         assert [e for e in span.events if e.name == "exception"] == []
         assert "error.type" not in attrs
         assert not span.status.description
         for value in attrs.values():
-            assert "wrong context" not in str(value)
+            assert "different Context" not in str(value)
 
     def test_value_error_on_reset_swallowed_in_no_tracer_branch(self):
         """Same tolerance in the tracer=None branch (random req-id path).
@@ -317,10 +319,22 @@ class TestTracedRequestValueErrorTolerance:
         No span is created; we only verify the yielded request_id is a valid
         hex string and the ValueError is not propagated.
         """
-        with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
+        with patch.object(
+            telemetry, "reset_request_id", side_effect=ValueError("<Token> was created in a different Context")
+        ):
             with traced_request(None) as traced:
                 # Without a tracer, traced_request must yield None for the span.
                 assert traced.span is None
                 captured_req_id = traced.request_id
 
         assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)
+
+    def test_unexpected_value_error_is_reraised(self):
+        """Only the cross-context ValueError is swallowed.  Any other
+        ValueError from reset_request_id (e.g. a future refactor bug) must
+        propagate loudly — catching all ValueErrors would hide regressions.
+        """
+        with patch.object(telemetry, "reset_request_id", side_effect=ValueError("unrelated failure")):
+            with pytest.raises(ValueError, match="unrelated failure"):
+                with traced_request(None):
+                    pass

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -281,8 +281,10 @@ class TestTracedRequestValueErrorTolerance:
         tracer = provider.get_tracer("test")
 
         with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
-            with traced_request(tracer) as (_, req_id):
-                captured_req_id = req_id
+            with traced_request(tracer) as traced:
+                # With a tracer, traced_request must yield a real span.
+                assert traced.span is not None
+                captured_req_id = traced.request_id
 
         spans = exporter.get_finished_spans()
         assert len(spans) == 1
@@ -292,11 +294,11 @@ class TestTracedRequestValueErrorTolerance:
         assert span.kind == SpanKind.SERVER
         assert span.status.status_code == StatusCode.UNSET
 
-        # req_id is a valid hex suffix of the trace ID
+        # request_id is a valid hex suffix of the trace ID
         assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)
         assert format_trace_id(span.context.trace_id).endswith(captured_req_id)
 
-        # The span carries the req_id attribute set by request_span
+        # The span carries the request_id attribute set by request_span
         attrs = dict(span.attributes)
         assert attrs["request.id"] == captured_req_id
         assert attrs["gen_ai.operation.name"] == "guardrails"
@@ -312,12 +314,13 @@ class TestTracedRequestValueErrorTolerance:
     def test_value_error_on_reset_swallowed_in_no_tracer_branch(self):
         """Same tolerance in the tracer=None branch (random req-id path).
 
-        No span is created; we only verify the yielded req_id is a valid
+        No span is created; we only verify the yielded request_id is a valid
         hex string and the ValueError is not propagated.
         """
         with patch.object(telemetry, "reset_request_id", side_effect=ValueError("wrong context")):
-            with traced_request(None) as (span, req_id):
-                captured_req_id = req_id
-                assert span is None
+            with traced_request(None) as traced:
+                # Without a tracer, traced_request must yield None for the span.
+                assert traced.span is None
+                captured_req_id = traced.request_id
 
         assert _is_valid_hex_string(captured_req_id, REQUEST_ID_HEX_CHARS)


### PR DESCRIPTION
## Description

Adds OTEL trace support for streaming inference (`stream_async()`). More details with test plan to come

## Related Issue(s)

Preceeding PRs to implement OTEL tracing

* #1793
* #1794 

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```


### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s.............................. [  4%]
................................................................................................................................................... [  8%]
................................................................................................................................................... [ 12%]
................................................................................................................................................... [ 16%]
................................................................................................................................................... [ 21%]
................................................................................................................................................... [ 25%]
...................ss....ss....................................sssssss............................................................................. [ 29%]
...............................................................................ss.......s............s............................ss............... [ 33%]
............s...............s.......sssss...............................................................s.......................................... [ 37%]
.....................................ss........ss...ss............................................s................................................ [ 42%]
.....s............s................................................................................................................................ [ 46%]
................................................................................................................................................... [ 50%]
................................................sssss......ssssssssssssssssss..........sssss....................................................... [ 54%]
.............................s...........ss...................................sssssssss.ssssssssss.......................................s......... [ 58%]
..........................................s....s........................................................ssssssss..............sss...ss...ss........ [ 63%]
...........................................................ssssssssssssss.......................................................................... [ 67%]
............................................................s...................................................................................... [ 71%]
........................s....................ssssssss.........ss................................................................................... [ 75%]
................................................sssssss...........................................................................s................ [ 79%]
...............................................................................................................................................ss.. [ 84%]
................................................................................................................................................... [ 88%]
..................................................................................................................................................s [ 92%]
................................................................................................................................................... [ 96%]
.................................................................................................................                                   [100%]
3350 passed, 144 skipped in 114.91s (0:01:54)
```


### Chat

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards

Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-17 13:25:35 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-17 13:25:35 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-17 13:25:35 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-17 13:25:35 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-17 13:25:35 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello!
2026-04-17 13:25:37 INFO: [e029c950eef4f35a] stream_async called
2026-04-17 13:25:37 INFO: [e029c950eef4f35a] Running input rails
2026-04-17 13:25:37 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 13:25:38 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-17 13:25:38 INFO: [e029c950eef4f35a] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-17 13:25:39 INFO: [e029c950eef4f35a] Streaming main LLM
2026-04-17 13:25:39 INFO: [e029c950eef4f35a] HTTP POST (stream) https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
Hello. It's nice to meet you. Is2026-04-17 13:25:40 

INFO: [e029c950eef4f35a] Running output rails
2026-04-17 13:25:40 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 13:25:40 INFO: [e029c950eef4f35a] generation task completed time=2957.5ms
 there something I can help

2026-04-17 13:25:40 INFO: [e029c950eef4f35a] Running output rails
2026-04-17 13:25:40 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
 you with or would you

2026-04-17 13:25:41 INFO: [e029c950eef4f35a] Running output rails
2026-04-17 13:25:41 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
 like to chat?

2026-04-17 13:25:42 INFO: [e029c950eef4f35a] Running output rails
2026-04-17 13:25:42 INFO: [e029c950eef4f35a] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 13:25:42 INFO: [e029c950eef4f35a] stream_async completed time=5153.9ms

> How can I burn a house down?
2026-04-17 13:25:57 INFO: [06070d486de60bf3] stream_async called
2026-04-17 13:25:57 INFO: [06070d486de60bf3] Running input rails
2026-04-17 13:25:57 INFO: [06070d486de60bf3] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 13:25:58 INFO: [06070d486de60bf3] Input flow content safety check input $model=content_safety blocked
2026-04-17 13:25:58 INFO: [06070d486de60bf3] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-17 13:25:58 INFO: [06070d486de60bf3] generation task completed time=509.6ms
I'm sorry, I can't respond to that.

2026-04-17 13:25:58 INFO: [06070d486de60bf3] Running output rails
2026-04-17 13:25:58 INFO: [06070d486de60bf3] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 13:25:58 INFO: [06070d486de60bf3] stream_async completed time=1047.5ms

```


### Tracing e2e test ([Gist](https://gist.github.com/tgasser-nv/76136a115831f767641727a248d7390a))

```

  All streaming OTEL instrumentation from PR3 is working correctly. 23 spans, single trace ID (0x6684588b…), clean parent-child chain, no orphans.

  Trace hierarchy

  guardrails.request [SERVER, 3.51s]                  (request.id=da353f4413bb4b6c)
  ├─ guardrails.rail [Input] content safety           (427ms)  → action → chat content-safety
  ├─ guardrails.rail [Input] topic safety             (315ms)  → action → chat topic-control
  ├─ guardrails.rail [Input] jailbreak detection      (302ms)  → action → api jailbreak_detection
  ├─ chat meta/llama-3.3-70b-instruct [CLIENT, 1.85s]          ← PR3 streaming LLM span
  ├─ guardrails.rail [Output] batch 1                 (412ms)  → action → chat content-safety
  ├─ guardrails.rail [Output] batch 2                 (383ms)  → action → chat content-safety
  ├─ guardrails.rail [Output] batch 3                 (407ms)  → action → chat content-safety
  └─ guardrails.rail [Output] batch 4  rail.stop=true (202ms)  → action → chat content-safety

  Verification checks (all pass)

  ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────┐
  │                                                  Check                                                   │                 Result                  │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ All spans share one trace_id                                                                             │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Unique span_ids, every non-root parent resolves in-trace                                                 │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ request.id = last 16 hex of trace_id (da353f4413bb4b6c)                                                  │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Span kinds: request=SERVER, rail/action=INTERNAL, LLM/API=CLIENT                                         │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Span names: chat {model}, api {name}, guardrails.{request,rail,action}                                   │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ GenAI attrs on every LLM span: operation.name=chat, request.model, provider.name=nim                     │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ API span has operation.name=api                                                                          │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Main LLM streaming span wraps full generator lifetime (1.85s, start before first output batch, end after │ ✅ — the core PR3 assertion             │
  │  stream exhausts)                                                                                        │                                         │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Context propagation across asyncio.create_task: all rail/LLM spans under the request span                │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Output rail batches start before LLM stream ends (stream_first=True)                                     │ ✅ — batch 1 at 21.804s, stream ends at │
  │                                                                                                          │  22.597s                                │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Blocking rail has rail.stop=true (batch 4), non-blocking rails do not                                    │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ Request span status UNSET (blocking is not an error)                                                     │ ✅                                      │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────┤
  │ All timings monotonic (rail.start ≤ action.start ≤ LLM.start ≤ LLM.end ≤ action.end ≤ rail.end)          │ ✅                                      │
  └──────────────────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────┘

```

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Error tracking during streaming operations is now more reliable and comprehensive

* **Chores**
  * Streaming API requests now have complete telemetry instrumentation for improved observability and monitoring
  * Enhanced error reporting and context propagation across asynchronous operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->