### PR TITLE
feat(iorails): Telemetry - OTEL logs

### DIFF
--- a/nemoguardrails/guardrails/iorails.py
+++ b/nemoguardrails/guardrails/iorails.py
@@ -39,6 +39,7 @@ from nemoguardrails.guardrails.guardrails_types import (
 from nemoguardrails.guardrails.rails_manager import RailsManager
 from nemoguardrails.guardrails.telemetry import (
     get_tracer,
+    install_log_handler,
     is_tracing_enabled,
     record_span_error,
     traced_request,
@@ -72,6 +73,11 @@ class IORails:
         # Pass to EngineRegistry and RailsManager to keep all spans consistent under parent
         self._tracing_enabled = is_tracing_enabled(config.tracing)
         self._tracer = get_tracer() if self._tracing_enabled else None
+
+        # Bridge Python logging → OTEL log records when tracing is on; records
+        # emitted inside a live span automatically carry trace_id / span_id.
+        if self._tracing_enabled:
+            install_log_handler()
 
         self.engine_registry = EngineRegistry(config.models, config.rails.config, tracer=self._tracer)
         self.rails_manager = RailsManager(

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -27,6 +27,7 @@ reachable through ``traced_request`` when a non-``None`` tracer is provided.
 
 import logging
 import secrets
+import threading
 import warnings
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generator, NamedTuple, Optional, Tuple
@@ -53,6 +54,8 @@ log = logging.getLogger(__name__)
 _OTEL_AVAILABLE: bool
 if TYPE_CHECKING:
     from opentelemetry import trace
+    from opentelemetry._logs import LoggerProvider
+    from opentelemetry.sdk._logs import LoggingHandler
     from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer, format_trace_id
 
     from nemoguardrails.rails.llm.config import TracingConfig
@@ -101,6 +104,74 @@ def get_tracer() -> Optional["Tracer"]:
             schema_url="https://opentelemetry.io/schemas/1.26.0",
         )
     return _tracer
+
+
+# Logger name that our OTEL log-bridge handler is attached to.  All IORails
+# modules log under this namespace (e.g. ``nemoguardrails.guardrails.iorails``)
+# so records flow through our handler via Python's logger hierarchy.  Chosen
+# narrow (``nemoguardrails.guardrails`` rather than ``nemoguardrails``) so
+# ``configure_logging()`` setting ``propagate=False`` at this level doesn't
+# break correlation, and so we don't bridge unrelated nemoguardrails.* loggers.
+_GUARDRAILS_LOGGER_NAME = "nemoguardrails.guardrails"
+
+# Module-level OTEL logging handler.  Installed once per process by the first
+# IORails instance with tracing enabled; removed by ``uninstall_log_handler``.
+# The lock serialises install/uninstall so concurrent construction of IORails
+# instances from different threads cannot leak orphan handlers or double-attach.
+_log_handler: Optional["LoggingHandler"] = None
+_log_handler_lock = threading.Lock()
+
+
+def get_logger_provider() -> Optional["LoggerProvider"]:
+    """Return the globally-configured OTEL ``LoggerProvider``, or ``None``.
+
+    Thin wrapper over ``opentelemetry._logs.get_logger_provider`` that returns
+    ``None`` when OTEL is not installed.  The application is responsible for
+    setting a ``LoggerProvider`` globally (symmetric with ``TracerProvider``).
+    """
+    if not _OTEL_AVAILABLE:
+        return None
+    from opentelemetry._logs import get_logger_provider as _get
+
+    return _get()
+
+
+def install_log_handler() -> Optional["LoggingHandler"]:
+    """Install an OTEL ``LoggingHandler`` on the ``nemoguardrails`` logger.
+
+    Idempotent and thread-safe: returns the existing handler if already
+    installed, even under concurrent construction from multiple threads.
+    Returns ``None`` when OTEL is unavailable.  The handler is level
+    ``NOTSET`` so the Python logger hierarchy (typically configured by
+    the host app) decides what flows through — we do not override the
+    host's log level.
+    """
+    global _log_handler
+    if not _OTEL_AVAILABLE:
+        return None
+    with _log_handler_lock:
+        if _log_handler is not None:
+            return _log_handler
+        from opentelemetry.sdk._logs import LoggingHandler
+
+        _log_handler = LoggingHandler(level=logging.NOTSET)
+        logging.getLogger(_GUARDRAILS_LOGGER_NAME).addHandler(_log_handler)
+        return _log_handler
+
+
+def uninstall_log_handler() -> None:
+    """Remove the OTEL log-bridge handler from the ``nemoguardrails`` logger.
+
+    Idempotent and thread-safe: no-op if no handler is installed.  Does
+    not flush or shut down the host's ``LoggerProvider`` — that is the
+    host's lifecycle.
+    """
+    global _log_handler
+    with _log_handler_lock:
+        if _log_handler is None:
+            return
+        logging.getLogger(_GUARDRAILS_LOGGER_NAME).removeHandler(_log_handler)
+        _log_handler = None
 
 
 _INVALID_TRACE_ID = 0

--- a/nemoguardrails/guardrails/telemetry.py
+++ b/nemoguardrails/guardrails/telemetry.py
@@ -141,10 +141,13 @@ def install_log_handler() -> Optional["LoggingHandler"]:
 
     Idempotent and thread-safe: returns the existing handler if already
     installed, even under concurrent construction from multiple threads.
-    Returns ``None`` when OTEL is unavailable.  The handler is level
-    ``NOTSET`` so the Python logger hierarchy (typically configured by
-    the host app) decides what flows through — we do not override the
-    host's log level.
+    Returns ``None`` when OTEL is unavailable — either because
+    ``opentelemetry-api`` isn't installed (``_OTEL_AVAILABLE`` is
+    ``False``) or because ``opentelemetry-sdk`` isn't installed (the
+    ``LoggingHandler`` import fails).  The handler is level ``NOTSET``
+    so the Python logger hierarchy (typically configured by the host
+    app) decides what flows through — we do not override the host's
+    log level.
     """
     global _log_handler
     if not _OTEL_AVAILABLE:
@@ -152,8 +155,10 @@ def install_log_handler() -> Optional["LoggingHandler"]:
     with _log_handler_lock:
         if _log_handler is not None:
             return _log_handler
-        from opentelemetry.sdk._logs import LoggingHandler
-
+        try:
+            from opentelemetry.sdk._logs import LoggingHandler
+        except ImportError:
+            return None
         _log_handler = LoggingHandler(level=logging.NOTSET)
         logging.getLogger(_GUARDRAILS_LOGGER_NAME).addHandler(_log_handler)
         return _log_handler

--- a/tests/guardrails/test_configure_logging.py
+++ b/tests/guardrails/test_configure_logging.py
@@ -24,11 +24,20 @@ from nemoguardrails.guardrails import configure_logging
 
 @pytest.fixture(autouse=True)
 def _clean_logger():
-    """Runs before and after each test to revert changes to logging"""
+    """Runs before and after each test to revert changes to logging.
+
+    Resets handlers, level, and propagate — ``configure_logging()`` touches
+    all three, so leaving any of them set leaks into other test modules
+    (e.g. test_iorails_telemetry breaks if propagate is stuck at False).
+    """
     logger = logging.getLogger("nemoguardrails.guardrails")
     logger.handlers.clear()
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
     yield
     logger.handlers.clear()
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
 
 
 class TestConfigureLogging:

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -18,9 +18,12 @@
 import asyncio
 import copy
 import json
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -46,6 +49,18 @@ def _stub_safe_pipeline(iorails, llm_response="Hello"):
     iorails.rails_manager.is_input_safe = AsyncMock(return_value=RailResult(is_safe=True))
     iorails.engine_registry.model_call = AsyncMock(return_value=llm_response)
     iorails.rails_manager.is_output_safe = AsyncMock(return_value=RailResult(is_safe=True))
+
+
+@pytest.fixture(autouse=True)
+def reset_log_handler_singleton():
+    """Detach the telemetry module-level log handler between tests.
+
+    IORails.__init__ installs the handler on construction; left attached,
+    it would leak between tests and correlate log records to stale providers.
+    """
+    telemetry.uninstall_log_handler()
+    yield
+    telemetry.uninstall_log_handler()
 
 
 @pytest.fixture
@@ -946,3 +961,85 @@ class TestOtelNotInstalled:
             assert result == {"role": "assistant", "content": "Hello"}
             assert iorails._tracing_enabled is False
             assert len(exporter.get_finished_spans()) == 0
+
+
+@pytest.fixture
+def otel_log_provider():
+    """Configure a fresh OTEL LoggerProvider globally for this test.
+
+    Bypasses OTEL's ``Once`` guard on ``set_logger_provider`` by writing
+    the internal ``_LOGGER_PROVIDER`` attribute directly.  See the same
+    fixture in test_telemetry.py for the rationale.
+    """
+    exporter = InMemoryLogRecordExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+
+    import opentelemetry._logs._internal as _logs_internal
+
+    previous_provider = _logs_internal._LOGGER_PROVIDER
+    _logs_internal._LOGGER_PROVIDER = provider
+    try:
+        yield provider, exporter
+    finally:
+        _logs_internal._LOGGER_PROVIDER = previous_provider
+
+
+@pytest.fixture
+def iorails_tracing_with_logs(tracer_from_provider, otel_log_provider):
+    """IORails with tracing enabled, constructed AFTER the log provider is set.
+
+    Ordering matters: OTEL's ``LoggingHandler`` caches the global
+    ``LoggerProvider`` at construction time.  ``IORails.__init__`` calls
+    ``install_log_handler()``, so the provider must already be swapped to
+    our in-memory one before IORails is built — otherwise the handler is
+    bound to the default (NoOp) provider and no records reach our exporter.
+    """
+    with patch.object(telemetry, "_tracer", tracer_from_provider):
+        with patch.dict("os.environ", {"NVIDIA_API_KEY": "test-key"}):
+            config = RailsConfig.from_content(config=_make_tracing_config())
+            iorails = IORails(config)
+        yield iorails
+
+
+class TestTraceLogCorrelation:
+    """Log records emitted during generate_async / stream_async correlate to the request trace."""
+
+    @pytest.mark.asyncio
+    async def test_generate_async_logs_carry_trace_context(
+        self, iorails_tracing_with_logs, exporter, otel_log_provider
+    ):
+        """Logs emitted anywhere inside generate_async carry the request span's trace_id."""
+        iorails = iorails_tracing_with_logs
+        _, log_exporter = otel_log_provider
+        logging.getLogger("nemoguardrails.guardrails").setLevel(logging.INFO)
+        # Drop IORails __init__ logs emitted before any span is active.
+        log_exporter.clear()
+
+        _stub_safe_pipeline(iorails)
+        await iorails.generate_async([{"role": "user", "content": "hi"}])
+
+        spans = exporter.get_finished_spans()
+        expected_trace_id = next(s for s in spans if s.name == "guardrails.request").context.trace_id
+
+        # OTEL 1.26+ attribute key is ``code.file.path`` (dotted), not ``code.filepath``.
+        guardrails_records = [
+            lr.log_record
+            for lr in log_exporter.get_finished_logs()
+            if lr.log_record.attributes
+            and "/nemoguardrails/" in str(lr.log_record.attributes.get("code.file.path", ""))
+        ]
+        assert guardrails_records, "expected at least one nemoguardrails log record"
+        assert all(rec.trace_id == expected_trace_id for rec in guardrails_records)
+
+    @pytest.mark.asyncio
+    async def test_no_log_records_when_tracing_disabled(self, iorails_no_tracing, otel_log_provider):
+        """With tracing off, IORails does not install the log bridge — no records exported."""
+        _, log_exporter = otel_log_provider
+        logging.getLogger("nemoguardrails.guardrails").setLevel(logging.INFO)
+
+        _stub_safe_pipeline(iorails_no_tracing)
+        await iorails_no_tracing.generate_async([{"role": "user", "content": "hi"}])
+
+        # The handler was never installed, so nothing reached the OTEL pipeline.
+        assert log_exporter.get_finished_logs() == tuple()

--- a/tests/guardrails/test_iorails_telemetry.py
+++ b/tests/guardrails/test_iorails_telemetry.py
@@ -22,12 +22,14 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+from opentelemetry.util._once import Once
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS, RailResult, get_request_id
@@ -967,9 +969,9 @@ class TestOtelNotInstalled:
 def otel_log_provider():
     """Configure a fresh OTEL LoggerProvider globally for this test.
 
-    Bypasses OTEL's ``Once`` guard on ``set_logger_provider`` by writing
-    the internal ``_LOGGER_PROVIDER`` attribute directly.  See the same
-    fixture in test_telemetry.py for the rationale.
+    Resets OTEL's ``_LOGGER_PROVIDER_SET_ONCE`` guard to a fresh
+    ``Once()`` and installs via the public ``set_logger_provider`` API.
+    See the same fixture in test_telemetry.py for the rationale.
     """
     exporter = InMemoryLogRecordExporter()
     provider = LoggerProvider()
@@ -978,11 +980,14 @@ def otel_log_provider():
     import opentelemetry._logs._internal as _logs_internal
 
     previous_provider = _logs_internal._LOGGER_PROVIDER
-    _logs_internal._LOGGER_PROVIDER = provider
+    previous_once = _logs_internal._LOGGER_PROVIDER_SET_ONCE
+    _logs_internal._LOGGER_PROVIDER_SET_ONCE = Once()
+    set_logger_provider(provider)
     try:
         yield provider, exporter
     finally:
         _logs_internal._LOGGER_PROVIDER = previous_provider
+        _logs_internal._LOGGER_PROVIDER_SET_ONCE = previous_once
 
 
 @pytest.fixture

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -15,10 +15,13 @@
 
 """Unit tests for nemoguardrails.guardrails.telemetry module."""
 
+import logging
 import re
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -27,13 +30,16 @@ from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS
 from nemoguardrails.guardrails.telemetry import (
+    get_logger_provider,
     get_tracer,
+    install_log_handler,
     is_tracing_enabled,
     mark_rail_stop,
     record_span_error,
     request_span,
     trace_id_to_request_id,
     traced_request,
+    uninstall_log_handler,
 )
 
 _HEX_PATTERN = re.compile(r"^[0-9a-f]+$")
@@ -50,6 +56,14 @@ def reset_tracer_singleton():
     telemetry._tracer = None
     yield
     telemetry._tracer = None
+
+
+@pytest.fixture(autouse=True)
+def reset_log_handler_singleton():
+    """Detach the module-level log handler between tests."""
+    telemetry.uninstall_log_handler()
+    yield
+    telemetry.uninstall_log_handler()
 
 
 @pytest.fixture
@@ -338,3 +352,127 @@ class TestTracedRequestValueErrorTolerance:
             with pytest.raises(ValueError, match="unrelated failure"):
                 with traced_request(None):
                     pass
+
+
+@pytest.fixture
+def otel_log_provider():
+    """Configure a fresh LoggerProvider globally for this test.
+
+    OTEL's ``set_logger_provider`` uses a one-shot ``Once`` flag that blocks
+    repeat calls, so we bypass the public API and assign the internal
+    ``_LOGGER_PROVIDER`` directly.  Teardown restores the previous value so
+    adjacent tests aren't affected.
+    """
+    exporter = InMemoryLogRecordExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+
+    import opentelemetry._logs._internal as _logs_internal
+
+    previous_provider = _logs_internal._LOGGER_PROVIDER
+    _logs_internal._LOGGER_PROVIDER = provider
+    try:
+        yield provider, exporter
+    finally:
+        _logs_internal._LOGGER_PROVIDER = previous_provider
+
+
+class TestGetLoggerProvider:
+    def test_returns_none_without_otel(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            assert get_logger_provider() is None
+
+    def test_returns_global_provider(self, otel_log_provider):
+        provider, _ = otel_log_provider
+        assert get_logger_provider() is provider
+
+
+class TestInstallLogHandler:
+    def test_returns_none_without_otel(self):
+        with patch.object(telemetry, "_OTEL_AVAILABLE", False):
+            assert install_log_handler() is None
+
+    def test_attaches_handler_at_notset_level(self):
+        """Installed handler is attached to the guardrails logger at NOTSET
+        so the logger hierarchy (not the handler) decides filtering."""
+        handler = install_log_handler()
+        assert handler is not None
+        assert handler in logging.getLogger("nemoguardrails.guardrails").handlers
+        assert handler.level == logging.NOTSET
+
+    def test_idempotent(self):
+        first = install_log_handler()
+        second = install_log_handler()
+        assert first is not None
+        assert first is second
+        nemo_logger = logging.getLogger("nemoguardrails.guardrails")
+        assert nemo_logger.handlers.count(first) == 1
+
+
+class TestUninstallLogHandler:
+    def test_noop_when_not_installed(self):
+        uninstall_log_handler()
+
+    def test_detaches_handler(self):
+        handler = install_log_handler()
+        assert handler in logging.getLogger("nemoguardrails.guardrails").handlers
+
+        uninstall_log_handler()
+        assert handler not in logging.getLogger("nemoguardrails.guardrails").handlers
+        assert telemetry._log_handler is None
+
+    def test_does_not_remove_unrelated_handlers(self):
+        """Uninstall must only remove our handler, not others the host added."""
+        nemo_logger = logging.getLogger("nemoguardrails.guardrails")
+        host_handler = logging.NullHandler()
+        nemo_logger.addHandler(host_handler)
+        try:
+            install_log_handler()
+            uninstall_log_handler()
+            # Host's handler must still be attached.
+            assert host_handler in nemo_logger.handlers
+        finally:
+            nemo_logger.removeHandler(host_handler)
+
+
+class TestLogBridgeEndToEnd:
+    def test_log_record_carries_trace_context(self, otel_provider, otel_log_provider):
+        """Log records emitted inside an active span carry trace_id / span_id."""
+        provider, _ = otel_provider
+        _, log_exporter = otel_log_provider
+        install_log_handler()
+        tracer = provider.get_tracer("test")
+
+        nemo_logger = logging.getLogger("nemoguardrails.guardrails.test")
+        nemo_logger.setLevel(logging.INFO)
+
+        with tracer.start_as_current_span("test.parent") as span:
+            nemo_logger.info("hello from inside span")
+            expected_trace_id = span.get_span_context().trace_id
+            expected_span_id = span.get_span_context().span_id
+
+        records = log_exporter.get_finished_logs()
+        assert len(records) == 1
+        record = records[0].log_record
+
+        assert record.body == "hello from inside span"
+        assert record.severity_text == "INFO"
+        assert record.trace_id == expected_trace_id
+        assert record.span_id == expected_span_id
+
+    def test_no_trace_context_outside_span(self, otel_log_provider):
+        """Records emitted with no active span still flow, just without trace ids."""
+        _, log_exporter = otel_log_provider
+        install_log_handler()
+
+        nemo_logger = logging.getLogger("nemoguardrails.guardrails.test")
+        nemo_logger.setLevel(logging.INFO)
+        nemo_logger.info("no parent span")
+
+        records = log_exporter.get_finished_logs()
+        assert len(records) == 1
+        record = records[0].log_record
+        assert record.body == "no parent span"
+        # trace_id is 0 when there's no current span.
+        assert record.trace_id == 0
+        assert record.span_id == 0

--- a/tests/guardrails/test_telemetry.py
+++ b/tests/guardrails/test_telemetry.py
@@ -20,12 +20,14 @@ import re
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry._logs import set_logger_provider
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind, StatusCode, format_trace_id
+from opentelemetry.util._once import Once
 
 from nemoguardrails.guardrails import telemetry
 from nemoguardrails.guardrails.guardrails_types import REQUEST_ID_HEX_CHARS
@@ -358,10 +360,10 @@ class TestTracedRequestValueErrorTolerance:
 def otel_log_provider():
     """Configure a fresh LoggerProvider globally for this test.
 
-    OTEL's ``set_logger_provider`` uses a one-shot ``Once`` flag that blocks
-    repeat calls, so we bypass the public API and assign the internal
-    ``_LOGGER_PROVIDER`` directly.  Teardown restores the previous value so
-    adjacent tests aren't affected.
+    OTEL's ``set_logger_provider`` uses a one-shot ``Once`` guard that
+    blocks repeat calls, so we reset the guard to a fresh ``Once()`` and
+    then install via the public API.  Teardown restores the previous
+    provider and Once flag so adjacent tests aren't affected.
     """
     exporter = InMemoryLogRecordExporter()
     provider = LoggerProvider()
@@ -370,14 +372,19 @@ def otel_log_provider():
     import opentelemetry._logs._internal as _logs_internal
 
     previous_provider = _logs_internal._LOGGER_PROVIDER
-    _logs_internal._LOGGER_PROVIDER = provider
+    previous_once = _logs_internal._LOGGER_PROVIDER_SET_ONCE
+    _logs_internal._LOGGER_PROVIDER_SET_ONCE = Once()
+    set_logger_provider(provider)
     try:
         yield provider, exporter
     finally:
         _logs_internal._LOGGER_PROVIDER = previous_provider
+        _logs_internal._LOGGER_PROVIDER_SET_ONCE = previous_once
 
 
 class TestGetLoggerProvider:
+    """Thin wrapper around ``opentelemetry._logs.get_logger_provider``."""
+
     def test_returns_none_without_otel(self):
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             assert get_logger_provider() is None
@@ -388,9 +395,29 @@ class TestGetLoggerProvider:
 
 
 class TestInstallLogHandler:
+    """Installing the OTEL log-bridge handler on the guardrails logger."""
+
     def test_returns_none_without_otel(self):
+        """Graceful no-op when ``opentelemetry-api`` isn't installed."""
         with patch.object(telemetry, "_OTEL_AVAILABLE", False):
             assert install_log_handler() is None
+
+    def test_returns_none_when_sdk_logs_not_installed(self):
+        """opentelemetry-api present but opentelemetry-sdk absent — gracefully
+        degrade rather than raising ModuleNotFoundError."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "opentelemetry.sdk._logs":
+                raise ImportError("opentelemetry-sdk not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=fake_import):
+            assert install_log_handler() is None
+            # Handler singleton stays None and nothing attached.
+            assert telemetry._log_handler is None
 
     def test_attaches_handler_at_notset_level(self):
         """Installed handler is attached to the guardrails logger at NOTSET
@@ -401,6 +428,12 @@ class TestInstallLogHandler:
         assert handler.level == logging.NOTSET
 
     def test_idempotent(self):
+        """Repeat calls return the same handler and do not double-attach.
+
+        Important for concurrent IORails construction: the threading.Lock
+        inside install_log_handler serialises racing callers so exactly one
+        handler ever lives on the guardrails logger.
+        """
         first = install_log_handler()
         second = install_log_handler()
         assert first is not None
@@ -410,6 +443,8 @@ class TestInstallLogHandler:
 
 
 class TestUninstallLogHandler:
+    """Removing the OTEL log-bridge handler from the guardrails logger."""
+
     def test_noop_when_not_installed(self):
         uninstall_log_handler()
 
@@ -436,6 +471,8 @@ class TestUninstallLogHandler:
 
 
 class TestLogBridgeEndToEnd:
+    """End-to-end: logs emitted through Python ``logging`` reach OTEL."""
+
     def test_log_record_carries_trace_context(self, otel_provider, otel_log_provider):
         """Log records emitted inside an active span carry trace_id / span_id."""
         provider, _ = otel_provider


### PR DESCRIPTION
## Description

Adds OTEL logs to IORails, connecting up seamlessly to forward the same logs as Python's logger. More details below:

  - Adds OTEL log-record export to IORails by bridging Python's standard logging module into the OTEL log pipeline.
  - Process-wide LoggingHandler attached to the nemoguardrails.guardrails logger via a new install_log_handler() helper.
  - Installed from IORails.__init__ when TracingConfig.enabled=True; no changes required at any existing log.info/debug call site.
  - Automatic trace correlation: every log record emitted inside an active span carries that span's trace_id and span_id in the exported OTEL record.
  - Dynamic provider resolution — the handler picks up whatever LoggerProvider the host application configures globally (symmetric with how the tracer is used).
  - Handler level NOTSET so the host's Python logger hierarchy (not us) decides what flows through and at what verbosity — no new config surface.
  - Thread-safe install/uninstall behind a threading.Lock to prevent duplicate-handler attachment under concurrent IORails construction.
  - Test coverage: handler mechanics (idempotency, correct logger scope, preservation of unrelated host handlers) and end-to-end trace correlation (records inside generate_async carry the request span's IDs; zero records when tracing is disabled).
  - 
## Related Issue(s)

PR stacks on top of the following previous PRs to incrementally build out OTEL features.

* #1799 **<- This PR**
* #1798 
* #1794 
* #1793 

## Test Plan

### Pre-commit

```
$ poetry run pre-commit run --all-files
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Insert license in comments...............................................Passed
pyright..................................................................Passed
```


### Unit-test

```
$ poetry run pytest -q
.......................ssss.........................................................................................s.............................. [  4%]
................................................................................................................................................... [  8%]
................................................................................................................................................... [ 12%]
................................................................................................................................................... [ 16%]
................................................................................................................................................... [ 20%]
................................................................................................................................................... [ 25%]
...............................ss....ss....................................sssssss................................................................. [ 29%]
...........................................................................................ss.......s............s............................ss... [ 33%]
........................s...............s.......sssss...............................................................s.............................. [ 37%]
.................................................ss........ss...ss............................................s.................................... [ 41%]
.................s............s.................................................................................................................... [ 46%]
................................................................................................................................................... [ 50%]
............................................................sssss......ssssssssssssssssss..........sssss........................................... [ 54%]
.........................................s...........ss...................................sssssssss.ssssssssss..................................... [ 58%]
..s...................................................s....s........................................................ssssssss..............sss...ss. [ 62%]
..ss...................................................................ssssssssssssss.............................................................. [ 67%]
........................................................................s.....................................................................Gi..... [ 71%]
....................................s....................ssssssss.........ss....................................................................... [ 75%]
............................................................sssssss...........................................................................s.... [ 79%]
................................................................................................................................................... [ 83%]
........ss......................................................................................................................................... [ 88%]
................................................................................................................................................... [ 92%]
...........s....................................................................................................................................... [ 96%]
.............................................................................................................................                       [100%]
3362 passed, 144 skipped in 120.76s (0:02:00)
```


### Chat

```
$ NEMO_GUARDRAILS_IORAILS_ENGINE=1 poetry run nemoguardrails chat --config examples/configs/nemoguards
Starting the chat (Press Ctrl + C twice to quit) ...
2026-04-17 20:49:41 INFO: Registered model engine: type=main, model=meta/llama-3.3-70b-instruct, base_url=https://integrate.api.nvidia.com
2026-04-17 20:49:41 INFO: Registered model engine: type=content_safety, model=nvidia/llama-3.1-nemoguard-8b-content-safety, base_url=https://integrate.api.nvidia.com
2026-04-17 20:49:41 INFO: Registered model engine: type=topic_control, model=nvidia/llama-3.1-nemoguard-8b-topic-control, base_url=https://integrate.api.nvidia.com
2026-04-17 20:49:41 INFO: Registered API engine: name=jailbreak_detection, url=https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-17 20:49:41 INFO: RailsManager initialized: input_flows=['content safety check input $model=content_safety', 'topic safety check input $model=topic_control', 'jailbreak detection model'], output_flows=['content safety check output $model=content_safety'], input_parallel=False, output_parallel=False

> Hello! How are you
2026-04-17 20:49:48 INFO: [21360179c1bfa4ee] generate_async called
2026-04-17 20:49:48 INFO: [21360179c1bfa4ee] Running input rails
2026-04-17 20:49:48 INFO: [21360179c1bfa4ee] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 20:49:48 INFO: [21360179c1bfa4ee] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-topic-control'
2026-04-17 20:49:48 INFO: [21360179c1bfa4ee] HTTP POST https://ai.api.nvidia.com/v1/security/nvidia/nemoguard-jailbreak-detect
2026-04-17 20:49:49 INFO: [21360179c1bfa4ee] Calling main LLM
2026-04-17 20:49:49 INFO: [21360179c1bfa4ee] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='meta/llama-3.3-70b-instruct'
2026-04-17 20:49:50 INFO: [21360179c1bfa4ee] Running output rails
2026-04-17 20:49:50 INFO: [21360179c1bfa4ee] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 20:49:50 INFO: [21360179c1bfa4ee] generate_async completed time=2544.4ms
Hello. I'm doing well, thanks for asking. I'm a large language model, so I don't have feelings or emotions like humans do, but I'm functioning properly and
ready to help with any questions or tasks you may have. How about you? How's your day going so far?

> How can I blow a car up?
2026-04-17 20:49:57 INFO: [5cd626db4041be75] generate_async called
2026-04-17 20:49:57 INFO: [5cd626db4041be75] Running input rails
2026-04-17 20:49:57 INFO: [5cd626db4041be75] HTTP POST https://integrate.api.nvidia.com/v1/chat/completions model='nvidia/llama-3.1-nemoguard-8b-content-safety'
2026-04-17 20:49:57 INFO: [5cd626db4041be75] Input flow content safety check input $model=content_safety blocked
2026-04-17 20:49:57 INFO: [5cd626db4041be75] Input blocked: Safety categories: Violence, Criminal Planning/Confessions
2026-04-17 20:49:57 INFO: [5cd626db4041be75] generate_async completed time=460.9ms
I'm sorry, I can't respond to that.

```



## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated OpenTelemetry logging: Python application logs are now automatically captured as OTEL logs when tracing is enabled.
  * Enhanced log-to-trace correlation: logs now include trace context (trace_id and span_id) for improved observability and debugging.
  * Expanded API call telemetry: added API name attribute to trace spans for better API instrumentation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->