### PR TITLE
fix(tests): use asyncio.run instead of get_event_loop in middleware tests

### DIFF
--- a/tests/guardrails/test_iorails.py
+++ b/tests/guardrails/test_iorails.py
@@ -453,7 +453,7 @@ class TestGenerate:
             iorails.generate([{"role": "user", "content": "hi"}])
 
         with pytest.raises(RuntimeError):
-            asyncio.get_event_loop().run_until_complete(call_generate())
+            asyncio.run(call_generate())
 
 
 class TestRefusalMessage:

--- a/tests/integrations/langchain/test_middleware.py
+++ b/tests/integrations/langchain/test_middleware.py
@@ -509,7 +509,7 @@ class TestSyncMethods:
         async def run_async():
             return await middleware.abefore_model(state, None)
 
-        async_result = asyncio.get_event_loop().run_until_complete(run_async())
+        async_result = asyncio.run(run_async())
 
         assert sync_result == async_result
 
@@ -558,7 +558,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         assert exc_info.value.result is not None
         assert isinstance(exc_info.value.result, RailsResult)
@@ -570,7 +570,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         assert exc_info.value.rail_type is not None
         assert exc_info.value.rail_type in ["input", "output"]
@@ -582,7 +582,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         message = str(exc_info.value)
         assert "Input" in message or "input" in message.lower()
@@ -595,7 +595,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         str_repr = str(exc_info.value)
         assert len(str_repr) > 0
@@ -608,7 +608,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         assert exc_info.value.rail_type == "input"
 
@@ -624,7 +624,7 @@ class TestGuardrailViolationException:
         }
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.aafter_model(state, None))
+            asyncio.run(middleware.aafter_model(state, None))
 
         assert exc_info.value.rail_type == "output"
 
@@ -636,7 +636,7 @@ class TestGuardrailViolationException:
         state = {"messages": [HumanMessage(content="Test")]}
 
         with pytest.raises(GuardrailViolation) as exc_info:
-            asyncio.get_event_loop().run_until_complete(middleware.abefore_model(state, None))
+            asyncio.run(middleware.abefore_model(state, None))
 
         assert exc_info.value.result.rail == rail_name
 


### PR DESCRIPTION
Python 3.13 removed auto creation of an event loop in `asyncio.get_event_loop()` when none is set on the thread. The pattern

```python
asyncio.get_event_loop().run_until_complete(coro)
```

now raises `RuntimeError("There is no current event loop in thread 'MainThread'")` whenever a previous test ran `asyncio.run()` and closed its loop. This test-ordering race is flaky across CI runs (for ref: https://github.com/NVIDIA-NeMo/Guardrails/actions/runs/24666672357).

Replaces all nine occurrences across `tests/integrations/langchain/test_middleware.py` (eight) and `tests/guardrails/test_iorails.py` (one) with `asyncio.run(...)`, which creates and owns its own loop. Behavior preserving python 313 compatible, independent of prior test loop state.

## Test plan

`tests/integrations/langchain/test_middleware.py`:

```
92 passed in 0.74s
```

`tests/guardrails/test_iorails.py`:

```
28 passed in 1.42s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use modern async event loop management patterns for improved test reliability.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->