### PR TITLE
docs(iorails): OTEL Logging page

### DIFF
--- a/docs/observability/tracing/index.md
+++ b/docs/observability/tracing/index.md
@@ -101,6 +101,7 @@ Existing configurations will continue to work. However, it is strongly recommend
 - [](quick-start.md) - Minimal setup to enable tracing using the OpenTelemetry SDK
 - [](adapter-configurations.md) - Detailed configuration for FileSystem, OpenTelemetry, and Custom adapters
 - [](opentelemetry-integration.md) - Production-ready OpenTelemetry setup and ecosystem compatibility
+- [](opentelemetry-logs.md) - Forward guardrails Python logs to OpenTelemetry with trace correlation
 - [](troubleshooting.md) - Common issues and solutions
 
 ## Jupyter Notebooks
@@ -114,5 +115,6 @@ Existing configurations will continue to work. However, it is strongly recommend
 Quick Start <quick-start>
 Adapters <adapter-configurations>
 OpenTelemetry <opentelemetry-integration>
+OpenTelemetry Logs <opentelemetry-logs>
 Troubleshooting <troubleshooting>
 ```

--- a/docs/observability/tracing/opentelemetry-integration.md
+++ b/docs/observability/tracing/opentelemetry-integration.md
@@ -114,3 +114,7 @@ The NeMo Guardrails library works with the entire OpenTelemetry ecosystem includ
 - **Backends**: Any system accepting OpenTelemetry traces
 
 See the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the complete list.
+
+## Exporting Logs
+
+To also forward guardrails Python log records into your OpenTelemetry backend with trace correlation, see [](opentelemetry-logs.md).

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -82,7 +82,6 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogRecordExporter  # ConsoleLogExporter on versions earlier than 1.39.0
 
 from nemoguardrails import LLMRails, RailsConfig

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -29,8 +29,8 @@ This page covers the setup. For plain Python logging (verbose mode, explain, gen
 
 The NeMo Guardrails library follows the OpenTelemetry library-instrumentation pattern.
 
-- **The library depends on the OpenTelemetry API only.** It creates spans, emits log records, and otherwise participates in whatever OTEL pipeline the host application provides.
-- **The host application owns the SDK.** Configuring a `TracerProvider`, a `LoggerProvider`, exporters, and attaching handlers to Python's `logging` tree are all the application's responsibility.
+- The library depends on the OpenTelemetry API only. It creates spans, emits log records, and otherwise participates in whatever OTEL pipeline the host application provides.
+- The host application owns the SDK. Configuring a `TracerProvider`, a `LoggerProvider`, exporters, and attaching handlers to Python's `logging` tree are all the application's responsibility.
 
 This split is deliberate. It lets the NeMo Guardrails library stay decoupled from SDK-version churn, avoids the library injecting itself into a host's observability stack without opt-in, and gives applications full control over where their telemetry is exported.
 
@@ -51,7 +51,7 @@ pip install opentelemetry-exporter-otlp
 Configure a `LoggerProvider` first, then attach the handler. The surrounding SDK setup appears in the [full example below](#full-example-with-traces-and-logs). The core of the bridge is three lines.
 
 ```{important}
-Configure the `LoggerProvider` through `set_logger_provider(...)` **before** you call `addHandler(LoggingHandler())`. The handler resolves its `LoggerProvider` on first emit and caches the result. If no provider is set by then, the SDK hands back a no-op logger and **every forwarded record is silently discarded**. No error is raised, and calling `set_logger_provider(...)` later does not recover the handler.
+Configure the `LoggerProvider` through `set_logger_provider(...)` **before** you call `addHandler(LoggingHandler())`. The handler resolves its `LoggerProvider` on first emit and caches the result. If no provider is set by then, the SDK hands back a no-op logger and **every forwarded record is silently discarded**. The SDK raises no error, and calling `set_logger_provider(...)` later does not recover the handler.
 ```
 
 ```python
@@ -61,7 +61,7 @@ from opentelemetry.sdk._logs import LoggingHandler
 logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
 ```
 
-What each line does.
+Each line does the following:
 
 - `logging.getLogger("nemoguardrails")` selects the logger namespace that catches most records emitted by the NeMo Guardrails library. Submodules that use `logging.getLogger(__name__)` inherit this handler. Verbose mode (`nemoguardrails.logging.verbose`) is the known exception. It writes to the root logger, so attach the handler to the root logger as well if you need verbose output forwarded.
 - `LoggingHandler()` is an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. On first emit it resolves the active `LoggerProvider` through `get_logger_provider()`, caches the resulting logger, and attaches trace context automatically.
@@ -142,20 +142,26 @@ The OpenTelemetry Collector then forwards the records to any compatible backend,
 
 Each forwarded `LogRecord` becomes an OTEL log record with the following fields populated automatically.
 
-- **Body** contains the formatted log message.
-- **Severity** records `severity_text` (`INFO`, `DEBUG`, `ERROR`, and so on) and `severity_number`.
-- **Timestamp** records the record's emit time.
-- **Trace context** carries the `trace_id` and `span_id` of the active span when the record was emitted. The values are zero when no span is active.
-- **Code attributes** include `code.file.path`, `code.function.name`, and `code.line.number` derived from the Python `LogRecord`.
+| Field | Description |
+|-------|-------------|
+| Body | Contains the formatted log message. |
+| Severity | Records `severity_text` (`INFO`, `DEBUG`, `ERROR`, and so on) and `severity_number`. |
+| Timestamp | Records the record's emit time. |
+| Trace context | Carries the `trace_id` and `span_id` of the active span when the record was emitted. The values are zero when no span is active. |
+| Code attributes | Include `code.file.path`, `code.function.name`, and `code.line.number` derived from the Python `LogRecord`. |
 
 Log records emitted outside any guardrails request (startup, engine registration, teardown) still flow through, but their `trace_id` / `span_id` are zero because there is no active span.
 
 ## Considerations
 
-- **Experimental SDK surface.** Both the `opentelemetry.sdk._logs` module and the OTLP log exporter at `opentelemetry.exporter.otlp.proto.grpc._log_exporter` are still under active development in the OpenTelemetry Python ecosystem. The underscore prefix on both paths denotes a non-stable API. Pin your `opentelemetry-sdk` and `opentelemetry-exporter-otlp` versions in production and review release notes before upgrading.
-- **Privacy.** Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention and redaction policies cover them.
-- **Performance.** At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
-- **Interaction with `propagate=False`.** If your application calls `nemoguardrails.guardrails.configure_logging()` on a freshly initialized logger, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. The flag is only set on the first call, when no handlers exist yet. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
+- Experimental SDK surface
+  : Both the `opentelemetry.sdk._logs` module and the OTLP log exporter at `opentelemetry.exporter.otlp.proto.grpc._log_exporter` are still under active development in the OpenTelemetry Python ecosystem. The underscore prefix on both paths denotes a non-stable API. Pin your `opentelemetry-sdk` and `opentelemetry-exporter-otlp` versions in production and review release notes before upgrading.
+- Privacy
+  : Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention and redaction policies cover them.
+- Performance
+  : At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
+- Interaction with `propagate=False`
+  : If your application calls `nemoguardrails.guardrails.configure_logging()` on a freshly initialized logger, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. The flag is only set on the first call, when no handlers exist yet. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
 
 ## Related Resources
 

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -82,7 +82,8 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogRecordExporter  # ConsoleLogExporter on versions earlier than 1.39.0
 
 from nemoguardrails import LLMRails, RailsConfig
 

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -96,7 +96,7 @@ trace.set_tracer_provider(tracer_provider)
 
 # 2. Logs → console
 logger_provider = LoggerProvider(resource=resource)
-logger_provider.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogExporter()))
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogRecordExporter()))
 set_logger_provider(logger_provider)
 
 # 3. Forward nemoguardrails log records into the OTEL pipeline

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -23,11 +23,11 @@ content:
 
 The NeMo Guardrails library emits operational logs through Python's standard `logging` module. When you have OpenTelemetry tracing configured, you can forward those log records into the same backend as your traces with a few lines of application code. Records emitted inside an active guardrails span automatically carry the span's `trace_id` and `span_id`, so every log line correlates to the request that produced it.
 
-This page covers the setup. For plain Python logging (verbose mode, explain, generation options), see [](../logging/index.md).
+This page covers the setup. For plain Python logging (verbose mode, explain, generation options), refer to [](../logging/index.md).
 
 ## API and SDK Responsibilities
 
-The NeMo Guardrails library follows the OpenTelemetry library-instrumentation pattern:
+The NeMo Guardrails library follows the OpenTelemetry library-instrumentation pattern.
 
 - **The library depends on the OpenTelemetry API only.** It creates spans, emits log records, and otherwise participates in whatever OTEL pipeline the host application provides.
 - **The host application owns the SDK.** Configuring a `TracerProvider`, a `LoggerProvider`, exporters, and attaching handlers to Python's `logging` tree are all the application's responsibility.
@@ -38,17 +38,21 @@ The three-line recipe below is therefore a user-side setup, not something the li
 
 ## Prerequisites
 
-Before enabling log export, install the OpenTelemetry SDK as described in [](opentelemetry-integration.md#installation). The OpenTelemetry log components live in the same `opentelemetry-sdk` package that powers trace export — no additional installation is required for in-process log forwarding.
+Before enabling log export, install the OpenTelemetry SDK as described in [](opentelemetry-integration.md#installation). The OpenTelemetry log components live in the same `opentelemetry-sdk` package that powers trace export. No additional installation is required for in-process log forwarding.
 
-For exporting logs to an external backend over OTLP, install the OTLP exporter:
+For exporting logs to an external backend over OTLP, install the OTLP exporter.
 
 ```bash
 pip install opentelemetry-exporter-otlp
 ```
 
-## Minimal Setup: Attach the Logging Handler
+## Attach the Logging Handler
 
-Add three lines to your application startup to forward `nemoguardrails` log records into the OpenTelemetry log pipeline:
+Configure a `LoggerProvider` first, then attach the handler. The surrounding SDK setup appears in the [full example below](#full-example-with-traces-and-logs). The core of the bridge is three lines.
+
+```{important}
+Configure the `LoggerProvider` through `set_logger_provider(...)` **before** you call `addHandler(LoggingHandler())`. The handler resolves its `LoggerProvider` on first emit and caches the result. If no provider is set by then, the SDK hands back a no-op logger and **every forwarded record is silently discarded**. No error is raised, and calling `set_logger_provider(...)` later does not recover the handler.
+```
 
 ```python
 import logging
@@ -57,19 +61,15 @@ from opentelemetry.sdk._logs import LoggingHandler
 logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
 ```
 
-```{important}
-These three lines are not independently sufficient. `LoggingHandler()` resolves the active `LoggerProvider` at emit time, and when no provider has been configured via `set_logger_provider(...)` the SDK falls back to a no-op proxy that **silently discards every forwarded record** — no error is raised. You must also configure a `LoggerProvider` with a processor and exporter as shown in the [full example below](#full-example-traces-and-logs-together) before records will actually leave your process.
-```
+What each line does.
 
-What each line does:
+- `logging.getLogger("nemoguardrails")` selects the logger namespace that catches most records emitted by the NeMo Guardrails library. Submodules that use `logging.getLogger(__name__)` inherit this handler. Verbose mode (`nemoguardrails.logging.verbose`) is the known exception. It writes to the root logger, so attach the handler to the root logger as well if you need verbose output forwarded.
+- `LoggingHandler()` is an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. On first emit it resolves the active `LoggerProvider` through `get_logger_provider()`, caches the resulting logger, and attaches trace context automatically.
+- `.addHandler(...)` attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, and so on) and the OpenTelemetry pipeline, provided a `LoggerProvider` was configured before this call.
 
-- `logging.getLogger("nemoguardrails")` — selects the logger namespace that catches every log record emitted by the NeMo Guardrails library (all submodules log under this prefix).
-- `LoggingHandler()` — an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. Resolves the active `LoggerProvider` at emit time and attaches trace context automatically.
-- `.addHandler(...)` — attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, etc.) and the OpenTelemetry pipeline — provided a `LoggerProvider` has been configured.
+This is **additive**. Your existing Python logging configuration continues to work unchanged. OpenTelemetry export happens alongside, not instead.
 
-This is **additive**: your existing Python logging configuration continues to work unchanged. OpenTelemetry export happens alongside, not instead.
-
-## Full Example: Traces and Logs Together
+## Full Example with Traces and Logs
 
 This program configures a `TracerProvider` and a `LoggerProvider`, both exporting to the console, then runs a guardrails request so you can see correlated spans and log records.
 
@@ -126,39 +126,39 @@ Running this script prints both the span tree and the log records to your consol
 
 ## Exporting to a Backend
 
-The log-record processor in the example above can target any OpenTelemetry log exporter. For an OTLP collector:
+The log-record processor in the example above can target any OpenTelemetry log exporter. The following example uses an OTLP collector.
 
 ```python
-# Private module — see "Experimental SDK surface" under Considerations
+# Private module. Refer to "Experimental SDK surface" under Considerations.
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 
 otlp_log_exporter = OTLPLogExporter(endpoint="http://localhost:4317", insecure=True)
 logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_log_exporter))
 ```
 
-The OpenTelemetry Collector then forwards the records to any compatible backend — Loki, Datadog, New Relic, Elastic, and so on. See the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the list.
+The OpenTelemetry Collector then forwards the records to any compatible backend, such as Loki, Datadog, New Relic, or Elastic. Refer to the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the list.
 
 ## What the Exported Records Contain
 
-Each forwarded `LogRecord` becomes an OTEL log record with the following fields populated automatically:
+Each forwarded `LogRecord` becomes an OTEL log record with the following fields populated automatically.
 
-- **Body** — the formatted log message.
-- **Severity** — `severity_text` (`INFO`, `DEBUG`, `ERROR`, etc.) and `severity_number`.
-- **Timestamp** — the record's emit time.
-- **Trace context** — `trace_id` and `span_id` of the active span when the record was emitted. Zero when no span is active.
-- **Code attributes** — `code.file.path`, `code.function.name`, `code.line.number` derived from the Python `LogRecord`.
+- **Body** contains the formatted log message.
+- **Severity** records `severity_text` (`INFO`, `DEBUG`, `ERROR`, and so on) and `severity_number`.
+- **Timestamp** records the record's emit time.
+- **Trace context** carries the `trace_id` and `span_id` of the active span when the record was emitted. The values are zero when no span is active.
+- **Code attributes** include `code.file.path`, `code.function.name`, and `code.line.number` derived from the Python `LogRecord`.
 
 Log records emitted outside any guardrails request (startup, engine registration, teardown) still flow through, but their `trace_id` / `span_id` are zero because there is no active span.
 
 ## Considerations
 
 - **Experimental SDK surface.** Both the `opentelemetry.sdk._logs` module and the OTLP log exporter at `opentelemetry.exporter.otlp.proto.grpc._log_exporter` are still under active development in the OpenTelemetry Python ecosystem. The underscore prefix on both paths denotes a non-stable API. Pin your `opentelemetry-sdk` and `opentelemetry-exporter-otlp` versions in production and review release notes before upgrading.
-- **Privacy.** Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention/redaction policies cover them.
+- **Privacy.** Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention and redaction policies cover them.
 - **Performance.** At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
-- **Interaction with `propagate=False`.** If your application calls `nemoguardrails.guardrails.configure_logging()`, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
+- **Interaction with `propagate=False`.** If your application calls `nemoguardrails.guardrails.configure_logging()` on a freshly initialized logger, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. The flag is only set on the first call, when no handlers exist yet. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
 
 ## Related Resources
 
-- [](opentelemetry-integration.md) — SDK installation and trace export setup.
-- [](quick-start.md) — minimal tracing setup with the OpenTelemetry SDK.
-- [](../logging/index.md) — Python logging, verbose mode, and the `log` generation option for in-process debugging.
+- [](opentelemetry-integration.md) covers SDK installation and trace export setup.
+- [](quick-start.md) provides a minimal tracing setup with the OpenTelemetry SDK.
+- [](../logging/index.md) covers Python logging, verbose mode, and the `log` generation option for in-process debugging.

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -57,11 +57,15 @@ from opentelemetry.sdk._logs import LoggingHandler
 logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
 ```
 
+```{important}
+These three lines are not independently sufficient. `LoggingHandler()` resolves the active `LoggerProvider` at emit time, and when no provider has been configured via `set_logger_provider(...)` the SDK falls back to a no-op proxy that **silently discards every forwarded record** — no error is raised. You must also configure a `LoggerProvider` with a processor and exporter as shown in the [full example below](#full-example-traces-and-logs-together) before records will actually leave your process.
+```
+
 What each line does:
 
 - `logging.getLogger("nemoguardrails")` — selects the logger namespace that catches every log record emitted by the NeMo Guardrails library (all submodules log under this prefix).
 - `LoggingHandler()` — an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. Resolves the active `LoggerProvider` at emit time and attaches trace context automatically.
-- `.addHandler(...)` — attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, etc.) and the OpenTelemetry pipeline.
+- `.addHandler(...)` — attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, etc.) and the OpenTelemetry pipeline — provided a `LoggerProvider` has been configured.
 
 This is **additive**: your existing Python logging configuration continues to work unchanged. OpenTelemetry export happens alongside, not instead.
 
@@ -125,6 +129,7 @@ Running this script prints both the span tree and the log records to your consol
 The log-record processor in the example above can target any OpenTelemetry log exporter. For an OTLP collector:
 
 ```python
+# Private module — see "Experimental SDK surface" under Considerations
 from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 
 otlp_log_exporter = OTLPLogExporter(endpoint="http://localhost:4317", insecure=True)
@@ -147,7 +152,7 @@ Log records emitted outside any guardrails request (startup, engine registration
 
 ## Considerations
 
-- **Experimental SDK surface.** The `opentelemetry.sdk._logs` module is still under active development in the OpenTelemetry Python SDK and may change in future releases. The underscore prefix denotes a non-stable API. Pin your `opentelemetry-sdk` version in production and review release notes before upgrading.
+- **Experimental SDK surface.** Both the `opentelemetry.sdk._logs` module and the OTLP log exporter at `opentelemetry.exporter.otlp.proto.grpc._log_exporter` are still under active development in the OpenTelemetry Python ecosystem. The underscore prefix on both paths denotes a non-stable API. Pin your `opentelemetry-sdk` and `opentelemetry-exporter-otlp` versions in production and review release notes before upgrading.
 - **Privacy.** Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention/redaction policies cover them.
 - **Performance.** At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
 - **Interaction with `propagate=False`.** If your application calls `nemoguardrails.guardrails.configure_logging()`, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.

--- a/docs/observability/tracing/opentelemetry-logs.md
+++ b/docs/observability/tracing/opentelemetry-logs.md
@@ -1,0 +1,159 @@
+---
+title:
+  page: Exporting Guardrails Logs to OpenTelemetry
+  nav: OpenTelemetry Logs
+description: Forward Python logs from the NeMo Guardrails library into your OpenTelemetry backend with automatic trace correlation.
+topics:
+- Observability
+- AI Safety
+tags:
+- OpenTelemetry
+- Logs
+- Log Correlation
+- OTLP
+content:
+  type: how_to
+  difficulty: technical_advanced
+  audience:
+  - DevOps Engineer
+  - AI Engineer
+---
+
+# Exporting Guardrails Logs to OpenTelemetry
+
+The NeMo Guardrails library emits operational logs through Python's standard `logging` module. When you have OpenTelemetry tracing configured, you can forward those log records into the same backend as your traces with a few lines of application code. Records emitted inside an active guardrails span automatically carry the span's `trace_id` and `span_id`, so every log line correlates to the request that produced it.
+
+This page covers the setup. For plain Python logging (verbose mode, explain, generation options), see [](../logging/index.md).
+
+## API and SDK Responsibilities
+
+The NeMo Guardrails library follows the OpenTelemetry library-instrumentation pattern:
+
+- **The library depends on the OpenTelemetry API only.** It creates spans, emits log records, and otherwise participates in whatever OTEL pipeline the host application provides.
+- **The host application owns the SDK.** Configuring a `TracerProvider`, a `LoggerProvider`, exporters, and attaching handlers to Python's `logging` tree are all the application's responsibility.
+
+This split is deliberate. It lets the NeMo Guardrails library stay decoupled from SDK-version churn, avoids the library injecting itself into a host's observability stack without opt-in, and gives applications full control over where their telemetry is exported.
+
+The three-line recipe below is therefore a user-side setup, not something the library does for you.
+
+## Prerequisites
+
+Before enabling log export, install the OpenTelemetry SDK as described in [](opentelemetry-integration.md#installation). The OpenTelemetry log components live in the same `opentelemetry-sdk` package that powers trace export — no additional installation is required for in-process log forwarding.
+
+For exporting logs to an external backend over OTLP, install the OTLP exporter:
+
+```bash
+pip install opentelemetry-exporter-otlp
+```
+
+## Minimal Setup: Attach the Logging Handler
+
+Add three lines to your application startup to forward `nemoguardrails` log records into the OpenTelemetry log pipeline:
+
+```python
+import logging
+from opentelemetry.sdk._logs import LoggingHandler
+
+logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
+```
+
+What each line does:
+
+- `logging.getLogger("nemoguardrails")` — selects the logger namespace that catches every log record emitted by the NeMo Guardrails library (all submodules log under this prefix).
+- `LoggingHandler()` — an OpenTelemetry-provided `logging.Handler` subclass that converts each Python `LogRecord` into an OTEL log record. Resolves the active `LoggerProvider` at emit time and attaches trace context automatically.
+- `.addHandler(...)` — attaches the handler. From this point forward, every record the NeMo Guardrails library emits flows to both the host's existing handlers (console, files, etc.) and the OpenTelemetry pipeline.
+
+This is **additive**: your existing Python logging configuration continues to work unchanged. OpenTelemetry export happens alongside, not instead.
+
+## Full Example: Traces and Logs Together
+
+This program configures a `TracerProvider` and a `LoggerProvider`, both exporting to the console, then runs a guardrails request so you can see correlated spans and log records.
+
+```python
+import logging
+
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
+
+from nemoguardrails import LLMRails, RailsConfig
+
+# Application-owned SDK setup
+resource = Resource.create({"service.name": "guardrails-log-demo"})
+
+# 1. Traces → console
+tracer_provider = TracerProvider(resource=resource)
+tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
+
+# 2. Logs → console
+logger_provider = LoggerProvider(resource=resource)
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogExporter()))
+set_logger_provider(logger_provider)
+
+# 3. Forward nemoguardrails log records into the OTEL pipeline
+logging.getLogger("nemoguardrails").addHandler(LoggingHandler())
+
+# Guardrails configuration
+config_yaml = """
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+tracing:
+  enabled: true
+  adapters:
+    - name: OpenTelemetry
+"""
+
+config = RailsConfig.from_content(yaml_content=config_yaml)
+rails = LLMRails(config)
+
+response = rails.generate(messages=[{"role": "user", "content": "Hello!"}])
+print(f"Response: {response}")
+```
+
+Running this script prints both the span tree and the log records to your console. Records emitted while the guardrails request is in flight carry `trace_id` and `span_id` fields that match the enclosing span.
+
+## Exporting to a Backend
+
+The log-record processor in the example above can target any OpenTelemetry log exporter. For an OTLP collector:
+
+```python
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+
+otlp_log_exporter = OTLPLogExporter(endpoint="http://localhost:4317", insecure=True)
+logger_provider.add_log_record_processor(BatchLogRecordProcessor(otlp_log_exporter))
+```
+
+The OpenTelemetry Collector then forwards the records to any compatible backend — Loki, Datadog, New Relic, Elastic, and so on. See the [OpenTelemetry Registry](https://opentelemetry.io/ecosystem/registry/) for the list.
+
+## What the Exported Records Contain
+
+Each forwarded `LogRecord` becomes an OTEL log record with the following fields populated automatically:
+
+- **Body** — the formatted log message.
+- **Severity** — `severity_text` (`INFO`, `DEBUG`, `ERROR`, etc.) and `severity_number`.
+- **Timestamp** — the record's emit time.
+- **Trace context** — `trace_id` and `span_id` of the active span when the record was emitted. Zero when no span is active.
+- **Code attributes** — `code.file.path`, `code.function.name`, `code.line.number` derived from the Python `LogRecord`.
+
+Log records emitted outside any guardrails request (startup, engine registration, teardown) still flow through, but their `trace_id` / `span_id` are zero because there is no active span.
+
+## Considerations
+
+- **Experimental SDK surface.** The `opentelemetry.sdk._logs` module is still under active development in the OpenTelemetry Python SDK and may change in future releases. The underscore prefix denotes a non-stable API. Pin your `opentelemetry-sdk` version in production and review release notes before upgrading.
+- **Privacy.** Guardrails log messages include user inputs and rail decisions. Before exporting to a third-party backend, review whether the records may contain PII and whether your retention/redaction policies cover them.
+- **Performance.** At high log volumes or DEBUG level, log export can add measurable overhead. Use `BatchLogRecordProcessor` (as shown) rather than the synchronous `SimpleLogRecordProcessor` in production, and consider filtering at the logger level (`logging.getLogger("nemoguardrails").setLevel(logging.INFO)`) to limit what crosses the bridge.
+- **Interaction with `propagate=False`.** If your application calls `nemoguardrails.guardrails.configure_logging()`, that helper sets `propagate=False` on the `nemoguardrails.guardrails` logger to prevent duplicate console output. Records from submodules under `nemoguardrails.guardrails.*` will then not reach the handler attached to `nemoguardrails`. To capture them, attach the handler to `nemoguardrails.guardrails` instead of (or in addition to) `nemoguardrails`.
+
+## Related Resources
+
+- [](opentelemetry-integration.md) — SDK installation and trace export setup.
+- [](quick-start.md) — minimal tracing setup with the OpenTelemetry SDK.
+- [](../logging/index.md) — Python logging, verbose mode, and the `log` generation option for in-process debugging.

--- a/nemoguardrails/rails/llm/llmrails.py
+++ b/nemoguardrails/rails/llm/llmrails.py
@@ -774,9 +774,8 @@ class LLMRails:
     ) -> Union[str, dict, GenerationResponse, Tuple[dict, dict]]:
         """Generate a completion or a next message.
 
-        The format for messages is the following:
+        The format for messages is the following::
 
-        ```python
             [
                 {"role": "context", "content": {"user_name": "John"}},
                 {"role": "user", "content": "Hello! How are you?"},
@@ -784,7 +783,6 @@ class LLMRails:
                 {"role": "event", "event": {"type": "UserSilent"}},
                 ...
             ]
-        ```
 
         Args:
             prompt: The prompt to be used for completion.
@@ -1340,14 +1338,12 @@ class LLMRails:
     ) -> List[dict]:
         """Generate the next events based on the provided history.
 
-        The format for events is the following:
+        The format for events is the following::
 
-        ```python
             [
                 {"type": "...", ...},
                 ...
             ]
-        ```
 
         Args:
             events: The history of events to be used to generate the next events.
@@ -1479,18 +1475,21 @@ class LLMRails:
             - rail: Name of the rail that blocked (if blocked)
 
         Examples:
-            Check user input (auto-detected):
+            Check user input (auto-detected)::
+
                 result = await rails.check_async([{"role": "user", "content": "Hello!"}])
                 if result.status == RailStatus.BLOCKED:
                     print(f"Blocked by: {result.rail}")
 
-            Check bot output with context (auto-detected):
+            Check bot output with context (auto-detected)::
+
                 result = await rails.check_async([
                     {"role": "user", "content": "Hello!"},
                     {"role": "assistant", "content": "Hi there!"}
                 ])
 
-            Run only input rails explicitly:
+            Run only input rails explicitly::
+
                 result = await rails.check_async(messages, rail_types=[RailType.INPUT])
         """
         if rail_types is not None:


### PR DESCRIPTION
## Description

Adds a page explaining how to connect up the Guardrails logger to an OTEL Logging SDK. While working on this I noticed doc builds were broken due to errors in docstrings in unrelated files.

## Related Issue(s)

* #1790 Closed this PR as it was pulling in too much OTEL SDK rather than just implementing the API and letting the Application hook up to the SDK.


## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [x] I've updated the documentation if applicable.
- [x] I've added tests if applicable.
- [x] @mentions of the person or team responsible for reviewing proposed changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenTelemetry Logs guide covering how to export NeMo Guardrails logs with trace correlation.
  * Included setup prerequisites, configuration examples, and best practices for OpenTelemetry log exporters.
  * Added logs exporting reference section to OpenTelemetry integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->